### PR TITLE
Support for multiple connection pools per node

### DIFF
--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -120,8 +120,10 @@ impl Cluster {
 
         // close all nodes
         let nodes = cluster.nodes();
-        for node in nodes {
-            node.close();
+        for mut node in nodes {
+            if let Some(node) = Arc::get_mut(&mut node) {
+                node.close();
+            }
         }
         cluster.set_nodes(vec![]);
     }
@@ -437,12 +439,14 @@ impl Cluster {
         self.set_nodes(nodes)
     }
 
-    fn remove_nodes(&self, nodes_to_remove: Vec<Arc<Node>>) -> Result<()> {
-        for node in &nodes_to_remove {
+    fn remove_nodes(&self, mut nodes_to_remove: Vec<Arc<Node>>) -> Result<()> {
+        for node in &mut nodes_to_remove {
             for alias in node.aliases() {
                 self.remove_alias(&alias)?;
             }
-            node.close();
+            if let Some(node) = Arc::get_mut(node) {
+                node.close();
+            }
         }
         self.remove_nodes_copy(&nodes_to_remove);
         Ok(())

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -232,7 +232,7 @@ impl Node {
         self.reference_count.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub fn close(&self) {
+    pub fn close(&mut self) {
         self.active.store(false, Ordering::Relaxed);
         self.connection_pool.close();
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -100,6 +100,12 @@ error_chain! {
             display("Invalid argument: {}", details)
         }
 
+/// Exceeded max. number of connections per node.
+        NoMoreConnections {
+            description("Too many connections")
+            display("Too many connections")
+        }
+
 /// Server responded with a response code indicating an error condition.
         ServerError(rc: ResultCode) {
             description("Server Error")

--- a/src/policy/client_policy.rs
+++ b/src/policy/client_policy.rs
@@ -33,8 +33,14 @@ pub struct ClientPolicy {
     /// the connection will be closed and discarded from the connection pool.
     pub idle_timeout: Option<Duration>,
 
-    /// Size of the Connection Queue cache.
-    pub connection_pool_size_per_node: usize,
+    /// Maximum number of synchronous connections allowed per server node.
+    pub max_conns_per_node: usize,
+
+    /// Number of connection pools used for each node. Machines with 8 CPU cores or less usually
+    /// need only one connection pool per node. Machines with larger number of CPU cores may have
+    /// their performance limited by contention for pooled connections. Contention for pooled
+    /// connections can be reduced by creating multiple mini connection pools per node.
+    pub conn_pools_per_node: usize,
 
     /// Throw exception if host connection fails during addHost().
     pub fail_if_not_connected: bool,
@@ -73,7 +79,8 @@ impl Default for ClientPolicy {
             user_password: None,
             timeout: Some(Duration::new(30, 0)),
             idle_timeout: Some(Duration::new(5, 0)),
-            connection_pool_size_per_node: 256,
+            max_conns_per_node: 256,
+            conn_pools_per_node: 1,
             fail_if_not_connected: true,
             tend_interval: Duration::new(1, 0),
             ip_map: None,

--- a/tools/benchmark/src/cli.rs
+++ b/tools/benchmark/src/cli.rs
@@ -57,6 +57,7 @@ pub struct Options {
     pub start_key: i64,
     pub concurrency: i64,
     pub workload: Workload,
+    pub conn_pools_per_node: usize,
 }
 
 pub fn parse_options() -> Options {
@@ -72,6 +73,7 @@ pub fn parse_options() -> Options {
         start_key: i64::from_str(matches.value_of("startkey").unwrap()).unwrap(),
         concurrency: i64::from_str(matches.value_of("concurrency").unwrap()).unwrap(),
         workload: Workload::from_str(matches.value_of("workload").unwrap()).unwrap(),
+        conn_pools_per_node: usize::from_str(matches.value_of("connPoolsPerNode").unwrap()).unwrap(),
     }
 }
 
@@ -103,6 +105,9 @@ fn build_cli() -> App<'static, 'static> {
         .arg(Arg::from_usage("-w, --workload 'Workload definition: I | RU (see below for \
                               details)'")
             .default_value("I"))
+        .arg(Arg::from_usage("-Y, --connPoolsPerNode 'Number of connection pools per node'")
+             .validator(|val| validate::<usize>(val, "Must be number".into()))
+             .default_value("1"))
         .after_help(AFTER_HELP.trim())
 }
 

--- a/tools/benchmark/src/main.rs
+++ b/tools/benchmark/src/main.rs
@@ -50,7 +50,8 @@ fn main() {
 }
 
 fn connect(options: &Options) -> Client {
-    let policy = ClientPolicy::default();
+    let mut policy = ClientPolicy::default();
+    policy.conn_pools_per_node = options.conn_pools_per_node;
     Client::new(&policy, &options.hosts).unwrap()
 }
 


### PR DESCRIPTION
Support multiple smaller connection pools per node and round-robin switch between the pools when assigning connections for database requests to avoid lock contention as per #19.