### PR TITLE
Resolve clippy warnings

### DIFF
--- a/benches/client_server.rs
+++ b/benches/client_server.rs
@@ -23,8 +23,6 @@ extern crate rand;
 extern crate test;
 
 use aerospike::{ReadPolicy, WritePolicy};
-use aerospike::{Key, Bin};
-use aerospike::value::*;
 
 use test::Bencher;
 
@@ -32,7 +30,7 @@ mod common1;
 
 #[bench]
 fn single_key_read(b: &mut Bencher) {
-    let ref client = common1::GLOBAL_CLIENT;
+    let client = &common1::GLOBAL_CLIENT;
     let namespace: &str = &common1::AEROSPIKE_NAMESPACE;
     let set_name: &str = &common1::AEROSPIKE_SET;
     let key = as_key!(namespace, set_name, common1::rand_str(10));

--- a/benches/common1/mod.rs
+++ b/benches/common1/mod.rs
@@ -39,18 +39,10 @@ lazy_static! {
     };
     pub static ref GLOBAL_CLIENT_POLICY: ClientPolicy = {
         let mut cp = ClientPolicy::default();
-        match env::var("AEROSPIKE_USER") {
-            Ok(user) => {
-                let pass =  match env::var("AEROSPIKE_PASSWORD") {
-                    Ok(pass) => pass,
-                    Err(_) => "".to_string(),
-                };
-
-                cp.set_user_password(Some((user, pass))).unwrap();
-            }
-            Err(_) => (),
+        if let Ok(user) = env::var("AEROSPIKE_USER") {
+            let pass = env::var("AEROSPIKE_PASSWORD").unwrap_or(String::new());
+            cp.set_user_password(user, pass).unwrap();
         }
-
         cp
     };
     pub static ref GLOBAL_CLIENT: Arc<Client> = {

--- a/src/client.rs
+++ b/src/client.rs
@@ -492,7 +492,7 @@ impl Client {
         let node = try!(self.cluster.get_random_node());
         let response = try!(node.info(policy.base_policy.timeout, &[&cmd]));
 
-        if let Some(_) = response.get("ok") {
+        if response.get("ok").is_some() {
             return Ok(());
         }
 
@@ -517,14 +517,14 @@ impl Client {
                                                  args);
         try!(command.execute());
 
-        let record = command.read_command.record.as_ref().unwrap().clone();
+        let record = command.read_command.record.unwrap();
 
         // User defined functions don't have to return a value.
-        if record.bins.len() == 0 {
+        if record.bins.is_empty() {
             return Ok(None);
         }
 
-        for (key, value) in record.bins.iter() {
+        for (key, value) in &record.bins {
             if key.contains("SUCCESS") {
                 return Ok(Some(value.clone()));
             } else if key.contains("FAILURE") {
@@ -773,7 +773,7 @@ impl Client {
                           cit_str,
                           bin_name,
                           index_type);
-        self.send_sindex_cmd(cmd, &policy).chain_err(|| "Error creating index")
+        self.send_sindex_cmd(cmd, policy).chain_err(|| "Error creating index")
     }
 
     /// Delete secondary index.
@@ -792,7 +792,7 @@ impl Client {
                           namespace,
                           set_name,
                           index_name);
-        self.send_sindex_cmd(cmd, &policy).chain_err(|| "Error dropping index")
+        self.send_sindex_cmd(cmd, policy).chain_err(|| "Error dropping index")
     }
 
     fn send_sindex_cmd(&self, cmd: String, policy: &WritePolicy) -> Result<()> {

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -428,9 +428,7 @@ impl Cluster {
 
     fn find_node_in_partition_map(&self, filter: Arc<Node>) -> bool {
         let partitions = self.partition_write_map.read().unwrap();
-        (*partitions).values().any(
-            |map| map.iter().any(
-                |node| *node == filter))
+        (*partitions).values().any(|map| map.iter().any(|node| *node == filter))
     }
 
     fn add_nodes(&self, friend_list: &[Arc<Node>]) -> Result<()> {

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -93,10 +93,6 @@ impl Node {
         &self.client_policy
     }
 
-    // pub fn cluster(&self) -> Arc<RwLock<Cluster>> {
-    //     self.cluster.clone()
-    // }
-
     pub fn host(&self) -> Host {
         self.host.clone()
     }
@@ -175,9 +171,9 @@ impl Node {
             Some(friend_string) => friend_string,
         };
 
-        let friend_names = friend_string.split(";");
+        let friend_names = friend_string.split(';');
         for friend in friend_names {
-            let mut friend_info = friend.split(":");
+            let mut friend_info = friend.split(':');
             if friend_info.clone().count() != 2 {
                 error!("Node info from asinfo:services is malformed. Expected HOST:PORT, but got \
                         '{}'",
@@ -246,12 +242,9 @@ impl Node {
                         }
                     };
 
-                    match conn.set_timeout(timeout) {
-                        Err(e) => {
-                            self.dec_connections();
-                            return Err(e);
-                        }
-                        _ => (),
+                    if let Err(e) = conn.set_timeout(timeout) {
+                        self.dec_connections();
+                        return Err(e);
                     }
 
                     return Ok(conn);

--- a/src/cluster/node_validator.rs
+++ b/src/cluster/node_validator.rs
@@ -83,7 +83,7 @@ impl NodeValidator {
                 self.address = format!("{}:{}", alias.name, alias.port);
 
                 if let Some(features) = info_map.get("features") {
-                    try!(self.set_features(features.to_string()));
+                    self.set_features(features);
                 }
             }
         }
@@ -91,8 +91,8 @@ impl NodeValidator {
         Ok(())
     }
 
-    fn set_features(&mut self, features: String) -> Result<()> {
-        let features = features.split(";");
+    fn set_features(&mut self, features: &str) {
+        let features = features.split(';');
         for feature in features {
             match feature {
                 "float" => self.supports_float = true,
@@ -102,7 +102,5 @@ impl NodeValidator {
                 _ => (),
             }
         }
-
-        Ok(())
     }
 }

--- a/src/cluster/partition_tokenizer.rs
+++ b/src/cluster/partition_tokenizer.rs
@@ -68,14 +68,14 @@ impl PartitionTokenizer {
                     match amap.entry(ns.to_string()) {
                         Vacant(entry) => {
                             entry.insert(vec![node.clone(); node::PARTITIONS]);
-                        },
+                        }
                         Occupied(mut entry) => {
                             for (idx, item) in entry.get_mut().iter_mut().enumerate() {
                                 if restore_buffer[idx >> 3] & (0x80 >> (idx & 7) as u8) != 0 {
                                     *item = node.clone();
                                 }
-                            };
-                        },
+                            }
+                        }
                     }
                 }
                 (None, None) => break,

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -147,11 +147,11 @@ impl Buffer {
 
     // Writes the command for write operations
     pub fn set_write(&mut self,
-                         policy: &WritePolicy,
-                         op_type: OperationType,
-                         key: &Key,
-                         bins: &[&Bin])
-                         -> Result<()> {
+                     policy: &WritePolicy,
+                     op_type: OperationType,
+                     key: &Key,
+                     bins: &[&Bin])
+                     -> Result<()> {
         try!(self.begin());
         let field_count = try!(self.estimate_key_size(key, policy.send_key));
 
@@ -228,10 +228,10 @@ impl Buffer {
 
     // Writes the command for get operations (specified bins)
     pub fn set_read(&mut self,
-                        policy: &ReadPolicy,
-                        key: &Key,
-                        bin_names: Option<&[&str]>)
-                        -> Result<()> {
+                    policy: &ReadPolicy,
+                    key: &Key,
+                    bin_names: Option<&[&str]>)
+                    -> Result<()> {
         match bin_names {
             None => {
                 try!(self.set_read_for_key_only(policy, key));
@@ -726,12 +726,12 @@ impl Buffer {
 
     // Header write for write operations.
     fn write_header_with_policy(&mut self,
-                                    policy: &WritePolicy,
-                                    read_attr: u8,
-                                    write_attr: u8,
-                                    field_count: u16,
-                                    operation_count: u16)
-                                    -> Result<()> {
+                                policy: &WritePolicy,
+                                read_attr: u8,
+                                write_attr: u8,
+                                field_count: u16,
+                                operation_count: u16)
+                                -> Result<()> {
         // Set flags.
         let mut generation: u32 = 0;
         let mut info_attr: u8 = 0;
@@ -934,8 +934,9 @@ impl Buffer {
         match pos {
             Some(pos) => Ok(NetworkEndian::read_u16(&self.data_buffer[pos..pos + len])),
             None => {
-                let res = NetworkEndian::read_u16(
-                    &self.data_buffer[self.data_offset..self.data_offset + len]);
+                let res =
+                    NetworkEndian::read_u16(&self.data_buffer[self.data_offset..self.data_offset +
+                                                                                len]);
                 self.data_offset += len;
                 Ok(res)
             }
@@ -952,8 +953,9 @@ impl Buffer {
         match pos {
             Some(pos) => Ok(NetworkEndian::read_u32(&self.data_buffer[pos..pos + len])),
             None => {
-                let res = NetworkEndian::read_u32(
-                    &self.data_buffer[self.data_offset..self.data_offset + len]);
+                let res =
+                    NetworkEndian::read_u32(&self.data_buffer[self.data_offset..self.data_offset +
+                                                                                len]);
                 self.data_offset += len;
                 Ok(res)
             }
@@ -970,8 +972,9 @@ impl Buffer {
         match pos {
             Some(pos) => Ok(NetworkEndian::read_u64(&self.data_buffer[pos..pos + len])),
             None => {
-                let res = NetworkEndian::read_u64(
-                    &self.data_buffer[self.data_offset..self.data_offset + len]);
+                let res =
+                    NetworkEndian::read_u64(&self.data_buffer[self.data_offset..self.data_offset +
+                                                                                len]);
                 self.data_offset += len;
                 Ok(res)
             }
@@ -994,8 +997,9 @@ impl Buffer {
         match pos {
             Some(pos) => Ok(NetworkEndian::read_f32(&self.data_buffer[pos..pos + len])),
             None => {
-                let res = NetworkEndian::read_f32(
-                    &self.data_buffer[self.data_offset..self.data_offset + len]);
+                let res =
+                    NetworkEndian::read_f32(&self.data_buffer[self.data_offset..self.data_offset +
+                                                                                len]);
                 self.data_offset += len;
                 Ok(res)
             }
@@ -1007,8 +1011,9 @@ impl Buffer {
         match pos {
             Some(pos) => Ok(NetworkEndian::read_f64(&self.data_buffer[pos..pos + len])),
             None => {
-                let res = NetworkEndian::read_f64(
-                    &self.data_buffer[self.data_offset..self.data_offset + len]);
+                let res =
+                    NetworkEndian::read_f64(&self.data_buffer[self.data_offset..self.data_offset +
+                                                                                len]);
                 self.data_offset += len;
                 Ok(res)
             }

--- a/src/commands/info_command.rs
+++ b/src/commands/info_command.rs
@@ -43,8 +43,8 @@ impl Message {
         let mut buf: Vec<u8> = Vec::with_capacity(1024);
         buf.push(2); // version
         buf.push(1); // msg_type
-        try!(buf.write(&len[2..8]));
-        try!(buf.write(&data));
+        buf.write_all(&len[2..8])?;
+        buf.write_all(data)?;
 
         Ok(Message { buf: buf })
     }
@@ -57,7 +57,6 @@ impl Message {
     }
 
     fn send(&mut self, conn: &mut Connection) -> Result<()> {
-        // send the message
         try!(conn.write(&self.buf));
 
         // read the header
@@ -80,8 +79,8 @@ impl Message {
         debug!("response from server for info command: {:?}", response);
         let mut result: HashMap<String, String> = HashMap::new();
 
-        for tuple in response.split("\n") {
-            let mut kv = tuple.split("\t");
+        for tuple in response.split('\n') {
+            let mut kv = tuple.split('\t');
             let key = kv.nth(0);
             let val = kv.nth(0);
 

--- a/src/commands/read_command.rs
+++ b/src/commands/read_command.rs
@@ -81,11 +81,19 @@ impl<'a> ReadCommand<'a> {
             if !value.is_nil() {
                 // list/map operations may return multiple values for the same bin.
                 match bins.entry(name) {
-                    Vacant(entry) => { entry.insert(value); () },
-                    Occupied(entry) => match *entry.into_mut() {
-                        Value::List(ref mut list) => list.push(value),
-                        ref mut prev => { *prev = as_list!(prev.clone(), value); () },
-                    },
+                    Vacant(entry) => {
+                        entry.insert(value);
+                        ()
+                    }
+                    Occupied(entry) => {
+                        match *entry.into_mut() {
+                            Value::List(ref mut list) => list.push(value),
+                            ref mut prev => {
+                                *prev = as_list!(prev.clone(), value);
+                                ()
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/src/commands/read_header_command.rs
+++ b/src/commands/read_header_command.rs
@@ -78,7 +78,7 @@ impl<'a> Command for ReadHeaderCommand<'a> {
                 self.record = Some(Record::new(None, HashMap::new(), generation, expiration));
                 SingleCommand::empty_socket(conn)
             }
-            rc @ _ => Err(ErrorKind::ServerError(rc).into()),
+            rc => Err(ErrorKind::ServerError(rc).into()),
         }
     }
 }

--- a/src/commands/single_command.rs
+++ b/src/commands/single_command.rs
@@ -150,8 +150,8 @@ impl<'a> SingleCommand<'a> {
     }
 
     fn keep_connection(err: &Error) -> bool {
-        match err {
-            &Error(ErrorKind::ServerError(result_code), _) => {
+        match *err {
+            Error(ErrorKind::ServerError(result_code), _) => {
                 match result_code {
                     ResultCode::KeyNotFoundError => true,
                     _ => false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,8 @@ pub use value::Value;
 #[macro_use]
 pub mod errors;
 #[macro_use]
+mod value;
+#[macro_use]
 mod bin;
 mod client;
 mod cluster;
@@ -151,8 +153,6 @@ pub mod query;
 mod record;
 mod result_code;
 mod user;
-#[macro_use]
-mod value;
 
 #[cfg(test)]
 extern crate hex;

--- a/src/msgpack/decoder.rs
+++ b/src/msgpack/decoder.rs
@@ -22,7 +22,7 @@ use commands::buffer::Buffer;
 use value::*;
 
 pub fn unpack_value_list(buf: &mut Buffer) -> Result<Value> {
-    if buf.data_buffer.len() == 0 {
+    if buf.data_buffer.is_empty() {
         return Ok(Value::List(vec![]));
     }
 
@@ -42,7 +42,7 @@ pub fn unpack_value_list(buf: &mut Buffer) -> Result<Value> {
 }
 
 pub fn unpack_value_map(buf: &mut Buffer) -> Result<Value> {
-    if buf.data_buffer.len() == 0 {
+    if buf.data_buffer.is_empty() {
         return Ok(Value::from(HashMap::with_capacity(0)));
     }
 
@@ -111,66 +111,46 @@ fn unpack_value(buf: &mut Buffer) -> Result<Value> {
 
     match obj_type {
         0xc0 => return Ok(Value::Nil),
-
         0xc3 => return Ok(Value::from(true)),
-
         0xc2 => return Ok(Value::from(false)),
-
         0xca => return Ok(Value::from(try!(buf.read_f32(None)))),
-
         0xcb => return Ok(Value::from(try!(buf.read_f64(None)))),
-
         0xcc => return Ok(Value::from(try!(buf.read_u8(None)))),
-
         0xcd => return Ok(Value::from(try!(buf.read_u16(None)))),
-
         0xce => return Ok(Value::from(try!(buf.read_u32(None)))),
-
         0xcf => return Ok(Value::from(try!(buf.read_u64(None)))),
-
         0xd0 => return Ok(Value::from(try!(buf.read_i8(None)))),
-
         0xd1 => return Ok(Value::from(try!(buf.read_i16(None)))),
-
         0xd2 => return Ok(Value::from(try!(buf.read_i32(None)))),
-
         0xd3 => return Ok(Value::from(try!(buf.read_i64(None)))),
-
         0xc4 | 0xd9 => {
             let count = try!(buf.read_u8(None));
             return Ok(Value::from(try!(unpack_blob(buf, count as usize))));
         }
-
         0xc5 | 0xda => {
             let count = try!(buf.read_u16(None));
             return Ok(Value::from(try!(unpack_blob(buf, count as usize))));
         }
-
         0xc6 | 0xdb => {
             let count = try!(buf.read_u32(None));
             return Ok(Value::from(try!(unpack_blob(buf, count as usize))));
         }
-
         0xdc => {
             let count = try!(buf.read_u16(None));
             return unpack_list(buf, count as usize);
         }
-
         0xdd => {
             let count = try!(buf.read_u32(None));
             return unpack_list(buf, count as usize);
         }
-
         0xde => {
             let count = try!(buf.read_u16(None));
             return unpack_map(buf, count as usize);
         }
-
         0xdf => {
             let count = try!(buf.read_u32(None));
             return unpack_map(buf, count as usize);
         }
-
         0xd4 => {
             // Skip over type extension with 1 byte
             let count = (1 + 1) as usize;

--- a/src/msgpack/encoder.rs
+++ b/src/msgpack/encoder.rs
@@ -24,23 +24,23 @@ use operations::cdt::{CdtOperation, CdtArgument};
 use value::*;
 
 pub fn pack_value(buf: &mut Option<&mut Buffer>, val: &Value) -> Result<usize> {
-    match val {
-        &Value::Nil => pack_nil(buf),
-        &Value::Int(ref val) => pack_integer(buf, *val),
-        &Value::UInt(ref val) => pack_u64(buf, *val),
-        &Value::Bool(ref val) => pack_bool(buf, *val),
-        &Value::String(ref val) => pack_string(buf, val),
-        &Value::Float(ref val) => {
-            match val {
-                &FloatValue::F64(_) => pack_f64(buf, f64::from(val)),
-                &FloatValue::F32(_) => pack_f32(buf, f32::from(val)),
+    match *val {
+        Value::Nil => pack_nil(buf),
+        Value::Int(ref val) => pack_integer(buf, *val),
+        Value::UInt(ref val) => pack_u64(buf, *val),
+        Value::Bool(ref val) => pack_bool(buf, *val),
+        Value::String(ref val) => pack_string(buf, val),
+        Value::Float(ref val) => {
+            match *val {
+                FloatValue::F64(_) => pack_f64(buf, f64::from(val)),
+                FloatValue::F32(_) => pack_f32(buf, f32::from(val)),
             }
-        }
-        &Value::Blob(ref val) => pack_blob(buf, val),
-        &Value::List(ref val) => pack_array(buf, val),
-        &Value::HashMap(ref val) => pack_map(buf, val),
-        &Value::OrderedMap(_) => panic!("Ordered maps are not supported in this encoder."),
-        &Value::GeoJSON(ref val) => pack_geo_json(buf, val),
+        },
+        Value::Blob(ref val) => pack_blob(buf, val),
+        Value::List(ref val) => pack_array(buf, val),
+        Value::HashMap(ref val) => pack_map(buf, val),
+        Value::OrderedMap(_) => panic!("Ordered maps are not supported in this encoder."),
+        Value::GeoJSON(ref val) => pack_geo_json(buf, val),
     }
 }
 
@@ -59,12 +59,12 @@ pub fn pack_cdt_op(buf: &mut Option<&mut Buffer>, cdt_op: &CdtOperation) -> Resu
     if !cdt_op.args.is_empty() {
         size += try!(pack_array_begin(buf, cdt_op.args.len()));
         for arg in &cdt_op.args {
-            size += match arg {
-                &CdtArgument::Byte(byte) => try!(pack_value(buf, &Value::from(byte))),
-                &CdtArgument::Int(int) => try!(pack_value(buf, &Value::from(int))),
-                &CdtArgument::Value(value) => try!(pack_value(buf, value)),
-                &CdtArgument::List(list) => try!(pack_array(buf, list)),
-                &CdtArgument::Map(map) => try!(pack_map(buf, map)),
+            size += match *arg {
+                CdtArgument::Byte(byte) => try!(pack_value(buf, &Value::from(byte))),
+                CdtArgument::Int(int) => try!(pack_value(buf, &Value::from(int))),
+                CdtArgument::Value(value) => try!(pack_value(buf, value)),
+                CdtArgument::List(list) => try!(pack_array(buf, list)),
+                CdtArgument::Map(map) => try!(pack_map(buf, map)),
             }
         }
     }
@@ -115,21 +115,21 @@ const MSGPACK_MARKER_NI64: u8 = 0xd3;
 // This method is not compatible with MsgPack specs and is only used by aerospike client<->server
 // for wire transfer only
 fn pack_raw_u16(buf: &mut Option<&mut Buffer>, val: u16) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u16(val));
     }
     Ok(2)
 }
 
 fn pack_half_byte(buf: &mut Option<&mut Buffer>, val: u8) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(val));
     }
     Ok(1)
 }
 
 fn pack_byte(buf: &mut Option<&mut Buffer>, marker: u8, val: u8) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(marker));
         try!(buf.write_u8(val));
     }
@@ -137,14 +137,14 @@ fn pack_byte(buf: &mut Option<&mut Buffer>, marker: u8, val: u8) -> Result<usize
 }
 
 fn pack_nil(buf: &mut Option<&mut Buffer>) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(MSGPACK_MARKER_NIL));
     }
     Ok(1)
 }
 
 fn pack_bool(buf: &mut Option<&mut Buffer>, val: bool) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         if val {
             try!(buf.write_u8(MSGPACK_MARKER_BOOL_TRUE));
         } else {
@@ -182,7 +182,7 @@ fn pack_blob(buf: &mut Option<&mut Buffer>, val: &[u8]) -> Result<usize> {
     let mut size = val.len() + 1;
 
     size += try!(pack_byte_array_begin(buf, size));
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(ParticleType::BLOB as u8));
         try!(buf.write_bytes(val));
     }
@@ -194,7 +194,7 @@ fn pack_string(buf: &mut Option<&mut Buffer>, val: &str) -> Result<usize> {
     let mut size = val.len() + 1;
 
     size += try!(pack_byte_array_begin(buf, size));
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(ParticleType::STRING as u8));
         try!(buf.write_str(val));
     }
@@ -206,7 +206,7 @@ fn pack_geo_json(buf: &mut Option<&mut Buffer>, val: &str) -> Result<usize> {
     let mut size = val.len() + 1;
 
     size += try!(pack_byte_array_begin(buf, size));
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(ParticleType::GEOJSON as u8));
         try!(buf.write_str(val));
     }
@@ -243,7 +243,7 @@ fn pack_integer(buf: &mut Option<&mut Buffer>, val: i64) -> Result<usize> {
 }
 
 fn pack_i16(buf: &mut Option<&mut Buffer>, marker: u8, val: i16) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(marker));
         try!(buf.write_i16(val));
     }
@@ -251,7 +251,7 @@ fn pack_i16(buf: &mut Option<&mut Buffer>, marker: u8, val: i16) -> Result<usize
 }
 
 fn pack_i32(buf: &mut Option<&mut Buffer>, marker: u8, val: i32) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(marker));
         try!(buf.write_i32(val));
     }
@@ -259,7 +259,7 @@ fn pack_i32(buf: &mut Option<&mut Buffer>, marker: u8, val: i32) -> Result<usize
 }
 
 fn pack_i64(buf: &mut Option<&mut Buffer>, marker: u8, val: i64) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(marker));
         try!(buf.write_i64(val));
     }
@@ -271,7 +271,7 @@ fn pack_u64(buf: &mut Option<&mut Buffer>, val: u64) -> Result<usize> {
         return pack_integer(buf, val as i64);
     }
 
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(0xcf));
         try!(buf.write_u64(val));
     }
@@ -279,7 +279,7 @@ fn pack_u64(buf: &mut Option<&mut Buffer>, val: u64) -> Result<usize> {
 }
 
 fn pack_f32(buf: &mut Option<&mut Buffer>, val: f32) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(0xca));
         try!(buf.write_f32(val));
     }
@@ -287,7 +287,7 @@ fn pack_f32(buf: &mut Option<&mut Buffer>, val: f32) -> Result<usize> {
 }
 
 fn pack_f64(buf: &mut Option<&mut Buffer>, val: f64) -> Result<usize> {
-    if let &mut Some(ref mut buf) = buf {
+    if let Some(ref mut buf) = *buf {
         try!(buf.write_u8(0xcb));
         try!(buf.write_f64(val));
     }

--- a/src/msgpack/encoder.rs
+++ b/src/msgpack/encoder.rs
@@ -35,7 +35,7 @@ pub fn pack_value(buf: &mut Option<&mut Buffer>, val: &Value) -> Result<usize> {
                 FloatValue::F64(_) => pack_f64(buf, f64::from(val)),
                 FloatValue::F32(_) => pack_f32(buf, f32::from(val)),
             }
-        },
+        }
         Value::Blob(ref val) => pack_blob(buf, val),
         Value::List(ref val) => pack_array(buf, val),
         Value::HashMap(ref val) => pack_map(buf, val),

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -99,47 +99,47 @@ impl Connection {
     }
 
     pub fn flush(&mut self) -> Result<()> {
-        try!(self.conn.write_all(&self.buffer.data_buffer));
+        self.conn.write_all(&self.buffer.data_buffer)?;
         self.refresh();
-        return Ok(());
+        Ok(())
     }
 
 
     pub fn read_buffer(&mut self, size: usize) -> Result<()> {
-        try!(self.buffer.resize_buffer(size));
-        try!(self.conn.read_exact(&mut self.buffer.data_buffer));
+        self.buffer.resize_buffer(size)?;
+        self.conn.read_exact(&mut self.buffer.data_buffer)?;
         self.bytes_read += size;
-        try!(self.buffer.reset_offset());
+        self.buffer.reset_offset()?;
         self.refresh();
-        return Ok(());
+        Ok(())
     }
 
 
     pub fn write(&mut self, buf: &[u8]) -> Result<()> {
-        try!(self.conn.write_all(buf));
+        self.conn.write_all(buf)?;
         self.refresh();
-        return Ok(());
+        Ok(())
     }
 
     pub fn read(&mut self, buf: &mut [u8]) -> Result<()> {
-        try!(self.conn.read_exact(buf));
+        self.conn.read_exact(buf)?;
         self.bytes_read += buf.len();
         self.refresh();
-        return Ok(());
+        Ok(())
     }
 
     pub fn set_timeout(&self, timeout: Option<Duration>) -> Result<()> {
-        try!(self.conn.set_read_timeout(timeout));
-        try!(self.conn.set_write_timeout(timeout));
+        self.conn.set_read_timeout(timeout)?;
+        self.conn.set_write_timeout(timeout)?;
         Ok(())
     }
 
     pub fn is_idle(&self) -> bool {
         if let Some(idle_dl) = self.idle_deadline {
-            return Instant::now() >= idle_dl;
-        };
-
-        return false;
+            Instant::now() >= idle_dl
+        } else {
+            false
+        }
     }
 
     fn refresh(&mut self) {
@@ -151,7 +151,7 @@ impl Connection {
 
 
     fn authenticate(&mut self, user_password: &Option<(String, String)>) -> Result<()> {
-        if let &Some((ref user, ref password)) = user_password {
+        if let Some((ref user, ref password)) = *user_password {
             match AdminCommand::authenticate(self, user, password) {
                 Ok(()) => {
                     return Ok(());

--- a/src/operations/lists.rs
+++ b/src/operations/lists.rs
@@ -97,7 +97,7 @@ pub fn insert_items<'a>(bin: &'a str, index: i64, values: &'a [Value]) -> Operat
 
 /// Create list pop operation. Server returns the item at the specified index and removes the
 /// item from the list bin.
-pub fn pop<'a>(bin: &'a str, index: i64) -> Operation<'a> {
+pub fn pop(bin: &str, index: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListPop,
         args: vec![CdtArgument::Int(index)],
@@ -111,7 +111,7 @@ pub fn pop<'a>(bin: &'a str, index: i64) -> Operation<'a> {
 
 /// Create list pop range operation. Server returns `count` items starting at the specified
 /// index and removes the items from the list bin.
-pub fn pop_range<'a>(bin: &'a str, index: i64, count: i64) -> Operation<'a> {
+pub fn pop_range(bin: &str, index: i64, count: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListPopRange,
         args: vec![CdtArgument::Int(index), CdtArgument::Int(count)],
@@ -125,7 +125,7 @@ pub fn pop_range<'a>(bin: &'a str, index: i64, count: i64) -> Operation<'a> {
 
 /// Create list pop range operation. Server returns the items starting at the specified index
 /// to the end of the list and removes those items from the list bin.
-pub fn pop_range_from<'a>(bin: &'a str, index: i64) -> Operation<'a> {
+pub fn pop_range_from(bin: &str, index: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListPopRange,
         args: vec![CdtArgument::Int(index)],
@@ -139,7 +139,7 @@ pub fn pop_range_from<'a>(bin: &'a str, index: i64) -> Operation<'a> {
 
 /// Create list remove operation. Server removes the item at the specified index from the list
 /// bin. Server returns the number of items removed.
-pub fn remove<'a>(bin: &'a str, index: i64) -> Operation<'a> {
+pub fn remove(bin: &str, index: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListRemove,
         args: vec![CdtArgument::Int(index)],
@@ -153,7 +153,7 @@ pub fn remove<'a>(bin: &'a str, index: i64) -> Operation<'a> {
 
 /// Create list remove range operation. Server removes `count` items starting at the specified
 /// index from the list bin. Server returns the number of items removed.
-pub fn remove_range<'a>(bin: &'a str, index: i64, count: i64) -> Operation<'a> {
+pub fn remove_range(bin: &str, index: i64, count: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListRemoveRange,
         args: vec![CdtArgument::Int(index), CdtArgument::Int(count)],
@@ -167,7 +167,7 @@ pub fn remove_range<'a>(bin: &'a str, index: i64, count: i64) -> Operation<'a> {
 
 /// Create list remove range operation. Server removes the items starting at the specified
 /// index to the end of the list. Server returns the number of items removed.
-pub fn remove_range_from<'a>(bin: &'a str, index: i64) -> Operation<'a> {
+pub fn remove_range_from(bin: &str, index: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListRemoveRange,
         args: vec![CdtArgument::Int(index)],
@@ -198,7 +198,7 @@ pub fn set<'a>(bin: &'a str, index: i64, value: &'a Value) -> Operation<'a> {
 /// Create list trim operation. Server removes `count` items in the list bin that do not fall
 /// into the range specified by `index` and `count`. If the range is out of bounds, then all
 /// items will be removed. Server returns list size after trim.
-pub fn trim<'a>(bin: &'a str, index: i64, count: i64) -> Operation<'a> {
+pub fn trim(bin: &str, index: i64, count: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListTrim,
         args: vec![CdtArgument::Int(index), CdtArgument::Int(count)],
@@ -212,7 +212,7 @@ pub fn trim<'a>(bin: &'a str, index: i64, count: i64) -> Operation<'a> {
 
 /// Create list clear operation. Server removes all items in the list bin. Server does not
 /// return a result by default.
-pub fn clear<'a>(bin: &'a str) -> Operation<'a> {
+pub fn clear(bin: &str) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListClear,
         args: vec![],
@@ -225,7 +225,7 @@ pub fn clear<'a>(bin: &'a str) -> Operation<'a> {
 }
 
 /// Create list size operation. Server returns size of the list.
-pub fn size<'a>(bin: &'a str) -> Operation<'a> {
+pub fn size(bin: &str) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListSize,
         args: vec![],
@@ -238,7 +238,7 @@ pub fn size<'a>(bin: &'a str) -> Operation<'a> {
 }
 
 /// Create list get operation. Server returns the item at the specified index in the list bin.
-pub fn get<'a>(bin: &'a str, index: i64) -> Operation<'a> {
+pub fn get(bin: &str, index: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListGet,
         args: vec![CdtArgument::Int(index)],
@@ -252,7 +252,7 @@ pub fn get<'a>(bin: &'a str, index: i64) -> Operation<'a> {
 
 /// Create list get range operation. Server returns `count` items starting at the specified
 /// index in the list bin.
-pub fn get_range<'a>(bin: &'a str, index: i64, count: i64) -> Operation<'a> {
+pub fn get_range(bin: &str, index: i64, count: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListGetRange,
         args: vec![CdtArgument::Int(index), CdtArgument::Int(count)],
@@ -266,7 +266,7 @@ pub fn get_range<'a>(bin: &'a str, index: i64, count: i64) -> Operation<'a> {
 
 /// Create list get range operation. Server returns items starting at the index to the end of
 /// the list.
-pub fn get_range_from<'a>(bin: &'a str, index: i64) -> Operation<'a> {
+pub fn get_range_from(bin: &str, index: i64) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::ListGetRange,
         args: vec![CdtArgument::Int(index)],

--- a/src/operations/maps.rs
+++ b/src/operations/maps.rs
@@ -452,10 +452,10 @@ pub fn remove_by_index(bin: &str, index: i64, return_type: MapReturnType) -> Ope
 /// Create map remove operation. Server removes `count` map items starting at the specified
 /// index and returns the removed data specified by `return_type`.
 pub fn remove_by_index_range(bin: &str,
-                                 index: i64,
-                                 count: i64,
-                                 return_type: MapReturnType)
-                                 -> Operation {
+                             index: i64,
+                             count: i64,
+                             return_type: MapReturnType)
+                             -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByIndexRange,
         args: vec![CdtArgument::Byte(return_type as u8),
@@ -471,10 +471,7 @@ pub fn remove_by_index_range(bin: &str,
 
 /// Create map remove operation. Server removes the map items starting at the specified index
 /// to the end of the map and returns the removed data specified by `return_type`.
-pub fn remove_by_index_range_from(bin: &str,
-                                      index: i64,
-                                      return_type: MapReturnType)
-                                      -> Operation {
+pub fn remove_by_index_range_from(bin: &str, index: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByIndexRange,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(index)],
@@ -503,10 +500,10 @@ pub fn remove_by_rank(bin: &str, rank: i64, return_type: MapReturnType) -> Opera
 /// Create map remove operation. Server removes `count` map items starting at the specified
 /// rank and returns the removed data specified by `return_type`.
 pub fn remove_by_rank_range(bin: &str,
-                                rank: i64,
-                                count: i64,
-                                return_type: MapReturnType)
-                                -> Operation {
+                            rank: i64,
+                            count: i64,
+                            return_type: MapReturnType)
+                            -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByRankRange,
         args: vec![CdtArgument::Byte(return_type as u8),
@@ -522,10 +519,7 @@ pub fn remove_by_rank_range(bin: &str,
 
 /// Create map remove operation. Server removes the map items starting at the specified rank to
 /// the last ranked item and returns the removed data specified by `return_type`.
-pub fn remove_by_rank_range_from(bin: &str,
-                                     rank: i64,
-                                     return_type: MapReturnType)
-                                     -> Operation {
+pub fn remove_by_rank_range_from(bin: &str, rank: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByRankRange,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(rank)],
@@ -646,10 +640,10 @@ pub fn get_by_index(bin: &str, index: i64, return_type: MapReturnType) -> Operat
 /// Create map get by index range operation. Server selects `count` map items starting at the
 /// specified index and returns the selected data specified by `return_type`.
 pub fn get_by_index_range(bin: &str,
-                              index: i64,
-                              count: i64,
-                              return_type: MapReturnType)
-                              -> Operation {
+                          index: i64,
+                          count: i64,
+                          return_type: MapReturnType)
+                          -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByIndexRange,
         args: vec![CdtArgument::Byte(return_type as u8),
@@ -666,10 +660,7 @@ pub fn get_by_index_range(bin: &str,
 /// Create map get by index range operation. Server selects the map items starting at the
 /// specified index to the end of the map and returns the selected data specified by
 /// `return_type`.
-pub fn get_by_index_range_from(bin: &str,
-                                   index: i64,
-                                   return_type: MapReturnType)
-                                   -> Operation {
+pub fn get_by_index_range_from(bin: &str, index: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByIndexRange,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(index)],
@@ -698,10 +689,10 @@ pub fn get_by_rank(bin: &str, rank: i64, return_type: MapReturnType) -> Operatio
 /// Create map get ranke range operation. Server selects `count` map items at the specified
 /// rank and returns the selected data specified by `return_type`.
 pub fn get_by_rank_range(bin: &str,
-                             rank: i64,
-                             count: i64,
-                             return_type: MapReturnType)
-                             -> Operation {
+                         rank: i64,
+                         count: i64,
+                         return_type: MapReturnType)
+                         -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByRankRange,
         args: vec![CdtArgument::Byte(return_type as u8),
@@ -718,10 +709,7 @@ pub fn get_by_rank_range(bin: &str,
 /// Create map get by rank range operation. Server selects the map items starting at the
 /// specified rank to the last ranked item and returns the selected data specified by
 /// `return_type`.
-pub fn get_by_rank_range_from(bin: &str,
-                                  rank: i64,
-                                  return_type: MapReturnType)
-                                  -> Operation {
+pub fn get_by_rank_range_from(bin: &str, rank: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByRankRange,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(rank)],

--- a/src/operations/maps.rs
+++ b/src/operations/maps.rs
@@ -125,7 +125,7 @@ pub enum MapWriteMode {
     CreateOnly,
 }
 
-/// MapPolicy directives when creating a map and writing map items.
+/// `MapPolicy` directives when creating a map and writing map items.
 #[derive(Debug)]
 pub struct MapPolicy {
     order: MapOrder,
@@ -185,7 +185,7 @@ fn map_order_arg(policy: &MapPolicy) -> Option<CdtArgument> {
 /// return a result.
 ///
 /// The required map policy attributes can be changed after the map has been created.
-pub fn set_order<'a>(bin: &'a str, map_order: MapOrder) -> Operation<'a> {
+pub fn set_order(bin: &str, map_order: MapOrder) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapSetType,
         args: vec![CdtArgument::Byte(map_order as u8)],
@@ -211,11 +211,11 @@ pub fn put_item<'a>(policy: &'a MapPolicy,
     if !val.is_nil() {
         args.push(CdtArgument::Value(val));
     }
-    if let Some(arg) = map_order_arg(&policy) {
+    if let Some(arg) = map_order_arg(policy) {
         args.push(arg);
     }
     let cdt_op = CdtOperation {
-        op: map_write_op(&policy, false),
+        op: map_write_op(policy, false),
         args: args,
     };
     Operation {
@@ -235,11 +235,11 @@ pub fn put_items<'a>(policy: &'a MapPolicy,
                      items: &'a HashMap<Value, Value>)
                      -> Operation<'a> {
     let mut args = vec![CdtArgument::Map(items)];
-    if let Some(arg) = map_order_arg(&policy) {
+    if let Some(arg) = map_order_arg(policy) {
         args.push(arg);
     }
     let cdt_op = CdtOperation {
-        op: map_write_op(&policy, true),
+        op: map_write_op(policy, true),
         args: args,
     };
     Operation {
@@ -263,7 +263,7 @@ pub fn increment_value<'a>(policy: &'a MapPolicy,
     if !incr.is_nil() {
         args.push(CdtArgument::Value(incr));
     }
-    if let Some(arg) = map_order_arg(&policy) {
+    if let Some(arg) = map_order_arg(policy) {
         args.push(arg);
     }
     let cdt_op = CdtOperation {
@@ -291,7 +291,7 @@ pub fn decrement_value<'a>(policy: &'a MapPolicy,
     if !decr.is_nil() {
         args.push(CdtArgument::Value(decr));
     }
-    if let Some(arg) = map_order_arg(&policy) {
+    if let Some(arg) = map_order_arg(policy) {
         args.push(arg);
     }
     let cdt_op = CdtOperation {
@@ -307,7 +307,7 @@ pub fn decrement_value<'a>(policy: &'a MapPolicy,
 
 /// Create map clear operation. Server removes all items in the map. Server does not return a
 /// result.
-pub fn clear<'a>(bin: &'a str) -> Operation<'a> {
+pub fn clear(bin: &str) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapClear,
         args: vec![],
@@ -437,7 +437,7 @@ pub fn remove_by_value_range<'a>(bin: &'a str,
 
 /// Create map remove operation. Server removes the map item identified by the index and return
 /// the removed data specified by `return_type`.
-pub fn remove_by_index<'a>(bin: &'a str, index: i64, return_type: MapReturnType) -> Operation<'a> {
+pub fn remove_by_index(bin: &str, index: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByIndex,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(index)],
@@ -451,11 +451,11 @@ pub fn remove_by_index<'a>(bin: &'a str, index: i64, return_type: MapReturnType)
 
 /// Create map remove operation. Server removes `count` map items starting at the specified
 /// index and returns the removed data specified by `return_type`.
-pub fn remove_by_index_range<'a>(bin: &'a str,
+pub fn remove_by_index_range(bin: &str,
                                  index: i64,
                                  count: i64,
                                  return_type: MapReturnType)
-                                 -> Operation<'a> {
+                                 -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByIndexRange,
         args: vec![CdtArgument::Byte(return_type as u8),
@@ -471,10 +471,10 @@ pub fn remove_by_index_range<'a>(bin: &'a str,
 
 /// Create map remove operation. Server removes the map items starting at the specified index
 /// to the end of the map and returns the removed data specified by `return_type`.
-pub fn remove_by_index_range_from<'a>(bin: &'a str,
+pub fn remove_by_index_range_from(bin: &str,
                                       index: i64,
                                       return_type: MapReturnType)
-                                      -> Operation<'a> {
+                                      -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByIndexRange,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(index)],
@@ -488,7 +488,7 @@ pub fn remove_by_index_range_from<'a>(bin: &'a str,
 
 /// Create map remove operation. Server removes the map item identified by rank and returns the
 /// removed data specified by `return_type`.
-pub fn remove_by_rank<'a>(bin: &'a str, rank: i64, return_type: MapReturnType) -> Operation<'a> {
+pub fn remove_by_rank(bin: &str, rank: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByRank,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(rank)],
@@ -502,11 +502,11 @@ pub fn remove_by_rank<'a>(bin: &'a str, rank: i64, return_type: MapReturnType) -
 
 /// Create map remove operation. Server removes `count` map items starting at the specified
 /// rank and returns the removed data specified by `return_type`.
-pub fn remove_by_rank_range<'a>(bin: &'a str,
+pub fn remove_by_rank_range(bin: &str,
                                 rank: i64,
                                 count: i64,
                                 return_type: MapReturnType)
-                                -> Operation<'a> {
+                                -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByRankRange,
         args: vec![CdtArgument::Byte(return_type as u8),
@@ -522,10 +522,10 @@ pub fn remove_by_rank_range<'a>(bin: &'a str,
 
 /// Create map remove operation. Server removes the map items starting at the specified rank to
 /// the last ranked item and returns the removed data specified by `return_type`.
-pub fn remove_by_rank_range_from<'a>(bin: &'a str,
+pub fn remove_by_rank_range_from(bin: &str,
                                      rank: i64,
                                      return_type: MapReturnType)
-                                     -> Operation<'a> {
+                                     -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByRankRange,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(rank)],
@@ -538,7 +538,7 @@ pub fn remove_by_rank_range_from<'a>(bin: &'a str,
 }
 
 /// Create map size operation. Server returns the size of the map.
-pub fn size<'a>(bin: &'a str) -> Operation<'a> {
+pub fn size(bin: &str) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapSize,
         args: vec![],
@@ -631,7 +631,7 @@ pub fn get_by_value_range<'a>(bin: &'a str,
 
 /// Create map get by index operation. Server selects the map item identified by index and
 /// returns the selected data specified by `return_type`.
-pub fn get_by_index<'a>(bin: &'a str, index: i64, return_type: MapReturnType) -> Operation<'a> {
+pub fn get_by_index(bin: &str, index: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByIndex,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(index)],
@@ -645,11 +645,11 @@ pub fn get_by_index<'a>(bin: &'a str, index: i64, return_type: MapReturnType) ->
 
 /// Create map get by index range operation. Server selects `count` map items starting at the
 /// specified index and returns the selected data specified by `return_type`.
-pub fn get_by_index_range<'a>(bin: &'a str,
+pub fn get_by_index_range(bin: &str,
                               index: i64,
                               count: i64,
                               return_type: MapReturnType)
-                              -> Operation<'a> {
+                              -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByIndexRange,
         args: vec![CdtArgument::Byte(return_type as u8),
@@ -666,10 +666,10 @@ pub fn get_by_index_range<'a>(bin: &'a str,
 /// Create map get by index range operation. Server selects the map items starting at the
 /// specified index to the end of the map and returns the selected data specified by
 /// `return_type`.
-pub fn get_by_index_range_from<'a>(bin: &'a str,
+pub fn get_by_index_range_from(bin: &str,
                                    index: i64,
                                    return_type: MapReturnType)
-                                   -> Operation<'a> {
+                                   -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByIndexRange,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(index)],
@@ -683,7 +683,7 @@ pub fn get_by_index_range_from<'a>(bin: &'a str,
 
 /// Create map get by rank operation. Server selects the mamp item identified by rank and
 /// returns the selected data specified by `return_type`.
-pub fn get_by_rank<'a>(bin: &'a str, rank: i64, return_type: MapReturnType) -> Operation<'a> {
+pub fn get_by_rank(bin: &str, rank: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByRank,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(rank)],
@@ -697,11 +697,11 @@ pub fn get_by_rank<'a>(bin: &'a str, rank: i64, return_type: MapReturnType) -> O
 
 /// Create map get ranke range operation. Server selects `count` map items at the specified
 /// rank and returns the selected data specified by `return_type`.
-pub fn get_by_rank_range<'a>(bin: &'a str,
+pub fn get_by_rank_range(bin: &str,
                              rank: i64,
                              count: i64,
                              return_type: MapReturnType)
-                             -> Operation<'a> {
+                             -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByRankRange,
         args: vec![CdtArgument::Byte(return_type as u8),
@@ -718,10 +718,10 @@ pub fn get_by_rank_range<'a>(bin: &'a str,
 /// Create map get by rank range operation. Server selects the map items starting at the
 /// specified rank to the last ranked item and returns the selected data specified by
 /// `return_type`.
-pub fn get_by_rank_range_from<'a>(bin: &'a str,
+pub fn get_by_rank_range_from(bin: &str,
                                   rank: i64,
                                   return_type: MapReturnType)
-                                  -> Operation<'a> {
+                                  -> Operation {
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByRankRange,
         args: vec![CdtArgument::Byte(return_type as u8), CdtArgument::Int(rank)],

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -86,7 +86,7 @@ impl<'a> Operation<'a> {
         };
         size += match self.data {
             OperationData::None => 0,
-            OperationData::Value(ref value) => try!(value.estimate_size()),
+            OperationData::Value(value) => try!(value.estimate_size()),
             OperationData::CdtListOp(ref cdt_op) |
             OperationData::CdtMapOp(ref cdt_op) => try!(cdt_op.estimate_size()),
         };
@@ -108,7 +108,7 @@ impl<'a> Operation<'a> {
             OperationData::None => {
                 size += try!(self.write_op_header_to(buffer, ParticleType::NULL as u8));
             }
-            OperationData::Value(ref value) => {
+            OperationData::Value(value) => {
                 size += try!(self.write_op_header_to(buffer, value.particle_type() as u8));
                 size += try!(value.write_to(buffer));
             }

--- a/src/operations/scalar.rs
+++ b/src/operations/scalar.rs
@@ -37,7 +37,7 @@ pub fn get_header<'a>() -> Operation<'a> {
 }
 
 /// Create read bin database operation.
-pub fn get_bin<'a>(bin_name: &'a str) -> Operation<'a> {
+pub fn get_bin(bin_name: &str) -> Operation {
     Operation {
         op: OperationType::Read,
         bin: OperationBin::Name(bin_name),

--- a/src/policy/client_policy.rs
+++ b/src/policy/client_policy.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use errors::*;
 use commands::admin_command::AdminCommand;
 
-/// ClientPolicy encapsulates parameters for client policy command.
+/// `ClientPolicy` encapsulates parameters for client policy command.
 #[derive(Debug, Clone)]
 pub struct ClientPolicy {
     /// User authentication to cluster. Leave empty for clusters running without restricted access.

--- a/src/policy/commit_level.rs
+++ b/src/policy/commit_level.rs
@@ -14,7 +14,7 @@
 // the License.
 //
 
-/// CommitLevel determines how to handle record writes based on record generation.
+/// `CommitLevel` determines how to handle record writes based on record generation.
 #[derive(Debug,PartialEq)]
 pub enum CommitLevel {
     /// CommitAll indicates the server should wait until successfully committing master and all

--- a/src/policy/consistency_level.rs
+++ b/src/policy/consistency_level.rs
@@ -14,7 +14,7 @@
 // the License.
 //
 
-/// ConsistencyLevel indicates how replicas should be consulted in a read
+/// `ConsistencyLevel` indicates how replicas should be consulted in a read
 /// operation to provide the desired consistency guarantee.
 #[derive(Debug,PartialEq,Clone)]
 pub enum ConsistencyLevel {

--- a/src/policy/generation_policy.rs
+++ b/src/policy/generation_policy.rs
@@ -14,7 +14,7 @@
 // the License.
 //
 
-/// GenerationPolicy determines how to handle record writes based on record generation.
+/// `GenerationPolicy` determines how to handle record writes based on record generation.
 #[derive(Debug,PartialEq)]
 pub enum GenerationPolicy {
     /// None means: Do not use record generation to restrict writes.

--- a/src/policy/query_policy.rs
+++ b/src/policy/query_policy.rs
@@ -15,7 +15,7 @@
 
 use policy::{BasePolicy, PolicyLike};
 
-/// QueryPolicy encapsulates parameters for query operations.
+/// `QueryPolicy` encapsulates parameters for query operations.
 #[derive(Debug,Clone)]
 pub struct QueryPolicy {
     /// Base policy instance

--- a/src/policy/read_policy.rs
+++ b/src/policy/read_policy.rs
@@ -18,7 +18,7 @@ use Priority;
 use ConsistencyLevel;
 use policy::BasePolicy;
 
-/// ReadPolicy excapsulates parameters for transaction policy attributes
+/// `ReadPolicy` excapsulates parameters for transaction policy attributes
 /// used in all database operation calls.
 pub type ReadPolicy = BasePolicy;
 

--- a/src/policy/record_exists_action.rs
+++ b/src/policy/record_exists_action.rs
@@ -14,7 +14,7 @@
 // the License.
 //
 
-/// RecordExistsAction determines how to handle record writes based on record generation.
+/// `RecordExistsAction` determines how to handle record writes based on record generation.
 #[derive(Debug,PartialEq)]
 pub enum RecordExistsAction {
     /// Update means: Create or update record.

--- a/src/policy/scan_policy.rs
+++ b/src/policy/scan_policy.rs
@@ -15,7 +15,7 @@
 
 use policy::{BasePolicy, PolicyLike};
 
-/// ScanPolicy encapsulates optional parameters used in scan operations.
+/// `ScanPolicy` encapsulates optional parameters used in scan operations.
 #[derive(Debug,Clone)]
 pub struct ScanPolicy {
     /// Base policy instance

--- a/src/policy/write_policy.rs
+++ b/src/policy/write_policy.rs
@@ -19,7 +19,7 @@ use GenerationPolicy;
 use CommitLevel;
 use Expiration;
 
-/// WritePolicy encapsulates parameters for all write operations.
+/// `WritePolicy` encapsulates parameters for all write operations.
 pub struct WritePolicy {
     /// Base policy instance
     pub base_policy: BasePolicy,

--- a/src/query/index_types.rs
+++ b/src/query/index_types.rs
@@ -46,22 +46,21 @@ pub enum CollectionIndexType {
 
 impl fmt::Display for IndexType {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self {
-            &IndexType::Numeric => "NUMERIC".fmt(f),
-            &IndexType::String => "STRING".fmt(f),
-            &IndexType::Geo2DSphere => "GEO2DSPHERE".fmt(f),
+        match *self {
+            IndexType::Numeric => "NUMERIC".fmt(f),
+            IndexType::String => "STRING".fmt(f),
+            IndexType::Geo2DSphere => "GEO2DSPHERE".fmt(f),
         }
     }
 }
 
 impl fmt::Display for CollectionIndexType {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self {
-            &CollectionIndexType::Default => panic!("Unknown IndexCollectionType value `Default`"),
-            &CollectionIndexType::List => try!("LIST".fmt(f)),
-            &CollectionIndexType::MapKeys => try!("MAPKEYS".fmt(f)),
-            &CollectionIndexType::MapValues => try!("MAPVALUES".fmt(f)),
+        match *self {
+            CollectionIndexType::Default => panic!("Unknown IndexCollectionType value `Default`"),
+            CollectionIndexType::List => "LIST".fmt(f),
+            CollectionIndexType::MapKeys => "MAPKEYS".fmt(f),
+            CollectionIndexType::MapValues => "MAPVALUES".fmt(f),
         }
-        Ok(())
     }
 }

--- a/src/query/udf.rs
+++ b/src/query/udf.rs
@@ -24,8 +24,8 @@ pub enum UDFLang {
 
 impl fmt::Display for UDFLang {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let s = match self {
-            &UDFLang::Lua => "LUA",
+        let s = match *self {
+            UDFLang::Lua => "LUA",
         };
 
         write!(f, "{}", s)

--- a/src/record.rs
+++ b/src/record.rs
@@ -63,7 +63,7 @@ impl Record {
     pub fn time_to_live(&self) -> Option<Duration> {
         match self.expiration {
             0 => None,
-            secs_since_epoch @ _ => {
+            secs_since_epoch => {
                 let expiration = *CITRUSLEAF_EPOCH + Duration::new(secs_since_epoch as u64, 0);
                 match expiration.duration_since(SystemTime::now()) {
                     Ok(d) => Some(d),

--- a/src/result_code.rs
+++ b/src/result_code.rs
@@ -264,7 +264,7 @@ impl ResultCode {
             213 => ResultCode::QueryGeneric,
             214 => ResultCode::QueryNetioErr,
             215 => ResultCode::QueryDuplicate,
-            code @ _ => ResultCode::Unknown(code),
+            code => ResultCode::Unknown(code),
         }
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -54,8 +54,10 @@ impl From<FloatValue> for f64 {
 impl<'a> From<&'a FloatValue> for f64 {
     fn from(val: &FloatValue) -> f64 {
         match *val {
-            FloatValue::F32(_) =>
-                panic!("This library does not automatically convert f32 -> f64 to be used in keys or bins."),
+            FloatValue::F32(_) => {
+                panic!("This library does not automatically convert f32 -> f64 to be used in keys \
+                        or bins.")
+            }
             FloatValue::F64(val) => unsafe { mem::transmute(val) },
         }
     }
@@ -290,7 +292,8 @@ impl Value {
             Value::Float(ref val) => buf.write_f64(f64::from(val)),
             Value::String(ref val) => buf.write_str(val),
             Value::Blob(ref val) => buf.write_bytes(val),
-            Value::List(_) | Value::HashMap(_) => encoder::pack_value(&mut Some(buf), self),
+            Value::List(_) |
+            Value::HashMap(_) => encoder::pack_value(&mut Some(buf), self),
             Value::OrderedMap(_) => panic!("The library never passes ordered maps to the server."),
             Value::GeoJSON(ref val) => buf.write_geo(val),
         }
@@ -714,10 +717,12 @@ mod tests {
     fn as_string() {
         assert_eq!(Value::Nil.as_string(), String::from("<null>"));
         assert_eq!(Value::Int(42).as_string(), String::from("42"));
-        assert_eq!(Value::UInt(9223372036854775808).as_string(), String::from("9223372036854775808"));
+        assert_eq!(Value::UInt(9223372036854775808).as_string(),
+                   String::from("9223372036854775808"));
         assert_eq!(Value::Bool(true).as_string(), String::from("true"));
         assert_eq!(Value::from(3.1416).as_string(), String::from("3.1416"));
-        assert_eq!(as_geo!(r#"{"type":"Point"}"#).as_string(), String::from(r#"{"type":"Point"}"#));
+        assert_eq!(as_geo!(r#"{"type":"Point"}"#).as_string(),
+                   String::from(r#"{"type":"Point"}"#));
     }
 
     #[test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -53,12 +53,10 @@ impl From<FloatValue> for f64 {
 
 impl<'a> From<&'a FloatValue> for f64 {
     fn from(val: &FloatValue) -> f64 {
-        match val {
-            &FloatValue::F32(_) => {
-                panic!("This library does not automatically convert f32 -> f64 to be used in keys \
-                        or bins.")
-            }
-            &FloatValue::F64(val) => unsafe { mem::transmute(val) },
+        match *val {
+            FloatValue::F32(_) =>
+                panic!("This library does not automatically convert f32 -> f64 to be used in keys or bins."),
+            FloatValue::F64(val) => unsafe { mem::transmute(val) },
         }
     }
 }
@@ -94,9 +92,9 @@ impl From<FloatValue> for f32 {
 
 impl<'a> From<&'a FloatValue> for f32 {
     fn from(val: &FloatValue) -> f32 {
-        match val {
-            &FloatValue::F32(val) => unsafe { mem::transmute(val) },
-            &FloatValue::F64(val) => unsafe { mem::transmute(val as u32) },
+        match *val {
+            FloatValue::F32(val) => unsafe { mem::transmute(val) },
+            FloatValue::F64(val) => unsafe { mem::transmute(val as u32) },
         }
     }
 }
@@ -123,12 +121,12 @@ impl<'a> From<&'a f32> for FloatValue {
 
 impl fmt::Display for FloatValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
-        match self {
-            &FloatValue::F32(val) => {
+        match *self {
+            FloatValue::F32(val) => {
                 let val: f32 = unsafe { mem::transmute(val) };
                 write!(f, "{}", val)
             }
-            &FloatValue::F64(val) => {
+            FloatValue::F64(val) => {
                 let val: f64 = unsafe { mem::transmute(val) };
                 write!(f, "{}", val)
             }
@@ -188,21 +186,21 @@ pub enum Value {
 
 impl Hash for Value {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            &Value::Nil => {
+        match *self {
+            Value::Nil => {
                 let v: Option<u8> = None;
                 v.hash(state)
             }
-            &Value::Bool(ref val) => val.hash(state),
-            &Value::Int(ref val) => val.hash(state),
-            &Value::UInt(ref val) => val.hash(state),
-            &Value::Float(ref val) => val.hash(state),
-            &Value::String(ref val) => val.hash(state),
-            &Value::Blob(ref val) => val.hash(state),
-            &Value::List(ref val) => val.hash(state),
-            &Value::HashMap(_) => panic!("HashMaps cannot be used as map keys."),
-            &Value::OrderedMap(_) => panic!("OrderedMaps cannot be used as map keys."),
-            &Value::GeoJSON(ref val) => val.hash(state),
+            Value::Bool(ref val) => val.hash(state),
+            Value::Int(ref val) => val.hash(state),
+            Value::UInt(ref val) => val.hash(state),
+            Value::Float(ref val) => val.hash(state),
+            Value::String(ref val) => val.hash(state),
+            Value::Blob(ref val) => val.hash(state),
+            Value::List(ref val) => val.hash(state),
+            Value::HashMap(_) => panic!("HashMaps cannot be used as map keys."),
+            Value::OrderedMap(_) => panic!("OrderedMaps cannot be used as map keys."),
+            Value::GeoJSON(ref val) => val.hash(state),
         }
     }
 }
@@ -210,8 +208,8 @@ impl Hash for Value {
 impl Value {
     /// Returns true if this value is the empty value (nil).
     pub fn is_nil(&self) -> bool {
-        match self {
-            &Value::Nil => true,
+        match *self {
+            Value::Nil => true,
             _ => false,
         }
     }
@@ -220,38 +218,38 @@ impl Value {
     /// For internal use only.
     #[doc(hidden)]
     pub fn particle_type(&self) -> ParticleType {
-        match self {
-            &Value::Nil => ParticleType::NULL,
-            &Value::Int(_) => ParticleType::INTEGER,
-            &Value::UInt(_) => {
+        match *self {
+            Value::Nil => ParticleType::NULL,
+            Value::Int(_) => ParticleType::INTEGER,
+            Value::UInt(_) => {
                 panic!("Aerospike does not support u64 natively on server-side. Use casting to \
                         store and retrieve u64 values.")
             }
-            &Value::Bool(_) => ParticleType::INTEGER,
-            &Value::Float(_) => ParticleType::FLOAT,
-            &Value::String(_) => ParticleType::STRING,
-            &Value::Blob(_) => ParticleType::BLOB,
-            &Value::List(_) => ParticleType::LIST,
-            &Value::HashMap(_) => ParticleType::MAP,
-            &Value::OrderedMap(_) => panic!("The library never passes ordered maps to the server."),
-            &Value::GeoJSON(_) => ParticleType::GEOJSON,
+            Value::Bool(_) => ParticleType::INTEGER,
+            Value::Float(_) => ParticleType::FLOAT,
+            Value::String(_) => ParticleType::STRING,
+            Value::Blob(_) => ParticleType::BLOB,
+            Value::List(_) => ParticleType::LIST,
+            Value::HashMap(_) => ParticleType::MAP,
+            Value::OrderedMap(_) => panic!("The library never passes ordered maps to the server."),
+            Value::GeoJSON(_) => ParticleType::GEOJSON,
         }
     }
 
     /// Returns a string representation of the value.
     pub fn as_string(&self) -> String {
-        match self {
-            &Value::Nil => "<null>".to_string(),
-            &Value::Int(ref val) => format!("{}", val),
-            &Value::UInt(ref val) => format!("{}", val),
-            &Value::Bool(ref val) => format!("{}", val),
-            &Value::Float(ref val) => format!("{}", f64::from(val)),
-            &Value::String(ref val) => format!("{}", val),
-            &Value::Blob(ref val) => format!("{:?}", val),
-            &Value::List(ref val) => format!("{:?}", val),
-            &Value::HashMap(ref val) => format!("{:?}", val),
-            &Value::OrderedMap(ref val) => format!("{:?}", val),
-            &Value::GeoJSON(ref val) => format!("{}", val),
+        match *self {
+            Value::Nil => "<null>".to_string(),
+            Value::Int(ref val) => val.to_string(),
+            Value::UInt(ref val) => val.to_string(),
+            Value::Bool(ref val) => val.to_string(),
+            Value::Float(ref val) => val.to_string(),
+            Value::String(ref val) => val.to_string(),
+            Value::Blob(ref val) => format!("{:?}", val),
+            Value::List(ref val) => format!("{:?}", val),
+            Value::HashMap(ref val) => format!("{:?}", val),
+            Value::OrderedMap(ref val) => format!("{:?}", val),
+            Value::GeoJSON(ref val) => val.to_string(),
         }
     }
 
@@ -259,21 +257,21 @@ impl Value {
     /// For internal use only.
     #[doc(hidden)]
     pub fn estimate_size(&self) -> Result<usize> {
-        match self {
-            &Value::Nil => Ok(0),
-            &Value::Int(_) => Ok(8),
-            &Value::UInt(_) => {
+        match *self {
+            Value::Nil => Ok(0),
+            Value::Int(_) => Ok(8),
+            Value::UInt(_) => {
                 panic!("Aerospike does not support u64 natively on server-side. Use casting to \
                         store and retrieve u64 values.")
             }
-            &Value::Bool(_) => Ok(8),
-            &Value::Float(_) => Ok(8),
-            &Value::String(ref s) => Ok(s.len()),
-            &Value::Blob(ref b) => Ok(b.len()),
-            &Value::List(_) => encoder::pack_value(&mut None, self),
-            &Value::HashMap(_) => encoder::pack_value(&mut None, self),
-            &Value::OrderedMap(_) => panic!("The library never passes ordered maps to the server."),
-            &Value::GeoJSON(ref s) => Ok(1 + 2 + s.len()), // flags + ncells + jsonstr
+            Value::Bool(_) => Ok(8),
+            Value::Float(_) => Ok(8),
+            Value::String(ref s) => Ok(s.len()),
+            Value::Blob(ref b) => Ok(b.len()),
+            Value::List(_) => encoder::pack_value(&mut None, self),
+            Value::HashMap(_) => encoder::pack_value(&mut None, self),
+            Value::OrderedMap(_) => panic!("The library never passes ordered maps to the server."),
+            Value::GeoJSON(ref s) => Ok(1 + 2 + s.len()), // flags + ncells + jsonstr
         }
     }
 
@@ -281,21 +279,20 @@ impl Value {
     /// For internal use only.
     #[doc(hidden)]
     pub fn write_to(&self, buf: &mut Buffer) -> Result<usize> {
-        match self {
-            &Value::Nil => Ok(0),
-            &Value::Int(ref val) => buf.write_i64(*val),
-            &Value::UInt(_) => {
+        match *self {
+            Value::Nil => Ok(0),
+            Value::Int(ref val) => buf.write_i64(*val),
+            Value::UInt(_) => {
                 panic!("Aerospike does not support u64 natively on server-side. Use casting to \
                         store and retrieve u64 values.")
             }
-            &Value::Bool(ref val) => buf.write_bool(*val),
-            &Value::Float(ref val) => buf.write_f64(f64::from(val)),
-            &Value::String(ref val) => buf.write_str(val),
-            &Value::Blob(ref val) => buf.write_bytes(val),
-            &Value::List(_) => encoder::pack_value(&mut Some(buf), self),
-            &Value::HashMap(_) => encoder::pack_value(&mut Some(buf), self),
-            &Value::OrderedMap(_) => panic!("The library never passes ordered maps to the server."),
-            &Value::GeoJSON(ref val) => buf.write_geo(val),
+            Value::Bool(ref val) => buf.write_bool(*val),
+            Value::Float(ref val) => buf.write_f64(f64::from(val)),
+            Value::String(ref val) => buf.write_str(val),
+            Value::Blob(ref val) => buf.write_bytes(val),
+            Value::List(_) | Value::HashMap(_) => encoder::pack_value(&mut Some(buf), self),
+            Value::OrderedMap(_) => panic!("The library never passes ordered maps to the server."),
+            Value::GeoJSON(ref val) => buf.write_geo(val),
         }
     }
 
@@ -303,18 +300,18 @@ impl Value {
     /// For internal use only.
     #[doc(hidden)]
     pub fn write_key_bytes(&self, h: &mut Ripemd160) -> Result<()> {
-        match self {
-            &Value::Int(ref val) => {
+        match *self {
+            Value::Int(ref val) => {
                 let mut buf = [0; 8];
                 NetworkEndian::write_i64(&mut buf, *val);
                 h.input(&buf);
                 Ok(())
             }
-            &Value::String(ref val) => {
+            Value::String(ref val) => {
                 h.input(val.as_bytes());
                 Ok(())
             }
-            &Value::Blob(ref val) => {
+            Value::Blob(ref val) => {
                 h.input(val);
                 Ok(())
             }
@@ -546,9 +543,9 @@ impl From<Value> for i64 {
 
 impl<'a> From<&'a Value> for i64 {
     fn from(val: &'a Value) -> i64 {
-        match val {
-            &Value::Int(val) => val,
-            &Value::UInt(val) => val as i64,
+        match *val {
+            Value::Int(val) => val,
+            Value::UInt(val) => val as i64,
             _ => panic!("Value is not an integer to convert."),
         }
     }

--- a/tests/src/cdt_list.rs
+++ b/tests/src/cdt_list.rs
@@ -25,8 +25,7 @@ use common1;
 fn cdt_list() {
     let _ = env_logger::init();
 
-    let ref client = common1::GLOBAL_CLIENT;
-
+    let client = &common1::GLOBAL_CLIENT;
     let namespace: &str = &common1::AEROSPIKE_NAMESPACE;
     let set_name = &common1::rand_str(10);
 

--- a/tests/src/cdt_map.rs
+++ b/tests/src/cdt_map.rs
@@ -22,7 +22,7 @@ use common1;
 
 #[test]
 fn map_operations() {
-    let ref client = common1::GLOBAL_CLIENT;
+    let client = &common1::GLOBAL_CLIENT;
     let namespace: &str = &common1::AEROSPIKE_NAMESPACE;
     let set_name = &common1::rand_str(10);
 
@@ -43,12 +43,12 @@ fn map_operations() {
     client.put(&wpolicy, &key, &bins).unwrap();
 
     let (k, v) = (as_val!("c"), as_val!(3));
-    let op = maps::put_item(&mpolicy, &bin_name, &k, &v);
-    let rec = client.operate(&wpolicy, &key, &vec![op]).unwrap();
+    let op = maps::put_item(&mpolicy, bin_name, &k, &v);
+    let rec = client.operate(&wpolicy, &key, &[op]).unwrap();
     assert_eq!(*rec.bins.get(bin_name).unwrap(), as_val!(3)); // size of map after put
 
-    let op = maps::size(&bin_name);
-    let rec = client.operate(&wpolicy, &key, &vec![op]).unwrap();
+    let op = maps::size(bin_name);
+    let rec = client.operate(&wpolicy, &key, &[op]).unwrap();
     assert_eq!(*rec.bins.get(bin_name).unwrap(), as_val!(3)); // size of map
 
     let rec = client.get(&rpolicy, &key, None).unwrap();
@@ -58,27 +58,34 @@ fn map_operations() {
     let mut items = HashMap::new();
     items.insert(as_val!("d"), as_val!(4));
     items.insert(as_val!("e"), as_val!(5));
-    let op = maps::put_items(&mpolicy, &bin_name, &items);
-    let rec = client.operate(&wpolicy, &key, &vec![op]).unwrap();
+    let op = maps::put_items(&mpolicy, bin_name, &items);
+    let rec = client.operate(&wpolicy, &key, &[op]).unwrap();
     assert_eq!(*rec.bins.get(bin_name).unwrap(), as_val!(5)); // size of map after put
 
     let k = as_val!("e");
-    let op = maps::remove_by_key(&bin_name, &k, MapReturnType::Value);
-    let rec = client.operate(&wpolicy, &key, &vec![op]).unwrap();
+    let op = maps::remove_by_key(bin_name, &k, MapReturnType::Value);
+    let rec = client.operate(&wpolicy, &key, &[op]).unwrap();
     assert_eq!(*rec.bins.get(bin_name).unwrap(), as_val!(5));
 
     let (k, i) = (as_val!("a"), as_val!(19));
-    let op = maps::increment_value(&mpolicy, &bin_name, &k, &i);
-    let rec = client.operate(&wpolicy, &key, &vec![op]).unwrap();
+    let op = maps::increment_value(&mpolicy, bin_name, &k, &i);
+    let rec = client.operate(&wpolicy, &key, &[op]).unwrap();
     assert_eq!(*rec.bins.get(bin_name).unwrap(), as_val!(20)); // value of the key after increment
 
     let (k, i) = (as_val!("a"), as_val!(10));
-    let op = maps::decrement_value(&mpolicy, &bin_name, &k, &i);
-    let rec = client.operate(&wpolicy, &key, &vec![op]).unwrap();
+    let op = maps::decrement_value(&mpolicy, bin_name, &k, &i);
+    let rec = client.operate(&wpolicy, &key, &[op]).unwrap();
     assert_eq!(*rec.bins.get(bin_name).unwrap(), as_val!(10)); // value of the key after decrement
 
-    let op = maps::clear(&bin_name);
-    let rec = client.operate(&wpolicy, &key, &vec![op]).unwrap();
+    let (k, i) = (as_val!("a"), as_val!(5));
+    let dec = maps::decrement_value(&mpolicy, bin_name, &k, &i);
+    let (k, i) = (as_val!("a"), as_val!(7));
+    let inc = maps::increment_value(&mpolicy, bin_name, &k, &i);
+    let rec = client.operate(&wpolicy, &key, &[dec, inc]).unwrap();
+    assert_eq!(*rec.bins.get(bin_name).unwrap(), as_list!(5, 12)); // values from multiple ops returned as list
+
+    let op = maps::clear(bin_name);
+    let rec = client.operate(&wpolicy, &key, &[op]).unwrap();
     assert!(rec.bins.get(bin_name).is_none()); // map_clear returns no result
 
     client.delete(&wpolicy, &key).unwrap();

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -26,7 +26,7 @@ use common1;
 fn connect() {
     let _ = env_logger::init();
 
-    let ref client = common1::GLOBAL_CLIENT;
+    let client = &common1::GLOBAL_CLIENT;
     let namespace: &str = &common1::AEROSPIKE_NAMESPACE;
     let set_name = &common1::rand_str(10);
     let policy = ReadPolicy::default();
@@ -39,7 +39,7 @@ fn connect() {
     let wbin4 = as_bin!("bin f64", 1.64f64);
     let wbin5 = as_bin!("bin Nil", None);
     let wbin6 = as_bin!("bin Geo", as_geo!(format!(
-                "{{ \"type\": \"Point\", \"coordinates\": [{}, {}] }}", 17.119381, 19.45612)));
+                r#"{{ "type": "Point", "coordinates": [{}, {}] }}"#, 17.119381, 19.45612)));
     let bins = vec![&wbin, &wbin1, &wbin2, &wbin3, &wbin4, &wbin5, &wbin6];
 
     client.delete(&wpolicy, &key).unwrap();

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -33,7 +33,7 @@ fn query_single_consumer() {
 
     let _ = env_logger::init();
 
-    let ref client = common1::GLOBAL_CLIENT;
+    let client = &common1::GLOBAL_CLIENT;
     let namespace: &str = &common1::AEROSPIKE_NAMESPACE;
     let set_name = &common1::rand_str(10);
 
@@ -65,10 +65,10 @@ fn query_single_consumer() {
 
     let rs = client.query(&qpolicy, statement).unwrap();
     let mut count = 0;
-    for res in rs.into_iter() {
+    for res in &*rs {
         match res {
             Ok(rec) => {
-                assert_eq!(*rec.bins.get("bin").unwrap(), as_val!(1));
+                assert_eq!(rec.bins["bin"], as_val!(1));
                 // println!("Record: {}", rec);
                 count += 1;
             }
@@ -85,13 +85,11 @@ fn query_single_consumer() {
 
     let rs = client.query(&qpolicy, statement).unwrap();
     let mut count = 0;
-    for res in rs.into_iter() {
+    for res in &*rs {
         match res {
             Ok(rec) => {
-                // println!("Record: {}", rec);
                 count += 1;
-                let v = i64::from(rec.bins.get("bin").unwrap());
-
+                let v: i64 = rec.bins["bin"].clone().into();
                 assert!(v >= 0);
                 assert!(v < 10);
 
@@ -105,12 +103,9 @@ fn query_single_consumer() {
 
 #[test]
 fn query_multi_consumer() {
+    let _ = env_logger::init();
 
-let _ = env_logger::init();
-
-
-let ref client = common1::GLOBAL_CLIENT;
-
+    let client = &common1::GLOBAL_CLIENT;
     let namespace: &str = &common1::AEROSPIKE_NAMESPACE;
     let set_name = &common1::rand_str(10);
 
@@ -150,12 +145,11 @@ let ref client = common1::GLOBAL_CLIENT;
         let count = count.clone();
         let rs = rs.clone();
         threads.push(thread::spawn(move || {
-            for res in rs.into_iter() {
+            for res in &*rs {
                 match res {
                     Ok(rec) => {
                         count.fetch_add(1, Ordering::Relaxed);
-                        let v = i64::from(rec.bins.get("bin").unwrap());
-
+                        let v: i64 = rec.bins["bin"].clone().into();
                         assert!(v >= 0);
                         assert!(v < 10);
                     }

--- a/tests/src/udf.rs
+++ b/tests/src/udf.rs
@@ -30,7 +30,7 @@ use common1;
 fn execute_udf() {
     let _ = env_logger::init();
 
-    let ref client = common1::GLOBAL_CLIENT;
+    let client = &common1::GLOBAL_CLIENT;
     let namespace: &str = &common1::AEROSPIKE_NAMESPACE;
     let set_name = &common1::rand_str(10);
 


### PR DESCRIPTION
Fix warnings raised by running rust-clippy:

    cargo +nightly clippy

https://github.com/Manishearth/rust-clippy

Remaining warnings are either non-issues or not trivial to solve and
need to be tacked separately:

* Need custom impl of PartialEq for Value to match Hash impl?
* High cyclomatic complexity for Buffer::set_query() and
  Msgpack::Decoder::unpack_value().
* Too many arguments for Client::create_complex_index().