### PR TITLE
Raise MSRV to 1.32.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.26.2
+  - 1.32.0
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
Raise minimum required Rust version (MSRV) to 1.32.0 as some dependencies require it. Resolves #59.