### PR TITLE
Support configurable scan socket timeout

### DIFF
--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -487,6 +487,10 @@ impl Buffer {
         self.data_offset += 2 + FIELD_HEADER_SIZE as usize;
         field_count += 1;
 
+        // Estimate scan timeout size.
+        self.data_offset += 4 + FIELD_HEADER_SIZE as usize;
+        field_count += 1;
+
         // Allocate space for task_id field.
         self.data_offset += 8 + FIELD_HEADER_SIZE as usize;
         field_count += 1;
@@ -534,6 +538,10 @@ impl Buffer {
 
         try!(self.write_u8(priority));
         try!(self.write_u8(policy.scan_percent));
+
+        // Write scan timeout
+        try!(self.write_field_header(4, FieldType::ScanTimeout));
+        try!(self.write_u32(policy.socket_timeout));
 
         try!(self.write_field_header(8, FieldType::TranId));
         try!(self.write_u64(task_id));

--- a/src/commands/field_type.rs
+++ b/src/commands/field_type.rs
@@ -26,6 +26,7 @@ pub enum FieldType {
     // DigestRipeArray = 6,
     TranId = 7, // user supplied transaction id, which is simply passed back,
     ScanOptions = 8,
+    ScanTimeout = 9,
     IndexName = 21,
     IndexRange = 22,
     // IndexFilter = 23,

--- a/src/policy/scan_policy.rs
+++ b/src/policy/scan_policy.rs
@@ -37,6 +37,11 @@ pub struct ScanPolicy {
 
     /// Terminate scan if cluster is in fluctuating state.
     pub fail_on_cluster_change: bool,
+
+    /// Maximum time in milliseconds to wait when polling socket for availability prior to
+    /// performing an operation on the socket on the server side. Zero means there is no socket
+    /// timeout. Default: 10,000 ms.
+    pub socket_timeout: u32,
 }
 
 
@@ -55,6 +60,7 @@ impl Default for ScanPolicy {
             max_concurrent_nodes: 0,
             record_queue_size: 1024,
             fail_on_cluster_change: true,
+            socket_timeout: 10000,
         }
     }
 }


### PR DESCRIPTION
New `socket_timeout` setting in `ScanPolicy` allows overwriting the server-side socket timeout for scan operations. Requires Aerospike server version 3.12.1 or later.

Ref. CLIENT-874