### PR TITLE
Support returning keys/digests without bins in query

### DIFF
--- a/src/batch/batch_read.rs
+++ b/src/batch/batch_read.rs
@@ -23,7 +23,7 @@ pub struct BatchRead<'a> {
     pub key: Key,
 
     /// Bins to retrieve for this key.
-    pub bins: Bins<'a>,
+    pub bins: &'a Bins,
 
     /// Will contain the record after the batch read operation.
     pub record: Option<Record>,
@@ -31,10 +31,7 @@ pub struct BatchRead<'a> {
 
 impl<'a> BatchRead<'a> {
     /// Create a new `BatchRead` instance for the given key and bin selector.
-    pub fn new<T>(key: Key, bins: T) -> Self
-        where T: Into<Bins<'a>>
-    {
-        let bins = bins.into();
+    pub fn new(key: Key, bins: &'a Bins) -> Self {
         BatchRead {
             key: key,
             bins: bins,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -50,7 +50,7 @@ macro_rules! as_bin {
 
 /// Specify which, if any, bins to return in read operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Bins<'a> {
+pub enum Bins {
     /// Read all bins.
     All,
 
@@ -58,10 +58,10 @@ pub enum Bins<'a> {
     None,
 
     /// Read specified bin names only.
-    Some(&'a [&'a str]),
+    Some(Vec<String>),
 }
 
-impl<'a> Bins<'a> {
+impl Bins {
     /// Returns `true` if the bins selector is an `All` value.
     pub fn is_all(&self) -> bool {
         match *self {
@@ -79,50 +79,64 @@ impl<'a> Bins<'a> {
     }
 }
 
-impl<'a> From<&'a [&'a str]> for Bins<'a> {
+impl<'a> From<&'a [&'a str]> for Bins {
     fn from(bins: &'a [&'a str]) -> Self {
+        let bins = bins.iter().cloned().map(String::from).collect();
         Bins::Some(bins)
     }
 }
 
-impl<'a> From<&'a Vec<&'a str>> for Bins<'a> {
-    fn from(bins: &'a Vec<&'a str>) -> Self {
-        Bins::Some(bins.as_slice())
-    }
-}
-
-impl<'a> From<&'a [&'a str; 1]> for Bins<'a> {
-    fn from(bins: &'a [&'a str; 1]) -> Self {
+impl<'a> From<[&'a str; 1]> for Bins {
+    fn from(bins: [&'a str; 1]) -> Self {
+        let bins = bins.iter().cloned().map(String::from).collect();
         Bins::Some(bins)
     }
 }
 
-impl<'a> From<&'a [&'a str; 2]> for Bins<'a> {
-    fn from(bins: &'a [&'a str; 2]) -> Self {
+impl<'a> From<[&'a str; 2]> for Bins {
+    fn from(bins: [&'a str; 2]) -> Self {
+        let bins = bins.iter().cloned().map(String::from).collect();
         Bins::Some(bins)
     }
 }
 
-impl<'a> From<&'a [&'a str; 3]> for Bins<'a> {
-    fn from(bins: &'a [&'a str; 3]) -> Self {
+impl<'a> From<[&'a str; 3]> for Bins {
+    fn from(bins: [&'a str; 3]) -> Self {
+        let bins = bins.iter().cloned().map(String::from).collect();
         Bins::Some(bins)
     }
 }
 
-impl<'a> From<&'a [&'a str; 4]> for Bins<'a> {
-    fn from(bins: &'a [&'a str; 4]) -> Self {
+impl<'a> From<[&'a str; 4]> for Bins {
+    fn from(bins: [&'a str; 4]) -> Self {
+        let bins = bins.iter().cloned().map(String::from).collect();
         Bins::Some(bins)
     }
 }
 
-impl<'a> From<&'a [&'a str; 5]> for Bins<'a> {
-    fn from(bins: &'a [&'a str; 5]) -> Self {
+impl<'a> From<[&'a str; 5]> for Bins {
+    fn from(bins: [&'a str; 5]) -> Self {
+        let bins = bins.iter().cloned().map(String::from).collect();
         Bins::Some(bins)
     }
 }
 
-impl<'a> From<&'a [&'a str; 6]> for Bins<'a> {
-    fn from(bins: &'a [&'a str; 6]) -> Self {
+impl<'a> From<[&'a str; 6]> for Bins {
+    fn from(bins: [&'a str; 6]) -> Self {
+        let bins = bins.iter().cloned().map(String::from).collect();
         Bins::Some(bins)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn into_bins() {
+        let bin_names = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+        let expected = Bins::Some(bin_names);
+
+        assert_eq!(expected, Bins::from(["a", "b", "c"]));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -693,7 +693,7 @@ impl Client {
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
-    /// let stmt = Statement::new("test", "test", None);
+    /// let stmt = Statement::new("test", "test", Bins::All);
     /// match client.query(&QueryPolicy::default(), stmt) {
     ///     Ok(records) => {
     ///         for record in &*records {

--- a/src/client.rs
+++ b/src/client.rs
@@ -158,7 +158,7 @@ impl Client {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
-    /// match client.get(&ReadPolicy::default(), &key, &["a", "b"]) {
+    /// match client.get(&ReadPolicy::default(), &key, ["a", "b"]) {
     ///     Ok(record)
     ///         => println!("a={:?}", record.bins.get("a")),
     ///     Err(Error(ErrorKind::ServerError(ResultCode::KeyNotFoundError), _))
@@ -193,7 +193,7 @@ impl Client {
     /// # }
     /// ```
     pub fn get<'a, T>(&self, policy: &ReadPolicy, key: &Key, bins: T) -> Result<Record>
-        where T: Into<Bins<'a>>
+        where T: Into<Bins>
     {
         let bins = bins.into();
         let mut command = ReadCommand::new(policy, self.cluster.clone(), key, bins);
@@ -218,7 +218,7 @@ impl Client {
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
-    /// let bins = ["name", "age"];
+    /// let bins = Bins::from(["name", "age"]);
     /// let mut batch_reads = vec![];
     /// for i in 0..10 {
     ///   let key = as_key!("test", "test", i);

--- a/src/client.rs
+++ b/src/client.rs
@@ -192,7 +192,7 @@ impl Client {
     /// }
     /// # }
     /// ```
-    pub fn get<'a, T>(&self, policy: &ReadPolicy, key: &Key, bins: T) -> Result<Record>
+    pub fn get<T>(&self, policy: &ReadPolicy, key: &Key, bins: T) -> Result<Record>
         where T: Into<Bins>
     {
         let bins = bins.into();
@@ -606,7 +606,7 @@ impl Client {
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
-    /// match client.scan(&ScanPolicy::default(), "test", "demo", None) {
+    /// match client.scan(&ScanPolicy::default(), "test", "demo", Bins::All) {
     ///     Ok(records) => {
     ///         let mut count = 0;
     ///         for record in &*records {
@@ -621,21 +621,15 @@ impl Client {
     /// }
     /// # }
     /// ```
-    pub fn scan(&self,
-                policy: &ScanPolicy,
-                namespace: &str,
-                set_name: &str,
-                bin_names: Option<&[&str]>)
-                -> Result<Arc<Recordset>> {
-
-        let bin_names = match bin_names {
-            None => None,
-            Some(bin_names) => {
-                let bin_names: Vec<_> = bin_names.iter().cloned().map(String::from).collect();
-                Some(bin_names)
-            }
-        };
-
+    pub fn scan<T>(&self,
+                   policy: &ScanPolicy,
+                   namespace: &str,
+                   set_name: &str,
+                   bins: T)
+                   -> Result<Arc<Recordset>>
+        where T: Into<Bins>
+    {
+        let bins = bins.into();
         let nodes = self.cluster.nodes();
         let recordset = Arc::new(Recordset::new(policy.record_queue_size, nodes.len()));
         for node in nodes {
@@ -644,11 +638,11 @@ impl Client {
             let policy = policy.to_owned();
             let namespace = namespace.to_owned();
             let set_name = set_name.to_owned();
-            let bin_names = bin_names.to_owned();
+            let bins = bins.clone();
 
             thread::spawn(move || {
                 let mut command =
-                    ScanCommand::new(&policy, node, &namespace, &set_name, &bin_names, recordset);
+                    ScanCommand::new(&policy, node, &namespace, &set_name, bins, recordset);
                 command.execute().unwrap();
             });
 
@@ -661,36 +655,26 @@ impl Client {
     /// concurrently pops records off the queue through the record iterator. Up to
     /// `policy.max_concurrent_nodes` nodes are scanned in parallel. If concurrent nodes is set to
     /// zero, the server nodes are read in series.
-    pub fn scan_node(&self,
-                     policy: &ScanPolicy,
-                     node: Arc<Node>,
-                     namespace: &str,
-                     set_name: &str,
-                     bin_names: Option<&[&str]>)
-                     -> Result<Arc<Recordset>> {
-        let bin_names = match bin_names {
-            None => None,
-            Some(bin_names) => {
-                let bin_names: Vec<_> = bin_names.iter().cloned().map(String::from).collect();
-                Some(bin_names)
-            }
-        };
-
+    pub fn scan_node<T>(&self,
+                        policy: &ScanPolicy,
+                        node: Arc<Node>,
+                        namespace: &str,
+                        set_name: &str,
+                        bins: T)
+                        -> Result<Arc<Recordset>>
+        where T: Into<Bins>
+    {
+        let bins = bins.into();
         let recordset = Arc::new(Recordset::new(policy.record_queue_size, 1));
         let t_recordset = recordset.clone();
         let policy = policy.to_owned();
         let namespace = namespace.to_owned();
         let set_name = set_name.to_owned();
-        let bin_names = bin_names.to_owned();
 
         self.thread_pool
             .spawn(move || {
-                let mut command = ScanCommand::new(&policy,
-                                                   node,
-                                                   &namespace,
-                                                   &set_name,
-                                                   &bin_names,
-                                                   t_recordset);
+                let mut command =
+                    ScanCommand::new(&policy, node, &namespace, &set_name, bins, t_recordset);
                 command.execute().unwrap();
             });
 

--- a/src/commands/read_command.rs
+++ b/src/commands/read_command.rs
@@ -35,15 +35,11 @@ pub struct ReadCommand<'a> {
     pub single_command: SingleCommand<'a>,
     pub record: Option<Record>,
     policy: &'a ReadPolicy,
-    bins: Bins<'a>,
+    bins: Bins,
 }
 
 impl<'a> ReadCommand<'a> {
-    pub fn new(policy: &'a ReadPolicy,
-               cluster: Arc<Cluster>,
-               key: &'a Key,
-               bins: Bins<'a>)
-               -> Self {
+    pub fn new(policy: &'a ReadPolicy, cluster: Arc<Cluster>, key: &'a Key, bins: Bins) -> Self {
         ReadCommand {
             single_command: SingleCommand::new(cluster, key),
             bins: bins,

--- a/src/commands/scan_command.rs
+++ b/src/commands/scan_command.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use std::str;
 
 use errors::*;
+use Bins;
 use Recordset;
 use cluster::Node;
 use commands::{Command, SingleCommand, StreamCommand};
@@ -28,7 +29,7 @@ pub struct ScanCommand<'a> {
     policy: &'a ScanPolicy,
     namespace: &'a str,
     set_name: &'a str,
-    bin_names: &'a Option<Vec<String>>,
+    bins: Bins,
 }
 
 impl<'a> ScanCommand<'a> {
@@ -36,7 +37,7 @@ impl<'a> ScanCommand<'a> {
                node: Arc<Node>,
                namespace: &'a str,
                set_name: &'a str,
-               bin_names: &'a Option<Vec<String>>,
+               bins: Bins,
                recordset: Arc<Recordset>)
                -> Self {
         ScanCommand {
@@ -44,7 +45,7 @@ impl<'a> ScanCommand<'a> {
             policy: policy,
             namespace: namespace,
             set_name: set_name,
-            bin_names: bin_names,
+            bins: bins,
         }
     }
 
@@ -68,7 +69,7 @@ impl<'a> Command for ScanCommand<'a> {
             .set_scan(self.policy,
                       self.namespace,
                       self.set_name,
-                      self.bin_names,
+                      &self.bins,
                       self.stream_command.recordset.task_id())
     }
 

--- a/src/policy/query_policy.rs
+++ b/src/policy/query_policy.rs
@@ -32,9 +32,6 @@ pub struct QueryPolicy {
     /// the queue is full, the producer threads will block until records are consumed.
     pub record_queue_size: usize,
 
-    /// Indicates if bin data is retrieved. If false, only record digests are retrieved.
-    pub include_bin_data: bool,
-
     /// Terminate query if cluster is in fluctuating state.
     pub fail_on_cluster_change: bool,
 }
@@ -53,7 +50,6 @@ impl Default for QueryPolicy {
             base_policy: BasePolicy::default(),
             max_concurrent_nodes: 0,
             record_queue_size: 1024,
-            include_bin_data: true,
             fail_on_cluster_change: true,
         }
     }

--- a/src/policy/scan_policy.rs
+++ b/src/policy/scan_policy.rs
@@ -35,9 +35,6 @@ pub struct ScanPolicy {
     /// the queue is full, the producer threads will block until records are consumed.
     pub record_queue_size: usize,
 
-    /// Indicates if bin data is retrieved. If false, only record digests are retrieved.
-    pub include_bin_data: bool,
-
     /// Terminate scan if cluster is in fluctuating state.
     pub fail_on_cluster_change: bool,
 }
@@ -57,7 +54,6 @@ impl Default for ScanPolicy {
             scan_percent: 100,
             max_concurrent_nodes: 0,
             record_queue_size: 1024,
-            include_bin_data: true,
             fail_on_cluster_change: true,
         }
     }

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -14,6 +14,7 @@
 // the License.
 
 use errors::*;
+use Bins;
 use Value;
 use query::Filter;
 
@@ -37,7 +38,7 @@ pub struct Statement {
     pub index_name: Option<String>,
 
     /// Optional list of bin names to return in query.
-    pub bin_names: Option<Vec<String>>,
+    pub bins: Bins,
 
     /// Optional list of query filters. Currently, only one filter is allowed by the server on a
     /// secondary index lookup.
@@ -57,24 +58,15 @@ impl Statement {
     /// "age" bins for each matching record.
     ///
     /// ```rust
-    /// use aerospike::Statement;
+    /// # use aerospike::*;
     ///
-    /// let stmt = Statement::new("foo", "bar", Some(&vec!["name", "age"]));
+    /// let stmt = Statement::new("foo", "bar", Bins::from(["name", "age"]));
     /// ```
-    pub fn new(namespace: &str, set_name: &str, bin_names: Option<&[&str]>) -> Self {
-
-        let bin_names = match bin_names {
-            None => None,
-            Some(bin_names) => {
-                let bin_names: Vec<_> = bin_names.iter().cloned().map(String::from).collect();
-                Some(bin_names)
-            }
-        };
-
+    pub fn new(namespace: &str, set_name: &str, bins: Bins) -> Self {
         Statement {
             namespace: namespace.to_owned(),
             set_name: set_name.to_owned(),
-            bin_names: bin_names,
+            bins: bins,
             index_name: None,
             aggregation: None,
             filters: None,
@@ -93,7 +85,7 @@ impl Statement {
     /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
-    /// let mut stmt = Statement::new("foo", "bar", Some(&vec!["name", "age"]));
+    /// let mut stmt = Statement::new("foo", "bar", Bins::from(["name", "age"]));
     /// stmt.add_filter(as_range!("baz", 0, 100));
     /// # }
     /// ```
@@ -160,7 +152,6 @@ impl Statement {
             if agg.function_name.is_empty() {
                 bail!(ErrorKind::InvalidArgument("Empty UDF function name".to_string()));
             }
-
         }
 
         Ok(())

--- a/tests/src/batch.rs
+++ b/tests/src/batch.rs
@@ -45,11 +45,14 @@ fn batch_get() {
     let key3 = as_key!(namespace, set_name, 3);
     client.put(&wpolicy, &key3, &[&bin1, &bin2, &bin3]).unwrap();
 
-    let bins = &["a"];
-    let batch = vec![BatchRead::new(key1, Bins::Some(bins)),
-                     BatchRead::new(key2, Bins::All),
-                     BatchRead::new(key3, Bins::None),
-                     BatchRead::new(as_key!(namespace, set_name, -1), Bins::None)];
+    let selected = Bins::from(["a"]);
+    let all = Bins::All;
+    let none = Bins::None;
+
+    let batch = vec![BatchRead::new(key1, &selected),
+                     BatchRead::new(key2, &all),
+                     BatchRead::new(key3, &none),
+                     BatchRead::new(as_key!(namespace, set_name, -1), &none)];
     let mut results = client.batch_get(&bpolicy, batch).unwrap();
 
     let record = results.remove(0).record.unwrap();

--- a/tests/src/scan.rs
+++ b/tests/src/scan.rs
@@ -20,7 +20,7 @@ use std::thread;
 use env_logger;
 use common;
 
-use aerospike::{WritePolicy, ScanPolicy};
+use aerospike::{Bins, WritePolicy, ScanPolicy};
 
 const EXPECTED: usize = 1000;
 
@@ -50,7 +50,9 @@ fn scan_single_consumer() {
     let set_name = create_test_set(EXPECTED);
 
     let spolicy = ScanPolicy::default();
-    let rs = client.scan(&spolicy, namespace, &set_name, None).unwrap();
+    let rs = client
+        .scan(&spolicy, namespace, &set_name, Bins::All)
+        .unwrap();
 
     let count = (&*rs).filter(|r| r.is_ok()).count();
     assert_eq!(count, EXPECTED);
@@ -66,7 +68,9 @@ fn scan_multi_consumer() {
 
     let mut spolicy = ScanPolicy::default();
     spolicy.record_queue_size = 4096;
-    let rs = client.scan(&spolicy, namespace, &set_name, None).unwrap();
+    let rs = client
+        .scan(&spolicy, namespace, &set_name, Bins::All)
+        .unwrap();
 
     let count = Arc::new(AtomicUsize::new(0));
     let mut threads = vec![];
@@ -105,7 +109,7 @@ fn scan_node() {
         threads.push(thread::spawn(move || {
             let spolicy = ScanPolicy::default();
             let rs = client
-                .scan_node(&spolicy, node, namespace, &set_name, None)
+                .scan_node(&spolicy, node, namespace, &set_name, Bins::All)
                 .unwrap();
             let ok = (&*rs).filter(|r| r.is_ok()).count();
             count.fetch_add(ok, Ordering::Relaxed);


### PR DESCRIPTION
Aerospike server versions 3.15 and later support running queries that only return meta-data, without the record bins. (Earlier versions support this scans only, but not for queries.)

To unify bin selection (all, none or some bins) for `get`, `batch`, `scan` and `query` commands, we should use `aerospike::Bins` and remove the `include_bin_data` flag from the scan and query policies.