### PR TITLE
Use generic types to make client API more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ fn main() {
     let rpolicy = ReadPolicy::default();
     let wpolicy = WritePolicy::default();
     let key = as_key!("test", "test", "test");
-    let wbin = as_bin!("int", 999);
-    let bins = vec![&wbin];
 
+    let bins = [
+        as_bin!("int", 999),
+        as_bin!("str", "Hello, World!"),
+    ];
     client.put(&wpolicy, &key, &bins).unwrap();
     let rec = client.get(&rpolicy, &key, Bins::All);
     println!("Record: {}", rec.unwrap());
@@ -64,7 +66,8 @@ fn main() {
     let exists = client.exists(&wpolicy, &key).unwrap();
     println!("exists: {}", exists);
 
-    let ops = &vec![operations::put(&wbin), operations::get()];
+    let bin = as_bin!("int", "123");
+    let ops = &vec![operations::put(&bin), operations::get()];
     let op_rec = client.operate(&wpolicy, &key, ops);
     println!("operate: {}", op_rec.unwrap());
 

--- a/benches/client_server.rs
+++ b/benches/client_server.rs
@@ -16,16 +16,16 @@
 #[macro_use]
 extern crate aerospike;
 #[macro_use]
+extern crate bencher;
+#[macro_use]
 extern crate lazy_static;
 extern crate rand;
-#[macro_use]
-extern crate bencher;
 
 use aerospike::{Bins, ReadPolicy, WritePolicy};
 
 use bencher::Bencher;
 
-#[path="../tests/common/mod.rs"]
+#[path = "../tests/common/mod.rs"]
 mod common;
 
 lazy_static! {
@@ -58,5 +58,28 @@ fn single_key_read_header(bench: &mut Bencher) {
     bench.iter(|| client.get(&rpolicy, &key, Bins::None).unwrap());
 }
 
-benchmark_group!(benches, single_key_read, single_key_read_header);
+fn single_key_write(bench: &mut Bencher) {
+    let client = common::client();
+    let namespace = common::namespace();
+    let key = as_key!(namespace, &TEST_SET, common::rand_str(10));
+    let wpolicy = WritePolicy::default();
+
+    let bin1 = as_bin!("str1", common::rand_str(256));
+    let bin2 = as_bin!("str1", common::rand_str(256));
+    let bin3 = as_bin!("str1", common::rand_str(256));
+    let bin4 = as_bin!("str1", common::rand_str(256));
+    let bins = [bin1, bin2, bin3, bin4];
+
+    bench.iter(|| {
+        client.put(&wpolicy, &key, &bins).unwrap();
+    });
+}
+
+benchmark_group!(
+    benches,
+    single_key_read,
+    single_key_read_header,
+    single_key_write,
+    // single_key_write_iter,
+);
 benchmark_main!(benches);

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -26,7 +26,6 @@ pub struct Bin<'a> {
     pub value: Value,
 }
 
-
 impl<'a> Bin<'a> {
     /// Construct a new bin given a name and a value.
     pub fn new(name: &'a str, val: Value) -> Self {
@@ -34,6 +33,12 @@ impl<'a> Bin<'a> {
             name: name,
             value: val,
         }
+    }
+}
+
+impl<'a> AsRef<Bin<'a>> for Bin<'a> {
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -151,7 +151,6 @@ impl Client {
     /// Fetch specified bins for a record with the given key.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
@@ -171,7 +170,6 @@ impl Client {
     /// Determine the remaining time-to-live of a record.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
@@ -212,7 +210,6 @@ impl Client {
     /// Fetch multiple records in a single client request
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
@@ -254,7 +251,6 @@ impl Client {
     /// Write a record with a single integer bin.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
@@ -271,7 +267,6 @@ impl Client {
     /// Write a record with an expiration of 10 seconds.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
@@ -311,7 +306,6 @@ impl Client {
     /// Add two integer values to two existing bin values.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
@@ -383,7 +377,6 @@ impl Client {
     /// Delete a record.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
@@ -410,7 +403,6 @@ impl Client {
     /// Reset a record's time to expiration to the default ttl for the namespace.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
@@ -448,7 +440,6 @@ impl Client {
     /// call.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,7 +20,6 @@
 //! Handling an error returned by the client.
 //!
 //! ```rust
-//! #[macro_use] extern crate aerospike;
 //! use aerospike::*;
 //!
 //! fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,10 @@
 //!             let rpolicy = ReadPolicy::default();
 //!             let wpolicy = WritePolicy::default();
 //!             let key = as_key!("test", "test", i);
-//!             let wbin = as_bin!("bin999", 1);
-//!             let bins = vec![&wbin];
+//!             let bins = [
+//!                 as_bin!("int", 123),
+//!                 as_bin!("str", "Hello, World!"),
+//!             ];
 //!
 //!             client.put(&wpolicy, &key, &bins).unwrap();
 //!             let rec = client.get(&rpolicy, &key, Bins::All);
@@ -82,7 +84,8 @@
 //!             let exists = client.exists(&wpolicy, &key).unwrap();
 //!             println!("exists: {}", exists);
 //!
-//!             let ops = &vec![operations::put(&wbin), operations::get()];
+//!             let bin = as_bin!("int", 999);
+//!             let ops = &vec![operations::put(&bin), operations::get()];
 //!             let op_rec = client.operate(&wpolicy, &key, ops);
 //!             println!("operate: {}", op_rec.unwrap());
 //!

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -82,7 +82,6 @@ impl Statement {
     /// all records using a filter with the range 0 to 100 inclusive:
     ///
     /// ```rust
-    /// # #[macro_use] extern crate aerospike;
     /// # use aerospike::*;
     /// # fn main() {
     /// let mut stmt = Statement::new("foo", "bar", Bins::from(["name", "age"]));
@@ -103,10 +102,12 @@ impl Statement {
     }
 
     /// Set Lua aggregation function parameters.
-    pub fn set_aggregate_function(&mut self,
-                                  package_name: &str,
-                                  function_name: &str,
-                                  function_args: Option<&[Value]>) {
+    pub fn set_aggregate_function(
+        &mut self,
+        package_name: &str,
+        function_name: &str,
+        function_args: Option<&[Value]>,
+    ) {
         let agg = Aggregation {
             package_name: package_name.to_owned(),
             function_name: function_name.to_owned(),
@@ -130,7 +131,9 @@ impl Statement {
     pub fn validate(&self) -> Result<()> {
         if let Some(ref filters) = self.filters {
             if filters.len() > 1 {
-                bail!(ErrorKind::InvalidArgument("Too many filter expressions".to_string()));
+                bail!(ErrorKind::InvalidArgument(
+                    "Too many filter expressions".to_string()
+                ));
             }
         }
 
@@ -146,11 +149,15 @@ impl Statement {
 
         if let Some(ref agg) = self.aggregation {
             if agg.package_name.is_empty() {
-                bail!(ErrorKind::InvalidArgument("Empty UDF package name".to_string()));
+                bail!(ErrorKind::InvalidArgument(
+                    "Empty UDF package name".to_string()
+                ));
             }
 
             if agg.function_name.is_empty() {
-                bail!(ErrorKind::InvalidArgument("Empty UDF function name".to_string()));
+                bail!(ErrorKind::InvalidArgument(
+                    "Empty UDF function name".to_string()
+                ));
             }
         }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -20,7 +20,7 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::result::Result as StdResult;
 
-use byteorder::{NetworkEndian, ByteOrder};
+use byteorder::{ByteOrder, NetworkEndian};
 
 use crypto::ripemd160::Ripemd160;
 use crypto::digest::Digest;
@@ -30,10 +30,10 @@ use std::vec::Vec;
 use errors::*;
 use commands::ParticleType;
 use commands::buffer::Buffer;
-use msgpack::{encoder, decoder};
+use msgpack::{decoder, encoder};
 
 /// Container for floating point bin values stored in the Aerospike database.
-#[derive(Debug,Clone,PartialEq,Eq,Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FloatValue {
     /// Container for single precision float values.
     F32(u32),
@@ -44,10 +44,10 @@ pub enum FloatValue {
 impl From<FloatValue> for f64 {
     fn from(val: FloatValue) -> f64 {
         match val {
-            FloatValue::F32(_) => {
-                panic!("This library does not automatically convert f32 -> f64 to be used in keys \
-                        or bins.")
-            }
+            FloatValue::F32(_) => panic!(
+                "This library does not automatically convert f32 -> f64 to be used in keys \
+                 or bins."
+            ),
             FloatValue::F64(val) => unsafe { mem::transmute(val) },
         }
     }
@@ -56,10 +56,10 @@ impl From<FloatValue> for f64 {
 impl<'a> From<&'a FloatValue> for f64 {
     fn from(val: &FloatValue) -> f64 {
         match *val {
-            FloatValue::F32(_) => {
-                panic!("This library does not automatically convert f32 -> f64 to be used in keys \
-                        or bins.")
-            }
+            FloatValue::F32(_) => panic!(
+                "This library does not automatically convert f32 -> f64 to be used in keys \
+                 or bins."
+            ),
             FloatValue::F64(val) => unsafe { mem::transmute(val) },
         }
     }
@@ -139,7 +139,7 @@ impl fmt::Display for FloatValue {
 }
 
 /// Container for bin values stored in the Aerospike database.
-#[derive(Debug,Clone,PartialEq,Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Value {
     /// Empty value.
     Nil,
@@ -225,10 +225,10 @@ impl Value {
         match *self {
             Value::Nil => ParticleType::NULL,
             Value::Int(_) => ParticleType::INTEGER,
-            Value::UInt(_) => {
-                panic!("Aerospike does not support u64 natively on server-side. Use casting to \
-                        store and retrieve u64 values.")
-            }
+            Value::UInt(_) => panic!(
+                "Aerospike does not support u64 natively on server-side. Use casting to \
+                 store and retrieve u64 values."
+            ),
             Value::Bool(_) => ParticleType::INTEGER,
             Value::Float(_) => ParticleType::FLOAT,
             Value::String(_) => ParticleType::STRING,
@@ -264,10 +264,10 @@ impl Value {
         match *self {
             Value::Nil => Ok(0),
             Value::Int(_) => Ok(8),
-            Value::UInt(_) => {
-                panic!("Aerospike does not support u64 natively on server-side. Use casting to \
-                        store and retrieve u64 values.")
-            }
+            Value::UInt(_) => panic!(
+                "Aerospike does not support u64 natively on server-side. Use casting to \
+                 store and retrieve u64 values."
+            ),
             Value::Bool(_) => Ok(8),
             Value::Float(_) => Ok(8),
             Value::String(ref s) => Ok(s.len()),
@@ -286,16 +286,15 @@ impl Value {
         match *self {
             Value::Nil => Ok(0),
             Value::Int(ref val) => buf.write_i64(*val),
-            Value::UInt(_) => {
-                panic!("Aerospike does not support u64 natively on server-side. Use casting to \
-                        store and retrieve u64 values.")
-            }
+            Value::UInt(_) => panic!(
+                "Aerospike does not support u64 natively on server-side. Use casting to \
+                 store and retrieve u64 values."
+            ),
             Value::Bool(ref val) => buf.write_bool(*val),
             Value::Float(ref val) => buf.write_f64(f64::from(val)),
             Value::String(ref val) => buf.write_str(val),
             Value::Blob(ref val) => buf.write_bytes(val),
-            Value::List(_) |
-            Value::HashMap(_) => encoder::pack_value(&mut Some(buf), self),
+            Value::List(_) | Value::HashMap(_) => encoder::pack_value(&mut Some(buf), self),
             Value::OrderedMap(_) => panic!("The library never passes ordered maps to the server."),
             Value::GeoJSON(ref val) => buf.write_geo(val),
         }
@@ -529,7 +528,6 @@ impl<'a> From<&'a usize> for Value {
     }
 }
 
-
 impl<'a> From<&'a bool> for Value {
     fn from(val: &'a bool) -> Value {
         Value::Bool(*val)
@@ -620,7 +618,6 @@ macro_rules! as_blob {
 /// Write a list value to a record bin.
 ///
 /// ```rust
-/// # #[macro_use] extern crate aerospike;
 /// # use aerospike::*;
 /// # use std::vec::Vec;
 /// # fn main() {
@@ -652,7 +649,6 @@ macro_rules! as_list {
 /// Execute a user-defined function (UDF) with some arguments.
 ///
 /// ```rust,should_panic
-/// # #[macro_use] extern crate aerospike;
 /// # use aerospike::*;
 /// # use std::vec::Vec;
 /// # fn main() {
@@ -686,7 +682,6 @@ macro_rules! as_values {
 /// Write a map value to a record bin.
 ///
 /// ```rust
-/// # #[macro_use] extern crate aerospike;
 /// # use aerospike::*;
 /// # use std::collections::HashMap;
 /// # fn main() {
@@ -719,12 +714,16 @@ mod tests {
     fn as_string() {
         assert_eq!(Value::Nil.as_string(), String::from("<null>"));
         assert_eq!(Value::Int(42).as_string(), String::from("42"));
-        assert_eq!(Value::UInt(9223372036854775808).as_string(),
-                   String::from("9223372036854775808"));
+        assert_eq!(
+            Value::UInt(9223372036854775808).as_string(),
+            String::from("9223372036854775808")
+        );
         assert_eq!(Value::Bool(true).as_string(), String::from("true"));
         assert_eq!(Value::from(3.1416).as_string(), String::from("3.1416"));
-        assert_eq!(as_geo!(r#"{"type":"Point"}"#).as_string(),
-                   String::from(r#"{"type":"Point"}"#));
+        assert_eq!(
+            as_geo!(r#"{"type":"Point"}"#).as_string(),
+            String::from(r#"{"type":"Point"}"#)
+        );
     }
 
     #[test]

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -15,7 +15,7 @@
 
 use std::collections::HashMap;
 
-use aerospike::{Bins, Value, ReadPolicy, WritePolicy};
+use aerospike::{Bins, ReadPolicy, Value, WritePolicy};
 use aerospike::operations;
 
 use env_logger;
@@ -32,20 +32,25 @@ fn connect() {
     let policy = ReadPolicy::default();
     let wpolicy = WritePolicy::default();
     let key = as_key!(namespace, set_name, -1);
-    let wbin = as_bin!("bin999", "test string");
-    let wbin1 = as_bin!("bin vec![int]", as_list![1u32, 2u32, 3u32]);
-    let wbin2 = as_bin!("bin vec![u8]", as_blob!(vec![1u8, 2u8, 3u8]));
-    let wbin3 = as_bin!("bin map", as_map!(1 => 1, 2 => 2, 3 => "hi!"));
-    let wbin4 = as_bin!("bin f64", 1.64f64);
-    let wbin5 = as_bin!("bin Nil", None); // Writing None erases the bin!
-    let wbin6 = as_bin!("bin Geo",
-                        as_geo!(format!(r#"{{ "type": "Point", "coordinates": [{}, {}] }}"#,
-                                        17.119381,
-                                        19.45612)));
-    let wbin7 = as_bin!("bin-name-len-15", "max. bin name length is 15 chars");
-    let bins = vec![&wbin, &wbin1, &wbin2, &wbin3, &wbin4, &wbin5, &wbin6, &wbin7];
 
     client.delete(&wpolicy, &key).unwrap();
+
+    let bins = [
+        as_bin!("bin999", "test string"),
+        as_bin!("bin vec![int]", as_list![1u32, 2u32, 3u32]),
+        as_bin!("bin vec![u8]", as_blob!(vec![1u8, 2u8, 3u8])),
+        as_bin!("bin map", as_map!(1 => 1, 2 => 2, 3 => "hi!")),
+        as_bin!("bin f64", 1.64f64),
+        as_bin!("bin Nil", None), // Writing None erases the bin!
+        as_bin!(
+            "bin Geo",
+            as_geo!(format!(
+                r#"{{ "type": "Point", "coordinates": [{}, {}] }}"#,
+                17.119381, 19.45612
+            ))
+        ),
+        as_bin!("bin-name-len-15", "max. bin name length is 15 chars"),
+    ];
     client.put(&wpolicy, &key, &bins).unwrap();
 
     let record = client.get(&policy, &key, Bins::All).unwrap();
@@ -53,15 +58,25 @@ fn connect() {
     assert_eq!(bins.len(), 7);
     assert_eq!(bins.get("bin999"), Some(&Value::from("test string")));
     assert_eq!(bins.get("bin vec![int]"), Some(&as_list![1u32, 2u32, 3u32]));
-    assert_eq!(bins.get("bin vec![u8]"),
-               Some(&as_blob!(vec![1u8, 2u8, 3u8])));
-    assert_eq!(bins.get("bin map"),
-               Some(&as_map!(1 => 1, 2 => 2, 3 => "hi!")));
+    assert_eq!(
+        bins.get("bin vec![u8]"),
+        Some(&as_blob!(vec![1u8, 2u8, 3u8]))
+    );
+    assert_eq!(
+        bins.get("bin map"),
+        Some(&as_map!(1 => 1, 2 => 2, 3 => "hi!"))
+    );
     assert_eq!(bins.get("bin f64"), Some(&Value::from(1.64f64)));
-    assert_eq!(bins.get("bin Geo"),
-               Some(&as_geo!(r#"{ "type": "Point", "coordinates": [17.119381, 19.45612] }"#)));
-    assert_eq!(bins.get("bin-name-len-15"),
-               Some(&Value::from("max. bin name length is 15 chars")));
+    assert_eq!(
+        bins.get("bin Geo"),
+        Some(&as_geo!(
+            r#"{ "type": "Point", "coordinates": [17.119381, 19.45612] }"#
+        ))
+    );
+    assert_eq!(
+        bins.get("bin-name-len-15"),
+        Some(&Value::from("max. bin name length is 15 chars"))
+    );
 
     client.touch(&wpolicy, &key).unwrap();
 
@@ -75,7 +90,8 @@ fn connect() {
     let exists = client.exists(&wpolicy, &key).unwrap();
     assert!(exists);
 
-    let ops = &vec![operations::put(&wbin), operations::get()];
+    let bin = as_bin!("bin999", "test string");
+    let ops = &vec![operations::put(&bin), operations::get()];
     client.operate(&wpolicy, &key, ops).unwrap();
 
     let existed = client.delete(&wpolicy, &key).unwrap();


### PR DESCRIPTION
As per #47 and this [rust-lang forum thread](https://users.rust-lang.org/t/newbie-ownership-issue/17079) any client API that takes `&[&Bin]` could be improved by taking `&[A] where A: AsRef<Bin>` instead.