### PR TITLE
Flexible Hosts Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,28 +29,32 @@ use std::thread;
 
 fn main() {
     let cpolicy = ClientPolicy::default();
-    let client: Arc<Client> = Arc::new(Client::new(&cpolicy, &vec![Host::new("127.0.0.1", 3000)]).unwrap());
+    let hosts = env::var("AEROSPIKE_HOSTS")
+        .unwrap_or(String::from("127.0.0.1:3000"));
+    let client = Client::new(&cpolicy, &hosts)
+        .expect("Failed to connect to cluster");
+    let client = Arc::new(client);
 
     let mut threads = vec![];
     let now = Instant::now();
     for i in 0..2 {
         let client = client.clone();
         let t = thread::spawn(move || {
-            let policy = ReadPolicy::default();
+            let rpolicy = ReadPolicy::default();
             let wpolicy = WritePolicy::default();
             let key = as_key!("test", "test", i);
             let wbin = as_bin!("bin999", 1);
             let bins = vec![&wbin];
 
             client.put(&wpolicy, &key, &bins).unwrap();
-            let rec = client.get(&policy, &key, None);
+            let rec = client.get(&rpolicy, &key, None);
             println!("Record: {}", rec.unwrap());
 
             client.touch(&wpolicy, &key).unwrap();
-            let rec = client.get(&policy, &key, None);
+            let rec = client.get(&rpolicy, &key, None);
             println!("Record: {}", rec.unwrap());
 
-            let rec = client.get_header(&policy, &key);
+            let rec = client.get_header(&rpolicy, &key);
             println!("Record Header: {}", rec.unwrap());
 
             let exists = client.exists(&wpolicy, &key).unwrap();

--- a/benches/common1/mod.rs
+++ b/benches/common1/mod.rs
@@ -13,14 +13,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::u16;
 use std::env;
 use std::sync::Arc;
 
 use rand;
 use rand::Rng;
 
-use aerospike::{ClientPolicy, Client, Host};
+use aerospike::{ClientPolicy, Client};
 
 pub fn rand_str(sz: usize) -> String {
     rand::thread_rng()
@@ -30,15 +29,6 @@ pub fn rand_str(sz: usize) -> String {
 }
 
 lazy_static! {
-    pub static ref AEROSPIKE_HOST: String = match env::var("AEROSPIKE_HOST") {
-        Ok(s) => s,
-        Err(_) => "127.0.0.1".to_string(),
-    };
-
-    pub static ref AEROSPIKE_PORT: u16 = match env::var("AEROSPIKE_PORT") {
-        Ok(s) => s.parse().unwrap(),
-        Err(_) => 3000,
-    };
     pub static ref AEROSPIKE_NAMESPACE: String = match env::var("AEROSPIKE_NAMESPACE") {
         Ok(s) => s,
         Err(_) => "test".to_string(),
@@ -64,6 +54,7 @@ lazy_static! {
         cp
     };
     pub static ref GLOBAL_CLIENT: Arc<Client> = {
-        Arc::new(Client::new(&GLOBAL_CLIENT_POLICY, &vec![Host::new(&AEROSPIKE_HOST, *AEROSPIKE_PORT)]).unwrap())
+        let hosts = env::var("AEROSPIKE_HOSTS").expect("Please set AEROSPIKE_HOSTS env variable!");
+        Arc::new(Client::new(&GLOBAL_CLIENT_POLICY, &hosts).unwrap())
     };
 }

--- a/benches/common1/mod.rs
+++ b/benches/common1/mod.rs
@@ -54,7 +54,7 @@ lazy_static! {
         cp
     };
     pub static ref GLOBAL_CLIENT: Arc<Client> = {
-        let hosts = env::var("AEROSPIKE_HOSTS").expect("Please set AEROSPIKE_HOSTS env variable!");
+        let hosts = env::var("AEROSPIKE_HOSTS").unwrap_or(String::from("127.0.0.1"));
         Arc::new(Client::new(&GLOBAL_CLIENT_POLICY, &hosts).unwrap())
     };
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -28,7 +28,7 @@ use std::path::Path;
 use rustc_serialize::base64::{ToBase64, FromBase64, STANDARD};
 use threadpool::ThreadPool;
 
-use net::Host;
+use net::ToHosts;
 use cluster::{Cluster, Node};
 use common::operation::{Operation, OperationType};
 use common::{Key, Record, Bin, UDFLang, Recordset, Statement, IndexType, CollectionIndexType};
@@ -59,8 +59,9 @@ unsafe impl Send for Client {}
 unsafe impl Sync for Client {}
 
 impl Client {
-    pub fn new(policy: &ClientPolicy, hosts: &[Host]) -> AerospikeResult<Self> {
-        let cluster = try!(Cluster::new(policy.clone(), hosts));
+    pub fn new(policy: &ClientPolicy, hosts: &ToHosts) -> AerospikeResult<Self> {
+        let hosts = try!(hosts.to_hosts());
+        let cluster = try!(Cluster::new(policy.clone(), &hosts));
         let thread_pool = ThreadPool::new(policy.thread_pool_size);
 
         Ok(Client {

--- a/src/command/read_command.rs
+++ b/src/command/read_command.rs
@@ -59,9 +59,10 @@ impl<'a> ReadCommand<'a> {
                         bins: &HashMap<String, Value>)
                         -> AerospikeError {
         if let Some(ret) = bins.get("FAILURE") {
-            return AerospikeError::new(result_code, Some(ret.to_string()));
+            AerospikeError::new(result_code, Some(ret.to_string()))
+        } else {
+            AerospikeError::new(result_code, None)
         }
-        return AerospikeError::new(result_code, None);
     }
 
     fn parse_record(&mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,39 +17,44 @@
 //!
 //! The following is a very simple example of CRUD operations in an Aerospike database.
 //!
-//! ```rust,no_run
+//! ```rust
 //! #[macro_use]
 //! extern crate aerospike;
 //!
 //! use aerospike::*;
+//! use std::env;
 //! use std::sync::Arc;
 //! use std::time::Instant;
 //! use std::thread;
 //!
 //! fn main() {
 //!     let cpolicy = ClientPolicy::default();
-//!     let client: Arc<Client> = Arc::new(Client::new(&cpolicy, &vec![Host::new("127.0.0.1", 3000)]).unwrap());
+//!     let hosts = env::var("AEROSPIKE_HOSTS")
+//!         .unwrap_or(String::from("127.0.0.1:3000"));
+//!     let client = Client::new(&cpolicy, &hosts)
+//!         .expect("Failed to connect to cluster");
+//!     let client = Arc::new(client);
 //!
 //!     let mut threads = vec![];
 //!     let now = Instant::now();
 //!     for i in 0..2 {
 //!         let client = client.clone();
 //!         let t = thread::spawn(move || {
-//!             let policy = ReadPolicy::default();
+//!             let rpolicy = ReadPolicy::default();
 //!             let wpolicy = WritePolicy::default();
 //!             let key = as_key!("test", "test", i);
 //!             let wbin = as_bin!("bin999", 1);
 //!             let bins = vec![&wbin];
 //!
 //!             client.put(&wpolicy, &key, &bins).unwrap();
-//!             let rec = client.get(&policy, &key, None);
+//!             let rec = client.get(&rpolicy, &key, None);
 //!             println!("Record: {}", rec.unwrap());
 //!
 //!             client.touch(&wpolicy, &key).unwrap();
-//!             let rec = client.get(&policy, &key, None);
+//!             let rec = client.get(&rpolicy, &key, None);
 //!             println!("Record: {}", rec.unwrap());
 //!
-//!             let rec = client.get_header(&policy, &key);
+//!             let rec = client.get_header(&rpolicy, &key);
 //!             println!("Record Header: {}", rec.unwrap());
 //!
 //!             let exists = client.exists(&wpolicy, &key).unwrap();

--- a/src/net/host.rs
+++ b/src/net/host.rs
@@ -13,11 +13,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::cmp;
 use std::fmt;
 
 // Host name/port of database server.
-#[derive(Debug, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Host {
     // Host name or IP address of database server.
     pub name: String,
@@ -32,12 +31,6 @@ impl Host {
             name: name.to_string(),
             port: port,
         }
-    }
-}
-
-impl cmp::PartialEq for Host {
-    fn eq(&self, other: &Host) -> bool {
-        self.name == other.name && self.port == other.port
     }
 }
 

--- a/src/net/host.rs
+++ b/src/net/host.rs
@@ -13,6 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+use net::parser::Parser;
+use error::{AerospikeResult, AerospikeError};
+use client::ResultCode;
 use std::fmt;
 
 // Host name/port of database server.
@@ -37,5 +40,44 @@ impl Host {
 impl fmt::Display for Host {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "({}, {})", self.name, self.port)
+    }
+}
+
+/// A trait for objects which can be converted to one or more `Host` values.
+pub trait ToHosts {
+    /// Converts this object into a list of `Host`s.
+    ///
+    /// # Errors
+    ///
+    /// Any errors encountered during conversion will be returned as an `Err`.
+    fn to_hosts(&self) -> AerospikeResult<Vec<Host>>;
+}
+
+impl ToHosts for Vec<Host> {
+    fn to_hosts(&self) -> AerospikeResult<Vec<Host>> {
+        Ok(self.clone())
+    }
+}
+
+impl ToHosts for String {
+    fn to_hosts(&self) -> AerospikeResult<Vec<Host>> {
+        let mut parser = Parser::new(self, 3000);
+        match parser.read_hosts() {
+            Ok(hosts) => return Ok(hosts),
+            Err(err) => return Err(AerospikeError::new(ResultCode::ParseError,
+                                                       Some(format!("Invalid hosts list: {}", err))))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_hosts() {
+        assert_eq!(Ok(vec![Host::new("foo", 3000)]), String::from("foo").to_hosts());
+        assert_eq!(Ok(vec![Host::new("foo", 1234)]), String::from("foo:1234").to_hosts());
+        assert_eq!(Ok(vec![Host::new("foo", 1234), Host::new("bar", 1234)]), String::from("foo:1234,bar:1234").to_hosts());
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -14,6 +14,7 @@
 // the License.
 
 pub use self::host::Host;
+pub use self::host::ToHosts;
 pub use self::connection::Connection;
 
 pub mod host;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -18,3 +18,4 @@ pub use self::connection::Connection;
 
 pub mod host;
 mod connection;
+mod parser;

--- a/src/net/parser.rs
+++ b/src/net/parser.rs
@@ -1,0 +1,146 @@
+// Copyright 2015-2016 Aerospike, Inc.
+//
+// Portions may be licensed to Aerospike, Inc. under one or more contributor
+// license agreements.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+use Host;
+use error::{AerospikeResult, AerospikeError};
+use client::ResultCode;
+use std::str::Chars;
+use std::iter::Peekable;
+
+pub struct Parser<'a> {
+    s: Peekable<Chars<'a>>,
+    default_port: u16,
+}
+
+impl<'a> Parser<'a> {
+
+    fn new(s: &'a str, default_port: u16) -> Self {
+        Parser {
+            s: s.chars().peekable(),
+            default_port: default_port,
+        }
+    }
+
+    fn peek(&mut self) -> Option<&char> {
+        self.s.peek()
+    }
+
+    fn next_char(&mut self) -> Option<char> {
+        self.s.next()
+    }
+
+    fn read_hosts(&mut self) -> AerospikeResult<Vec<Host>> {
+        let mut hosts = Vec::new();
+        loop {
+            let addr = try!(self.read_addr_tuple());
+            let (host, _tls_name, port) = match addr.len() {
+                3 => (addr[0].clone(), Some(addr[1].clone()), addr[2].parse()?),
+                2 => {
+                    if let Ok(port) = addr[1].parse() {
+                        (addr[0].clone(), None, port)
+                    } else {
+                        (addr[0].clone(), Some(addr[1].clone()), self.default_port)
+                    }
+                },
+                1 => (addr[0].clone(), None, self.default_port),
+                _ => return Err(AerospikeError::new(ResultCode::ParseError, Some("Invalid address string".to_string()))),
+            };
+            // TODO: add TLS name
+            hosts.push(Host::new(&host, port));
+
+            match self.peek() {
+                Some(&c) if c == ',' => self.next_char(),
+                _ => break,
+            };
+        }
+
+        Ok(hosts)
+    }
+
+    fn read_addr_tuple(&mut self) -> AerospikeResult<Vec<String>> {
+        let mut parts = Vec::new();
+        loop {
+            let part= try!(self.read_addr_part());
+            parts.push(part);
+            match self.peek() {
+                Some(&c) if c == ':' => self.next_char(),
+                _ => break,
+            };
+        }
+        Ok(parts)
+    }
+
+    fn read_addr_part(&mut self) -> AerospikeResult<String> {
+        let mut substr = String::new();
+        loop {
+            match self.peek() {
+                Some(&c) if c != ':' && c != ',' => {
+                    substr.push(c);
+                    self.next_char();
+                }
+                _ => {
+                    return if substr.is_empty() {
+                        Err(AerospikeError::new(ResultCode::ParseError, Some("Invalid address string".to_string())))
+                    } else {
+                        Ok(substr)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use Host;
+
+    #[test]
+    fn read_addr_part() {
+        assert_eq!(Ok("foo".to_string()), Parser::new("foo:bar", 3000).read_addr_part());
+        assert_eq!(Ok("foo".to_string()), Parser::new("foo,bar", 3000).read_addr_part());
+        assert_eq!(Ok("foo".to_string()), Parser::new("foo", 3000).read_addr_part());
+        assert!(Parser::new("", 3000).read_addr_part().is_err());
+        assert!(Parser::new(",", 3000).read_addr_part().is_err());
+        assert!(Parser::new(":", 3000).read_addr_part().is_err());
+    }
+
+    #[test]
+    fn read_addr_tuple() {
+        assert_eq!(Ok(vec!["foo".to_string()]), Parser::new("foo", 3000).read_addr_tuple());
+        assert_eq!(Ok(vec!["foo".to_string(), "bar".to_string()]), Parser::new("foo:bar", 3000).read_addr_tuple());
+        assert_eq!(Ok(vec!["foo".to_string()]), Parser::new("foo,", 3000).read_addr_tuple());
+        assert!(Parser::new("", 3000).read_addr_tuple().is_err());
+        assert!(Parser::new(",", 3000).read_addr_tuple().is_err());
+        assert!(Parser::new(":", 3000).read_addr_tuple().is_err());
+        assert!(Parser::new("foo:", 3000).read_addr_tuple().is_err());
+    }
+
+    #[test]
+    fn read_hosts() {
+        assert_eq!(Ok(vec![Host::new("foo", 3000)]), Parser::new("foo", 3000).read_hosts());
+        assert_eq!(Ok(vec![Host::new("foo", 3000)]), Parser::new("foo:bar", 3000).read_hosts());
+        assert_eq!(Ok(vec![Host::new("foo", 1234)]), Parser::new("foo:1234", 3000).read_hosts());
+        assert_eq!(Ok(vec![Host::new("foo", 1234)]), Parser::new("foo:bar:1234", 3000).read_hosts());
+        assert_eq!(Ok(vec![Host::new("foo", 1234), Host::new("bar", 1234)]), Parser::new("foo:1234,bar:1234", 3000).read_hosts());
+        assert!(Parser::new("", 3000).read_hosts().is_err());
+        assert!(Parser::new(",", 3000).read_hosts().is_err());
+        assert!(Parser::new("foo,", 3000).read_hosts().is_err());
+        assert!(Parser::new(":", 3000).read_hosts().is_err());
+        assert!(Parser::new("foo:", 3000).read_hosts().is_err());
+        assert!(Parser::new("foo:bar:bar", 3000).read_hosts().is_err());
+        assert!(Parser::new("foo:bar:1234:1234", 3000).read_hosts().is_err());
+    }
+}

--- a/src/net/parser.rs
+++ b/src/net/parser.rs
@@ -26,22 +26,14 @@ pub struct Parser<'a> {
 
 impl<'a> Parser<'a> {
 
-    fn new(s: &'a str, default_port: u16) -> Self {
+    pub fn new(s: &'a str, default_port: u16) -> Self {
         Parser {
             s: s.chars().peekable(),
             default_port: default_port,
         }
     }
 
-    fn peek(&mut self) -> Option<&char> {
-        self.s.peek()
-    }
-
-    fn next_char(&mut self) -> Option<char> {
-        self.s.next()
-    }
-
-    fn read_hosts(&mut self) -> AerospikeResult<Vec<Host>> {
+    pub fn read_hosts(&mut self) -> AerospikeResult<Vec<Host>> {
         let mut hosts = Vec::new();
         loop {
             let addr = try!(self.read_addr_tuple());
@@ -99,6 +91,14 @@ impl<'a> Parser<'a> {
                 }
             }
         }
+    }
+
+    fn peek(&mut self) -> Option<&char> {
+        self.s.peek()
+    }
+
+    fn next_char(&mut self) -> Option<char> {
+        self.s.next()
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -21,7 +21,6 @@ extern crate rand;
 extern crate lazy_static;
 
 pub mod common1 {
-    use std::u16;
     use std::env;
     use std::sync::Arc;
 
@@ -38,15 +37,6 @@ pub mod common1 {
     }
 
     lazy_static! {
-        pub static ref AEROSPIKE_HOST: String = match env::var("AEROSPIKE_HOST") {
-            Ok(s) => s,
-                Err(_) => "127.0.0.1".to_string(),
-        };
-
-        pub static ref AEROSPIKE_PORT: u16 = match env::var("AEROSPIKE_PORT") {
-            Ok(s) => s.parse().unwrap(),
-                Err(_) => 3000,
-        };
         pub static ref AEROSPIKE_NAMESPACE: String = match env::var("AEROSPIKE_NAMESPACE") {
             Ok(s) => s,
                 Err(_) => "test".to_string(),
@@ -68,7 +58,8 @@ pub mod common1 {
             cp
         };
         pub static ref GLOBAL_CLIENT: Arc<Client> = {
-            Arc::new(Client::new(&GLOBAL_CLIENT_POLICY, &vec![Host::new(&AEROSPIKE_HOST, *AEROSPIKE_PORT)]).unwrap())
+            let hosts = env::var("AEROSPIKE_HOSTS").expect("Please set AEROSPIKE_HOSTS env variable!");
+            Arc::new(Client::new(&GLOBAL_CLIENT_POLICY, &hosts).unwrap())
         };
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -58,7 +58,7 @@ pub mod common1 {
             cp
         };
         pub static ref GLOBAL_CLIENT: Arc<Client> = {
-            let hosts = env::var("AEROSPIKE_HOSTS").expect("Please set AEROSPIKE_HOSTS env variable!");
+            let hosts = env::var("AEROSPIKE_HOSTS").unwrap_or(String::from("127.0.0.1"));
             Arc::new(Client::new(&GLOBAL_CLIENT_POLICY, &hosts).unwrap())
         };
     }


### PR DESCRIPTION
Support flexible configuration of the list of seed hosts when initializing a new client instance by specifying a `ToHosts` trait with implementations for `Vec<Host>` and `String`. This is a similar pattern as used by the `std::net::ToSocketAddrs` trait or the `postgres::params::IntoConnectParams` trait in the `postgres` crate.