### PR TITLE
Replace std::sync primitives with parking_lot equivalents

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ threadpool = "1.0"
 pwhash = "0.1"
 lazy_static = "^0.2"
 error-chain = "^0.7"
+parking_lot = "^0.4"
 
 [dev-dependencies]
 env_logger = "0.3"

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -162,10 +162,11 @@ impl Node {
                     Some(info_name) if info_name == expected => Ok(()),
                     Some(info_name) => {
                         self.inactivate();
-                        Err(ErrorKind::InvalidNode(format!("Cluster name mismatch: expected={}, got={}",
-                                                   expected,
-                                                   info_name))
-                            .into())
+                        Err(ErrorKind::InvalidNode(format!("Cluster name mismatch: expected={},
+                                                           got={}",
+                                                           expected,
+                                                           info_name))
+                                    .into())
                     }
                 }
             }

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -15,11 +15,13 @@
 
 use std::str::FromStr;
 use std::collections::HashMap;
-use std::sync::{RwLock, Arc};
+use std::sync::Arc;
 use std::time::Duration;
 use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering};
 use std::fmt;
 use std::result::Result as StdResult;
+
+use parking_lot::RwLock;
 
 use errors::*;
 use net::{Host, ConnectionPool, PooledConnection};
@@ -248,12 +250,11 @@ impl Node {
     }
 
     pub fn aliases(&self) -> Vec<Host> {
-        let aliases = self.aliases.read().unwrap();
-        aliases.to_vec()
+        self.aliases.read().to_vec()
     }
 
     pub fn add_alias(&self, alias: Host) {
-        let mut aliases = self.aliases.write().unwrap();
+        let mut aliases = self.aliases.write();
         aliases.push(alias);
         self.reference_count.fetch_add(1, Ordering::Relaxed);
     }

--- a/src/cluster/node_validator.rs
+++ b/src/cluster/node_validator.rs
@@ -103,7 +103,8 @@ impl NodeValidator {
                 None => bail!(ErrorKind::InvalidNode(String::from("Missing cluster name"))),
                 Some(info_name) if info_name == cluster_name => {}
                 Some(info_name) => {
-                    bail!(ErrorKind::InvalidNode(format!("Cluster name mismatch: expected={}, got={}",
+                    bail!(ErrorKind::InvalidNode(format!("Cluster name mismatch: expected={},
+                                                         got={}",
                                                          cluster_name,
                                                          info_name)))
                 }

--- a/src/cluster/partition_tokenizer.rs
+++ b/src/cluster/partition_tokenizer.rs
@@ -18,8 +18,9 @@ use std::str;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Vacant, Occupied};
 use std::vec::Vec;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
+use parking_lot::RwLock;
 use rustc_serialize::base64::FromBase64;
 
 use errors::*;
@@ -56,7 +57,7 @@ impl PartitionTokenizer {
                             node: Arc<Node>)
                             -> Result<HashMap<String, Vec<Arc<Node>>>> {
 
-        let mut amap = nmap.read().unwrap().clone();
+        let mut amap = nmap.read().clone();
 
         // <ns>:<base64-encoded partition map>;<ns>:<base64-encoded partition map>; ...
         let part_str = try!(str::from_utf8(&self.buffer));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,7 @@ extern crate pwhash;
 extern crate lazy_static;
 #[macro_use]
 extern crate error_chain;
+extern crate parking_lot;
 
 pub use bin::Bin;
 pub use client::Client;


### PR DESCRIPTION
The [`parking_log` library](https://crates.io/crates/parking_lot) provides more compact and efficient implementations of the standard synchronization primitives. Replacing the `std::sync::{Mutex, RwLock}` primitives with the parking lot equivalent primitives improves the benchmark results for the 100%-read workload by 10% on a high-end 56 core machine using 150 client threads while the results for the Insert workload (100%-write) are not impacted.