### PR TITLE
Switch to bencher crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,14 @@ env_logger = "^0.4"
 hex = "^0.2"
 rustfmt = "^0.8"
 skeptic = "0.9"
+bencher = "^0.1.4"
 
 [build-dependencies]
 skeptic = "0.9"
+
+[[bench]]
+name = "client_server"
+harness = false
 
 [workspace]
 members = ["tools/benchmark"]

--- a/README.md
+++ b/README.md
@@ -120,10 +120,12 @@ To enable backtraces set the `RUST_BACKTRACE` environment variable:
 <a name="Benchmarks"></a>
 ## Benchmarks
 
-The micro-benchmarks in the `benches` directory require nightly Rust builds to execute:
+The micro-benchmarks in the `benches` directory use the
+[`bencher`](https://crates.io/crates/bencher) crate and can be run on Rust
+stable releases:
 
     $ export AEROSPIKE_HOSTS=127.0.0.1:3000
-    $ cargo +nightly bench
+    $ cargo bench
 
 There is a separate benchmark tool under the
 [tools/benchmark](tools/benchmark) directory that is designed to

--- a/benches/client_server.rs
+++ b/benches/client_server.rs
@@ -13,48 +13,50 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-#![feature(test)]
-
 #[macro_use]
 extern crate aerospike;
 #[macro_use]
 extern crate lazy_static;
 extern crate rand;
-extern crate test;
+#[macro_use]
+extern crate bencher;
 
 use aerospike::{Bins, ReadPolicy, WritePolicy};
 
-use test::Bencher;
+use bencher::Bencher;
 
 #[path="../tests/common/mod.rs"]
 mod common;
 
-#[bench]
-fn single_key_read(b: &mut Bencher) {
+lazy_static! {
+    static ref TEST_SET: String = common::rand_str(10);
+}
+
+fn single_key_read(bench: &mut Bencher) {
     let client = common::client();
     let namespace = common::namespace();
-    let set_name = &common::rand_str(10);
-    let key = as_key!(namespace, set_name, common::rand_str(10));
+    let key = as_key!(namespace, &TEST_SET, common::rand_str(10));
     let wbin = as_bin!("i", 1);
     let bins = vec![&wbin];
     let rpolicy = ReadPolicy::default();
     let wpolicy = WritePolicy::default();
     client.put(&wpolicy, &key, &bins).unwrap();
 
-    b.iter(|| client.get(&rpolicy, &key, Bins::All).unwrap());
+    bench.iter(|| client.get(&rpolicy, &key, Bins::All).unwrap());
 }
 
-#[bench]
-fn single_key_read_header(b: &mut Bencher) {
+fn single_key_read_header(bench: &mut Bencher) {
     let client = common::client();
     let namespace = common::namespace();
-    let set_name = &common::rand_str(10);
-    let key = as_key!(namespace, set_name, common::rand_str(10));
+    let key = as_key!(namespace, &TEST_SET, common::rand_str(10));
     let wbin = as_bin!("i", 1);
     let bins = vec![&wbin];
     let rpolicy = ReadPolicy::default();
     let wpolicy = WritePolicy::default();
     client.put(&wpolicy, &key, &bins).unwrap();
 
-    b.iter(|| client.get(&rpolicy, &key, Bins::None).unwrap());
+    bench.iter(|| client.get(&rpolicy, &key, Bins::None).unwrap());
 }
+
+benchmark_group!(benches, single_key_read, single_key_read_header);
+benchmark_main!(benches);

--- a/src/batch/batch_executor.rs
+++ b/src/batch/batch_executor.rs
@@ -77,7 +77,7 @@ impl BatchExecutor {
                     let jobs = jobs.clone();
                     scope.execute(move || {
                         let next_job = || jobs.lock().next();
-                        while let Some(mut cmd) = next_job() {
+                        while let Some(cmd) = next_job() {
                             if let Err(err) = cmd.execute() {
                                 *last_err.lock() = Some(err);
                                 jobs.lock().all(|_| true); // consume the remaining jobs

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use std::str;
 
 use errors::*;
 use Key;

--- a/src/commands/exists_command.rs
+++ b/src/commands/exists_command.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use std::str;
 
 use errors::*;
 use Key;

--- a/src/commands/read_command.rs
+++ b/src/commands/read_command.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::time::Duration;
-use std::str;
 
 use errors::*;
 use Bins;

--- a/src/commands/stream_command.rs
+++ b/src/commands/stream_command.rs
@@ -15,7 +15,6 @@
 use std::sync::Arc;
 use std::collections::HashMap;
 use std::time::Duration;
-use std::str;
 use std::thread;
 
 use errors::*;

--- a/src/commands/touch_command.rs
+++ b/src/commands/touch_command.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use std::str;
 
 use errors::*;
 use Key;

--- a/src/commands/write_command.rs
+++ b/src/commands/write_command.rs
@@ -14,7 +14,6 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use std::str;
 
 use errors::*;
 use Bin;

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -26,7 +26,7 @@ mod common;
 #[test]
 #[should_panic(expected = "Failed to connect to host(s).")]
 fn cluster_name() {
-    let mut policy = &mut common::client_policy().clone();
+    let policy = &mut common::client_policy().clone();
     policy.cluster_name = Some(String::from("notTheRealClusterName"));
     Client::new(policy, &common::hosts()).unwrap();
 }

--- a/tools/benchmark/src/workers.rs
+++ b/tools/benchmark/src/workers.rs
@@ -204,7 +204,7 @@ impl Task for ReadUpdateTask {
     fn execute(&self, key: &Key) -> Status {
         if self.reads >= random() {
             trace!("Reading {}", key);
-            self.status(self.client.get(&self.rpolicy, key, &["int"]).map(|_| ()))
+            self.status(self.client.get(&self.rpolicy, key, ["int"]).map(|_| ()))
         } else {
             trace!("Writing {}", key);
             let bin = as_bin!("int", random::<i64>());


### PR DESCRIPTION
[`bencher`](https://crates.io/crates/bencher) is a port of the libtest (unstable Rust) benchmark runner to Rust stable releases. 