### PR TITLE
Update all dependencies and remove multi-versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.32.0
+  - 1.34.0
 matrix:
   allow_failures:
     - rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,22 +22,22 @@ travis-ci = { repository = "aerospike/aerospike-client-rust" }
 appveyor = { repository = "aerospike/aerospike-client-rust" }
 
 [dependencies]
-log = "^0.4"
-byteorder = "^0.5"
-rust-crypto = "^0.2"
-base64 = "^0.7.0"
-crossbeam = "^0.4"
-rand = "^0.5"
-scoped-pool = "^1.0"
-pwhash = "0.1"
-lazy_static = "^1.0"
-error-chain = "^0.12"
-parking_lot = "^0.6"
+log = "0.4"
+byteorder = "1.3"
+ripemd160 = "0.8"
+base64 = "0.11"
+crossbeam-queue = "0.2"
+rand = "0.7"
+scoped-pool = "1.0"
+lazy_static = "1.4"
+error-chain = "0.12"
+parking_lot = "0.9"
+pwhash = "0.3"
 
 [dev-dependencies]
-env_logger = "^0.5"
-hex = "^0.2"
-bencher = "^0.1.4"
+env_logger = "0.7"
+hex = "0.4"
+bencher = "0.1"
 
 [[bench]]
 name = "client_server"

--- a/src/commands/admin_command.rs
+++ b/src/commands/admin_command.rs
@@ -16,8 +16,7 @@
 
 use std::str;
 
-use pwhash::bcrypt;
-use pwhash::bcrypt::{BcryptSetup, BcryptVariant};
+use pwhash::bcrypt::{self, BcryptSetup, BcryptVariant};
 
 use errors::*;
 use ResultCode;
@@ -307,14 +306,14 @@ impl AdminCommand {
     }
 
     pub fn hash_password(password: &str) -> Result<String> {
-        let password_hash = try!(bcrypt::hash_with(
+        bcrypt::hash_with(
             BcryptSetup {
                 salt: Some("7EqJtq98hPqEX7fNZaFWoO"),
                 cost: Some(10),
                 variant: Some(BcryptVariant::V2a),
             },
-            &password
-        ));
-        Ok(password_hash)
+            &password,
+        )
+        .map_err(|e| e.into())
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -19,8 +19,8 @@ use std::result::Result as StdResult;
 use errors::*;
 use Value;
 
-use crypto::ripemd160::Ripemd160;
-use crypto::digest::Digest;
+use ripemd160::Ripemd160;
+use ripemd160::digest::Digest;
 
 /// Unique record identifier. Records can be identified using a specified namespace, an optional
 /// set name and a user defined key which must be uique within a set. Records can also be
@@ -71,7 +71,7 @@ impl Key {
         } else {
             unreachable!()
         }
-        hash.result(&mut self.digest);
+        self.digest = hash.result().into();
 
         Ok(())
     }
@@ -110,10 +110,9 @@ macro_rules! as_key {
 #[cfg(test)]
 mod tests {
     use std::str;
-    use hex::ToHex;
 
     macro_rules! digest {
-        ($x:expr) => (as_key!("namespace", "set", $x).digest.to_hex())
+        ($x:expr) => (hex::encode(as_key!("namespace", "set", $x).digest))
     }
     macro_rules! str_repeat {
         ($c:expr, $n:expr) => (str::from_utf8(&vec![$c as u8; $n]).unwrap())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,8 @@
 
 extern crate base64;
 extern crate byteorder;
-extern crate crossbeam;
-extern crate crypto;
+extern crate crossbeam_queue;
+extern crate ripemd160;
 #[macro_use]
 extern crate error_chain;
 #[macro_use]

--- a/src/value.rs
+++ b/src/value.rs
@@ -22,8 +22,8 @@ use std::result::Result as StdResult;
 
 use byteorder::{ByteOrder, NetworkEndian};
 
-use crypto::ripemd160::Ripemd160;
-use crypto::digest::Digest;
+use ripemd160::Ripemd160;
+use ripemd160::digest::Digest;
 
 use std::vec::Vec;
 

--- a/tools/benchmark/Cargo.toml
+++ b/tools/benchmark/Cargo.toml
@@ -8,12 +8,12 @@ repository = "https://github.com/aerospike/aerospike-client-rust/"
 license = "Apache-2.0"
 
 [dependencies]
-clap = "2.20"
-log = "^0.4"
-env_logger = "^0.5"
-lazy_static = "^1.0"
-num_cpus = "1.2"
-rand = "^0.5"
+clap = "2.33"
+log = "0.4"
+env_logger = "0.7"
+lazy_static = "1.4"
+num_cpus = "1.11"
+rand = "0.7"
 aerospike = { path = "../.." }
 
 [[bin]]


### PR DESCRIPTION
I was just starting to use this library and noticed that it pulls in a lot of outdated dependencies.
Also `cargo-audit` gave me 2 vulnerability warnings for the dependencies used.

I simply updated most of the dependencies and replaced a few where it made sense. Only two things are there, where I'm not 💯 sure about:
- As `crossbeam`'s `MsQueue` is gone, I simply replaced it with `SegQueue`.
- `pwhash` pulled in tons of dependencies so I replaced it with the `bcrypt` crate. In that process I had to drop the fixed salt value and the BCrypt version changed. I'm not sure why the salt was fixed and why this specific version was used, some Aerospike server specifics?