### PR TITLE
Fix warnings and errors

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,0 @@
-write_mode = "overwrite"

--- a/src/batch/batch_read.rs
+++ b/src/batch/batch_read.rs
@@ -33,8 +33,8 @@ impl<'a> BatchRead<'a> {
     /// Create a new `BatchRead` instance for the given key and bin selector.
     pub fn new(key: Key, bins: &'a Bins) -> Self {
         BatchRead {
-            key: key,
-            bins: bins,
+            key,
+            bins,
             record: None,
         }
     }

--- a/src/batch/batch_read.rs
+++ b/src/batch/batch_read.rs
@@ -31,7 +31,7 @@ pub struct BatchRead<'a> {
 
 impl<'a> BatchRead<'a> {
     /// Create a new `BatchRead` instance for the given key and bin selector.
-    pub fn new(key: Key, bins: &'a Bins) -> Self {
+    pub const fn new(key: Key, bins: &'a Bins) -> Self {
         BatchRead {
             key,
             bins,

--- a/src/batch/mod.rs
+++ b/src/batch/mod.rs
@@ -13,8 +13,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-pub mod batch_read;
 pub mod batch_executor;
+pub mod batch_read;
 
-pub use self::batch_read::BatchRead;
 pub use self::batch_executor::BatchExecutor;
+pub use self::batch_read::BatchRead;

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -28,7 +28,7 @@ pub struct Bin<'a> {
 
 impl<'a> Bin<'a> {
     /// Construct a new bin given a name and a value.
-    pub fn new(name: &'a str, val: Value) -> Self {
+    pub const fn new(name: &'a str, val: Value) -> Self {
         Bin { name, value: val }
     }
 }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -29,10 +29,7 @@ pub struct Bin<'a> {
 impl<'a> Bin<'a> {
     /// Construct a new bin given a name and a value.
     pub fn new(name: &'a str, val: Value) -> Self {
-        Bin {
-            name: name,
-            value: val,
-        }
+        Bin { name, value: val }
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -100,7 +100,7 @@ impl Client {
     /// let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// ```
-    pub fn new(policy: &ClientPolicy, hosts: &ToHosts) -> Result<Self> {
+    pub fn new(policy: &ClientPolicy, hosts: &dyn ToHosts) -> Result<Self> {
         let hosts = hosts.to_hosts()?;
         let cluster = Cluster::new(policy.clone(), &hosts)?;
         let thread_pool = Pool::new(policy.thread_pool_size);

--- a/src/client.rs
+++ b/src/client.rs
@@ -154,7 +154,7 @@ impl Client {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
@@ -166,14 +166,13 @@ impl Client {
     ///     Err(err)
     ///         => println!("Error fetching record: {}", err),
     /// }
-    /// # }
     /// ```
     ///
     /// Determine the remaining time-to-live of a record.
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
@@ -189,7 +188,6 @@ impl Client {
     ///     Err(err)
     ///         => println!("Error fetching record: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn get<T>(&self, policy: &ReadPolicy, key: &Key, bins: T) -> Result<Record>
     where
@@ -213,7 +211,7 @@ impl Client {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let bins = Bins::from(["name", "age"]);
@@ -234,7 +232,6 @@ impl Client {
     ///     Err(err)
     ///         => println!("Error executing batch request: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn batch_get<'a>(
         &self,
@@ -254,7 +251,7 @@ impl Client {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
@@ -263,14 +260,13 @@ impl Client {
     ///     Ok(()) => println!("Record written"),
     ///     Err(err) => println!("Error writing record: {}", err),
     /// }
-    /// # }
     /// ```
     ///
     /// Write a record with an expiration of 10 seconds.
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
@@ -281,7 +277,6 @@ impl Client {
     ///     Ok(()) => println!("Record written"),
     ///     Err(err) => println!("Error writing record: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn put<'a, 'b, A: AsRef<Bin<'b>>>(
         &self,
@@ -309,7 +304,7 @@ impl Client {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
@@ -320,7 +315,6 @@ impl Client {
     ///     Ok(()) => println!("Record updated"),
     ///     Err(err) => println!("Error writing record: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn add<'a, 'b, A: AsRef<Bin<'b>>>(
         &self,
@@ -380,7 +374,7 @@ impl Client {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
@@ -389,7 +383,6 @@ impl Client {
     ///     Ok(false) => println!("Record did not exist"),
     ///     Err(err) => println!("Error deleting record: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn delete(&self, policy: &WritePolicy, key: &Key) -> Result<bool> {
         let mut command = DeleteCommand::new(policy, self.cluster.clone(), key);
@@ -406,7 +399,7 @@ impl Client {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
@@ -416,7 +409,6 @@ impl Client {
     ///     Ok(()) => println!("Record expiration updated"),
     ///     Err(err) => println!("Error writing record: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn touch(&self, policy: &WritePolicy, key: &Key) -> Result<()> {
         let mut command = TouchCommand::new(policy, self.cluster.clone(), key);
@@ -443,7 +435,7 @@ impl Client {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
@@ -456,7 +448,6 @@ impl Client {
     ///     Ok(record) => println!("The new value is {}", record.bins.get("a").unwrap()),
     ///     Err(err) => println!("Error writing record: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn operate(&self, policy: &WritePolicy, key: &Key, ops: &[Operation]) -> Result<Record> {
         let mut command = OperateCommand::new(policy, self.cluster.clone(), key, ops);
@@ -476,7 +467,7 @@ impl Client {
     /// ```rust
     /// # extern crate aerospike;
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let code = r#"
@@ -505,7 +496,6 @@ impl Client {
     ///
     /// client.register_udf(&WritePolicy::default(), code.as_bytes(),
     ///                     "example.lua", UDFLang::Lua).unwrap();
-    /// # }
     /// ```
     pub fn register_udf(
         &self,
@@ -629,7 +619,7 @@ impl Client {
     /// ```rust
     /// # extern crate aerospike;
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// match client.scan(&ScanPolicy::default(), "test", "demo", Bins::All) {
@@ -645,7 +635,6 @@ impl Client {
     ///     },
     ///     Err(err) => println!("Failed to execute scan: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn scan<T>(
         &self,
@@ -718,7 +707,7 @@ impl Client {
     /// ```rust
     /// # extern crate aerospike;
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let stmt = Statement::new("test", "test", Bins::All);
@@ -730,7 +719,6 @@ impl Client {
     ///     },
     ///     Err(err) => println!("Error fetching record: {}", err),
     /// }
-    /// # }
     /// ```
     pub fn query(&self, policy: &QueryPolicy, statement: Statement) -> Result<Arc<Recordset>> {
         statement.validate()?;
@@ -766,7 +754,7 @@ impl Client {
         let recordset = Arc::new(Recordset::new(policy.record_queue_size, 1));
         let t_recordset = recordset.clone();
         let policy = policy.to_owned();
-        let statement = Arc::new(statement).clone();
+        let statement = Arc::new(statement);
 
         self.thread_pool.spawn(move || {
             let mut command = QueryCommand::new(&policy, node, statement, t_recordset);
@@ -780,7 +768,7 @@ impl Client {
     ///
     /// This method is many orders of magnitude faster than deleting records one at a time. It
     /// requires Aerospike Server version 3.12 or later. See
-    /// https://www.aerospike.com/docs/reference/info#truncate for further info.
+    /// <https://www.aerospike.com/docs/reference/info#truncate> for further info.
     ///
     /// The `set_name` is optional; set to `""` to delete all sets in `namespace`.
     ///
@@ -824,7 +812,7 @@ impl Client {
     /// ```rust
     /// # extern crate aerospike;
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// match client.create_index(&WritePolicy::default(), "foo", "bar", "baz",
@@ -832,7 +820,6 @@ impl Client {
     ///     Err(err) => println!("Failed to create index: {}", err),
     ///     _ => {}
     /// }
-    /// # }
     /// ```
     pub fn create_index(
         &self,
@@ -902,7 +889,7 @@ impl Client {
 
     fn send_info_cmd(&self, cmd: &str, policy: &WritePolicy) -> Result<()> {
         let node = self.cluster.get_random_node()?;
-        let response = node.info(policy.base_policy.timeout, &[&cmd])?;
+        let response = node.info(policy.base_policy.timeout, &[cmd])?;
 
         if let Some(v) = response.values().next() {
             if v.to_uppercase() == "OK" {

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -13,16 +13,16 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-pub mod node_validator;
 pub mod node;
+pub mod node_validator;
 pub mod partition;
 pub mod partition_tokenizer;
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
-use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::sync::mpsc;
+use std::sync::mpsc::{Receiver, Sender, TryRecvError};
+use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 use std::vec::Vec;

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -215,11 +215,11 @@ impl Cluster {
             .map_err(|err| format!("Error during initial cluster tend: {:?}", err).into())
     }
 
-    pub fn cluster_name(&self) -> &Option<String> {
+    pub const fn cluster_name(&self) -> &Option<String> {
         &self.client_policy.cluster_name
     }
 
-    pub fn client_policy(&self) -> &ClientPolicy {
+    pub const fn client_policy(&self) -> &ClientPolicy {
         &self.client_policy
     }
 

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -18,17 +18,17 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::result::Result as StdResult;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use parking_lot::RwLock;
 
+use cluster::node_validator::NodeValidator;
+use commands::Message;
 use errors::*;
 use net::{ConnectionPool, Host, PooledConnection};
-use commands::Message;
 use policy::ClientPolicy;
-use cluster::node_validator::NodeValidator;
 
 pub const PARTITIONS: usize = 4096;
 
@@ -120,12 +120,14 @@ impl Node {
             "partition-generation",
             self.services_name(),
         ];
-        let info_map = self.info(None, &commands)
+        let info_map = self
+            .info(None, &commands)
             .chain_err(|| "Info command failed")?;
         self.validate_node(&info_map)
             .chain_err(|| "Failed to validate node")?;
         self.responded.store(true, Ordering::Relaxed);
-        let friends = self.add_friends(current_aliases, &info_map)
+        let friends = self
+            .add_friends(current_aliases, &info_map)
             .chain_err(|| "Failed to add friends")?;
         self.update_partitions(&info_map)
             .chain_err(|| "Failed to update partitions")?;
@@ -157,7 +159,8 @@ impl Node {
                 Err(ErrorKind::InvalidNode(format!(
                     "Node name has changed: '{}' => '{}'",
                     self.name, info_name
-                )).into())
+                ))
+                .into())
             }
         }
     }
@@ -174,7 +177,8 @@ impl Node {
                         "Cluster name mismatch: expected={},
                                                            got={}",
                         expected, info_name
-                    )).into())
+                    ))
+                    .into())
                 }
             },
         }

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -206,7 +206,7 @@ impl Node {
             }
 
             let host = friend_info.next().unwrap();
-            let port = try!(u16::from_str(friend_info.next().unwrap()));
+            let port = u16::from_str(friend_info.next().unwrap())?;
             let alias = match self.client_policy.ip_map {
                 Some(ref ip_map) if ip_map.contains_key(host) => {
                     Host::new(ip_map.get(host).unwrap(), port)
@@ -230,7 +230,7 @@ impl Node {
                 "Missing partition generation".to_string()
             )),
             Some(gen_string) => {
-                let gen = try!(gen_string.parse::<isize>());
+                let gen = gen_string.parse::<isize>()?;
                 self.partition_generation.store(gen, Ordering::Relaxed);
             }
         }

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -89,7 +89,7 @@ impl Node {
         &self.name
     }
 
-    pub fn client_policy(&self) -> &ClientPolicy {
+    pub const fn client_policy(&self) -> &ClientPolicy {
         &self.client_policy
     }
 

--- a/src/cluster/node_validator.rs
+++ b/src/cluster/node_validator.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::vec::Vec;
 use std::net::ToSocketAddrs;
 use std::str;
+use std::vec::Vec;
 
-use errors::*;
 use cluster::Cluster;
 use commands::Message;
+use errors::*;
 use net::{Connection, Host};
 use policy::ClientPolicy;
 
@@ -57,7 +57,7 @@ impl NodeValidator {
             .chain_err(|| "Failed to resolve host aliases")?;
 
         let mut last_err = None;
-        for ref alias in self.aliases() {
+        for alias in &self.aliases() {
             match self.validate_alias(cluster, alias) {
                 Ok(_) => return Ok(()),
                 Err(err) => {

--- a/src/cluster/partition.rs
+++ b/src/cluster/partition.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::io::Cursor;
 use std::fmt;
+use std::io::Cursor;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
-use Key;
 use cluster::node;
+use Key;
 
 // Validates a Database server node
 #[derive(Debug, Clone)]
@@ -30,8 +30,8 @@ pub struct Partition<'a> {
 impl<'a> Partition<'a> {
     pub fn new(namespace: &'a str, partition_id: usize) -> Self {
         Partition {
-            namespace: namespace,
-            partition_id: partition_id,
+            namespace,
+            partition_id,
         }
     }
 

--- a/src/cluster/partition.rs
+++ b/src/cluster/partition.rs
@@ -28,7 +28,7 @@ pub struct Partition<'a> {
 }
 
 impl<'a> Partition<'a> {
-    pub fn new(namespace: &'a str, partition_id: usize) -> Self {
+    pub const fn new(namespace: &'a str, partition_id: usize) -> Self {
         Partition {
             namespace,
             partition_id,

--- a/src/cluster/partition_tokenizer.rs
+++ b/src/cluster/partition_tokenizer.rs
@@ -39,7 +39,7 @@ pub struct PartitionTokenizer {
 
 impl PartitionTokenizer {
     pub fn new(conn: &mut Connection) -> Result<Self> {
-        let info_map = try!(Message::info(conn, &[REPLICAS_NAME]));
+        let info_map = Message::info(conn, &[REPLICAS_NAME])?;
         if let Some(buf) = info_map.get(REPLICAS_NAME) {
             return Ok(PartitionTokenizer {
                 length: info_map.len(),
@@ -58,8 +58,8 @@ impl PartitionTokenizer {
         let mut amap = nmap.read().clone();
 
         // <ns>:<base64-encoded partition map>;<ns>:<base64-encoded partition map>; ...
-        let part_str = try!(str::from_utf8(&self.buffer));
-        let mut parts = part_str.trim_right().split(|c| c == ':' || c == ';');
+        let part_str = str::from_utf8(&self.buffer)?;
+        let mut parts = part_str.trim_end().split(|c| c == ':' || c == ';');
         loop {
             match (parts.next(), parts.next()) {
                 (Some(ns), Some(part)) => {

--- a/src/cluster/partition_tokenizer.rs
+++ b/src/cluster/partition_tokenizer.rs
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str;
-use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::vec::Vec;
+use std::collections::HashMap;
+use std::str;
 use std::sync::Arc;
+use std::vec::Vec;
 
-use parking_lot::RwLock;
 use base64;
+use parking_lot::RwLock;
 
-use errors::*;
-use cluster::Node;
 use cluster::node;
+use cluster::Node;
 use commands::Message;
+use errors::*;
 use net::Connection;
 
-const REPLICAS_NAME: &'static str = "replicas-master";
+const REPLICAS_NAME: &str = "replicas-master";
 
 // Validates a Database server node
 #[derive(Debug, Clone)]

--- a/src/commands/admin_command.rs
+++ b/src/commands/admin_command.rs
@@ -55,7 +55,7 @@ const QUERY_END: usize = 50;
 pub struct AdminCommand {}
 
 impl AdminCommand {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         AdminCommand {}
     }
 

--- a/src/commands/admin_command.rs
+++ b/src/commands/admin_command.rs
@@ -18,12 +18,12 @@ use std::str;
 
 use pwhash::bcrypt::{self, BcryptSetup, BcryptVariant};
 
-use errors::*;
-use ResultCode;
 use cluster::Cluster;
+use errors::*;
 use net::Connection;
 use net::PooledConnection;
 use policy::AdminPolicy;
+use ResultCode;
 
 // Commands
 const AUTHENTICATE: u8 = 0;
@@ -105,11 +105,7 @@ impl AdminCommand {
         conn.buffer.reset_offset()?;
         AdminCommand::write_header(conn, AUTHENTICATE, 2)?;
         AdminCommand::write_field_str(conn, USER, user)?;
-        AdminCommand::write_field_bytes(
-            conn,
-            CREDENTIAL,
-            password.as_bytes()
-        )?;
+        AdminCommand::write_field_bytes(conn, CREDENTIAL, password.as_bytes())?;
         conn.buffer.size_buffer()?;
         let size = conn.buffer.data_offset;
         conn.buffer.reset_offset()?;
@@ -135,7 +131,7 @@ impl AdminCommand {
         AdminCommand::write_field_str(
             &mut conn,
             PASSWORD,
-            &AdminCommand::hash_password(password)?
+            &AdminCommand::hash_password(password)?,
         )?;
         AdminCommand::write_roles(&mut conn, roles)?;
 
@@ -170,7 +166,7 @@ impl AdminCommand {
         AdminCommand::write_field_str(
             &mut conn,
             PASSWORD,
-            &AdminCommand::hash_password(password)?
+            &AdminCommand::hash_password(password)?,
         )?;
 
         AdminCommand::execute(conn)
@@ -194,7 +190,7 @@ impl AdminCommand {
                 AdminCommand::write_field_str(
                     &mut conn,
                     OLD_PASSWORD,
-                    &AdminCommand::hash_password(password)?
+                    &AdminCommand::hash_password(password)?,
                 )?;
             }
 
@@ -204,7 +200,7 @@ impl AdminCommand {
         AdminCommand::write_field_str(
             &mut conn,
             PASSWORD,
-            &AdminCommand::hash_password(password)?
+            &AdminCommand::hash_password(password)?,
         )?;
 
         AdminCommand::execute(conn)

--- a/src/commands/batch_read_command.rs
+++ b/src/commands/batch_read_command.rs
@@ -17,17 +17,17 @@ use std::sync::Arc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use BatchRead;
-use Record;
-use ResultCode;
-use Value;
+use batch::batch_executor::SharedSlice;
 use cluster::Node;
 use commands::{self, buffer, Command, StreamCommand};
 use errors::*;
 use net::Connection;
 use policy::{BatchPolicy, Policy, PolicyLike};
 use value;
-use batch::batch_executor::SharedSlice;
+use BatchRead;
+use Record;
+use ResultCode;
+use Value;
 
 struct BatchRecord {
     batch_index: usize,
@@ -49,10 +49,10 @@ impl<'a, 'b> BatchReadCommand<'a, 'b> {
         offsets: Vec<usize>,
     ) -> Self {
         BatchReadCommand {
-            policy: policy,
-            node: node,
-            batch_reads: batch_reads,
-            offsets: offsets,
+            policy,
+            node,
+            batch_reads,
+            offsets,
         }
     }
 
@@ -144,7 +144,8 @@ impl<'a, 'b> BatchReadCommand<'a, 'b> {
             match self.parse_record(conn)? {
                 None => return Ok(false),
                 Some(batch_record) => {
-                    let batch_read = self.batch_reads
+                    let batch_read = self
+                        .batch_reads
                         .get_mut(batch_record.batch_index)
                         .expect("Invalid batch index");
                     let record = batch_record.record;
@@ -208,7 +209,7 @@ impl<'a, 'b> BatchReadCommand<'a, 'b> {
         };
         Ok(Some(BatchRecord {
             batch_index: batch_index as usize,
-            record: record,
+            record,
         }))
     }
 }

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -15,14 +15,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use errors::*;
-use Key;
-use ResultCode;
 use cluster::{Cluster, Node};
 use commands::buffer;
 use commands::{Command, SingleCommand};
+use errors::*;
 use net::Connection;
 use policy::WritePolicy;
+use Key;
+use ResultCode;
 
 pub struct DeleteCommand<'a> {
     single_command: SingleCommand<'a>,
@@ -34,7 +34,7 @@ impl<'a> DeleteCommand<'a> {
     pub fn new(policy: &'a WritePolicy, cluster: Arc<Cluster>, key: &'a Key) -> Self {
         DeleteCommand {
             single_command: SingleCommand::new(cluster, key),
-            policy: policy,
+            policy,
             existed: false,
         }
     }
@@ -73,7 +73,7 @@ impl<'a> Command for DeleteCommand<'a> {
 
         // A number of these are commented out because we just don't care enough to read
         // that section of the header. If we do care, uncomment and check!
-        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))? & 0xFF);
+        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))?);
 
         if result_code != ResultCode::Ok && result_code != ResultCode::KeyNotFoundError {
             bail!(ErrorKind::ServerError(result_code));

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -69,11 +69,11 @@ impl<'a> Command for DeleteCommand<'a> {
             return Err(err);
         }
 
-        try!(conn.buffer.reset_offset());
+        conn.buffer.reset_offset()?;
 
         // A number of these are commented out because we just don't care enough to read
         // that section of the header. If we do care, uncomment and check!
-        let result_code = ResultCode::from(try!(conn.buffer.read_u8(Some(13))) & 0xFF);
+        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))? & 0xFF);
 
         if result_code != ResultCode::Ok && result_code != ResultCode::KeyNotFoundError {
             bail!(ErrorKind::ServerError(result_code));

--- a/src/commands/execute_udf_command.rs
+++ b/src/commands/execute_udf_command.rs
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str;
 use std::sync::Arc;
 use std::time::Duration;
-use std::str;
 
+use cluster::{Cluster, Node};
+use commands::{Command, ReadCommand, SingleCommand};
 use errors::*;
+use net::Connection;
+use policy::WritePolicy;
 use Bins;
 use Key;
 use Value;
-use cluster::{Cluster, Node};
-use commands::{Command, ReadCommand, SingleCommand};
-use net::Connection;
-use policy::WritePolicy;
 
 pub struct ExecuteUDFCommand<'a> {
     pub read_command: ReadCommand<'a>,
@@ -44,10 +44,10 @@ impl<'a> ExecuteUDFCommand<'a> {
     ) -> Self {
         ExecuteUDFCommand {
             read_command: ReadCommand::new(&policy.base_policy, cluster, key, Bins::All),
-            policy: policy,
-            package_name: package_name,
-            function_name: function_name,
-            args: args,
+            policy,
+            package_name,
+            function_name,
+            args,
         }
     }
 

--- a/src/commands/exists_command.rs
+++ b/src/commands/exists_command.rs
@@ -69,11 +69,11 @@ impl<'a> Command for ExistsCommand<'a> {
             return Err(err);
         }
 
-        try!(conn.buffer.reset_offset());
+        conn.buffer.reset_offset()?;
 
         // A number of these are commented out because we just don't care enough to read
         // that section of the header. If we do care, uncomment and check!
-        let result_code = ResultCode::from(try!(conn.buffer.read_u8(Some(13))) & 0xFF);
+        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))? & 0xFF);
 
         if result_code != ResultCode::Ok && result_code != ResultCode::KeyNotFoundError {
             bail!(ErrorKind::ServerError(result_code));

--- a/src/commands/exists_command.rs
+++ b/src/commands/exists_command.rs
@@ -15,14 +15,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use errors::*;
-use Key;
-use ResultCode;
 use cluster::{Cluster, Node};
 use commands::buffer;
 use commands::{Command, SingleCommand};
+use errors::*;
 use net::Connection;
 use policy::WritePolicy;
+use Key;
+use ResultCode;
 
 pub struct ExistsCommand<'a> {
     single_command: SingleCommand<'a>,
@@ -34,7 +34,7 @@ impl<'a> ExistsCommand<'a> {
     pub fn new(policy: &'a WritePolicy, cluster: Arc<Cluster>, key: &'a Key) -> Self {
         ExistsCommand {
             single_command: SingleCommand::new(cluster, key),
-            policy: policy,
+            policy,
             exists: false,
         }
     }
@@ -73,7 +73,7 @@ impl<'a> Command for ExistsCommand<'a> {
 
         // A number of these are commented out because we just don't care enough to read
         // that section of the header. If we do care, uncomment and check!
-        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))? & 0xFF);
+        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))?);
 
         if result_code != ResultCode::Ok && result_code != ResultCode::KeyNotFoundError {
             bail!(ErrorKind::ServerError(result_code));

--- a/src/commands/info_command.rs
+++ b/src/commands/info_command.rs
@@ -29,10 +29,10 @@ pub struct Message {
 impl Message {
     pub fn info(conn: &mut Connection, commands: &[&str]) -> Result<HashMap<String, String>> {
         let cmd = commands.join("\n") + "\n";
-        let mut msg = try!(Message::new(&cmd.into_bytes()));
+        let mut msg = Message::new(&cmd.into_bytes())?;
 
-        try!(msg.send(conn));
-        Ok(try!(msg.parse_response()))
+        msg.send(conn)?;
+        Ok(msg.parse_response()?)
     }
 
     fn new(data: &[u8]) -> Result<Self> {
@@ -56,23 +56,23 @@ impl Message {
     }
 
     fn send(&mut self, conn: &mut Connection) -> Result<()> {
-        try!(conn.write(&self.buf));
+        conn.write(&self.buf)?;
 
         // read the header
-        try!(conn.read(self.buf[..8].as_mut()));
+        conn.read(self.buf[..8].as_mut())?;
 
         // figure our message size and grow the buffer if necessary
         let data_len = self.data_len() as usize;
         self.buf.resize(data_len, 0);
 
         // read the message content
-        try!(conn.read(self.buf.as_mut()));
+        conn.read(self.buf.as_mut())?;
 
         Ok(())
     }
 
     fn parse_response(&self) -> Result<HashMap<String, String>> {
-        let response = try!(str::from_utf8(&self.buf));
+        let response = str::from_utf8(&self.buf)?;
         let response = response.trim_matches('\n');
 
         debug!("response from server for info command: {:?}", response);

--- a/src/commands/info_command.rs
+++ b/src/commands/info_command.rs
@@ -13,10 +13,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::io::{Cursor, Write};
-use std::collections::HashMap;
-use std::str;
 use byteorder::{NetworkEndian, ReadBytesExt, WriteBytesExt};
+use std::collections::HashMap;
+use std::io::{Cursor, Write};
+use std::str;
 
 use errors::*;
 use net::Connection;
@@ -45,7 +45,7 @@ impl Message {
         buf.write_all(&len[2..8])?;
         buf.write_all(data)?;
 
-        Ok(Message { buf: buf })
+        Ok(Message { buf })
     }
 
     fn data_len(&self) -> u64 {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -12,22 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod info_command;
-pub mod single_command;
-pub mod read_command;
-pub mod write_command;
-pub mod delete_command;
-pub mod touch_command;
-pub mod exists_command;
-pub mod operate_command;
-pub mod execute_udf_command;
-pub mod stream_command;
-pub mod scan_command;
-pub mod query_command;
-pub mod batch_read_command;
 pub mod admin_command;
+pub mod batch_read_command;
 pub mod buffer;
+pub mod delete_command;
+pub mod execute_udf_command;
+pub mod exists_command;
+pub mod info_command;
+pub mod operate_command;
 pub mod particle_type;
+pub mod query_command;
+pub mod read_command;
+pub mod scan_command;
+pub mod single_command;
+pub mod stream_command;
+pub mod touch_command;
+pub mod write_command;
 
 mod field_type;
 
@@ -40,6 +40,7 @@ pub use self::execute_udf_command::ExecuteUDFCommand;
 pub use self::exists_command::ExistsCommand;
 pub use self::info_command::Message;
 pub use self::operate_command::OperateCommand;
+pub use self::particle_type::ParticleType;
 pub use self::query_command::QueryCommand;
 pub use self::read_command::ReadCommand;
 pub use self::scan_command::ScanCommand;
@@ -47,11 +48,10 @@ pub use self::single_command::SingleCommand;
 pub use self::stream_command::StreamCommand;
 pub use self::touch_command::TouchCommand;
 pub use self::write_command::WriteCommand;
-pub use self::particle_type::ParticleType;
 
+use cluster::Node;
 use errors::*;
 use net::Connection;
-use cluster::Node;
 use ResultCode;
 
 // Command interface describes all commands available

--- a/src/commands/operate_command.rs
+++ b/src/commands/operate_command.rs
@@ -15,14 +15,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use errors::*;
-use Bins;
-use Key;
 use cluster::{Cluster, Node};
 use commands::{Command, ReadCommand, SingleCommand};
+use errors::*;
 use net::Connection;
 use operations::Operation;
 use policy::WritePolicy;
+use Bins;
+use Key;
 
 pub struct OperateCommand<'a> {
     pub read_command: ReadCommand<'a>,
@@ -39,8 +39,8 @@ impl<'a> OperateCommand<'a> {
     ) -> Self {
         OperateCommand {
             read_command: ReadCommand::new(&policy.base_policy, cluster, key, Bins::All),
-            policy: policy,
-            operations: operations,
+            policy,
+            operations,
         }
     }
 

--- a/src/commands/query_command.rs
+++ b/src/commands/query_command.rs
@@ -15,13 +15,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use errors::*;
-use Recordset;
-use Statement;
 use cluster::Node;
 use commands::{Command, SingleCommand, StreamCommand};
+use errors::*;
 use net::Connection;
 use policy::QueryPolicy;
+use Recordset;
+use Statement;
 
 pub struct QueryCommand<'a> {
     stream_command: StreamCommand,
@@ -38,8 +38,8 @@ impl<'a> QueryCommand<'a> {
     ) -> Self {
         QueryCommand {
             stream_command: StreamCommand::new(node, recordset),
-            policy: policy,
-            statement: statement,
+            policy,
+            statement,
         }
     }
 

--- a/src/commands/read_command.rs
+++ b/src/commands/read_command.rs
@@ -69,12 +69,12 @@ impl<'a> ReadCommand<'a> {
         }
 
         for _ in 0..op_count {
-            let op_size = try!(conn.buffer.read_u32(None)) as usize;
-            try!(conn.buffer.skip(1));
-            let particle_type = try!(conn.buffer.read_u8(None));
-            try!(conn.buffer.skip(1));
-            let name_size = try!(conn.buffer.read_u8(None)) as usize;
-            let name: String = try!(conn.buffer.read_str(name_size));
+            let op_size = conn.buffer.read_u32(None)? as usize;
+            conn.buffer.skip(1)?;
+            let particle_type = conn.buffer.read_u8(None)?;
+            conn.buffer.skip(1)?;
+            let name_size = conn.buffer.read_u8(None)? as usize;
+            let name: String = conn.buffer.read_str(name_size)?;
 
             let particle_bytes_size = op_size - (4 + name_size);
             let value = bytes_to_particle(particle_type, &mut conn.buffer, particle_bytes_size)?;

--- a/src/commands/read_command.rs
+++ b/src/commands/read_command.rs
@@ -132,7 +132,7 @@ impl<'a> Command for ReadCommand<'a> {
         let expiration = conn.buffer.read_u32(Some(18))?;
         let field_count = conn.buffer.read_u16(Some(26))? as usize; // almost certainly 0
         let op_count = conn.buffer.read_u16(Some(28))? as usize;
-        let receive_size = ((sz & 0xFFFF_FFFF_FFFF) - header_length as u64) as usize;
+        let receive_size = ((sz & 0xFFFF_FFFF_FFFF) - u64::from(header_length)) as usize;
 
         // Read remaining message bytes
         if receive_size > 0 {
@@ -159,7 +159,7 @@ impl<'a> Command for ReadCommand<'a> {
                 let reason = record
                     .bins
                     .get("FAILURE")
-                    .map_or(String::from("UDF Error"), |v| v.to_string());
+                    .map_or(String::from("UDF Error"), ToString::to_string);
                 Err(ErrorKind::UdfBadResponse(reason).into())
             }
             rc => Err(ErrorKind::ServerError(rc).into()),

--- a/src/commands/scan_command.rs
+++ b/src/commands/scan_command.rs
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::str;
 use std::sync::Arc;
 use std::time::Duration;
-use std::str;
 
-use errors::*;
-use Bins;
-use Recordset;
 use cluster::Node;
 use commands::{Command, SingleCommand, StreamCommand};
+use errors::*;
 use net::Connection;
 use policy::ScanPolicy;
+use Bins;
+use Recordset;
 
 pub struct ScanCommand<'a> {
     stream_command: StreamCommand,
@@ -43,10 +43,10 @@ impl<'a> ScanCommand<'a> {
     ) -> Self {
         ScanCommand {
             stream_command: StreamCommand::new(node, recordset),
-            policy: policy,
-            namespace: namespace,
-            set_name: set_name,
-            bins: bins,
+            policy,
+            namespace,
+            set_name,
+            bins,
         }
     }
 

--- a/src/commands/single_command.rs
+++ b/src/commands/single_command.rs
@@ -63,7 +63,7 @@ impl<'a> SingleCommand<'a> {
     // EXECUTE
     //
 
-    pub fn execute(policy: &Policy, cmd: &'a mut Command) -> Result<()> {
+    pub fn execute(policy: &dyn Policy, cmd: &'a mut dyn Command) -> Result<()> {
         let mut iterations = 0;
 
         // set timeout outside the loop

--- a/src/commands/single_command.rs
+++ b/src/commands/single_command.rs
@@ -34,7 +34,7 @@ impl<'a> SingleCommand<'a> {
     pub fn new(cluster: Arc<Cluster>, key: &'a Key) -> Self {
         let partition = Partition::new_by_key(key);
         SingleCommand {
-            cluster: cluster.clone(),
+            cluster,
             key,
             partition,
         }
@@ -48,7 +48,7 @@ impl<'a> SingleCommand<'a> {
         // There should not be any more bytes.
         // Empty the socket to be safe.
         let sz = conn.buffer.read_i64(None)?;
-        let header_length = conn.buffer.read_u8(None)? as i64;
+        let header_length = i64::from(conn.buffer.read_u8(None)?);
         let receive_size = ((sz & 0xFFFF_FFFF_FFFF) - header_length) as usize;
 
         // Read remaining message bytes.

--- a/src/commands/single_command.rs
+++ b/src/commands/single_command.rs
@@ -47,14 +47,14 @@ impl<'a> SingleCommand<'a> {
     pub fn empty_socket(conn: &mut Connection) -> Result<()> {
         // There should not be any more bytes.
         // Empty the socket to be safe.
-        let sz = try!(conn.buffer.read_i64(None));
-        let header_length = try!(conn.buffer.read_u8(None)) as i64;
+        let sz = conn.buffer.read_i64(None)?;
+        let header_length = conn.buffer.read_u8(None)? as i64;
         let receive_size = ((sz & 0xFFFFFFFFFFFF) - header_length) as usize;
 
         // Read remaining message bytes.
         if receive_size > 0 {
-            try!(conn.buffer.resize_buffer(receive_size));
-            try!(conn.read_buffer(receive_size));
+            conn.buffer.resize_buffer(receive_size)?;
+            conn.read_buffer(receive_size)?;
         }
 
         Ok(())

--- a/src/commands/single_command.rs
+++ b/src/commands/single_command.rs
@@ -16,13 +16,13 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
 
-use errors::*;
-use Key;
 use cluster::partition::Partition;
 use cluster::{Cluster, Node};
 use commands::{self, Command};
+use errors::*;
 use net::Connection;
 use policy::Policy;
+use Key;
 
 pub struct SingleCommand<'a> {
     cluster: Arc<Cluster>,
@@ -35,8 +35,8 @@ impl<'a> SingleCommand<'a> {
         let partition = Partition::new_by_key(key);
         SingleCommand {
             cluster: cluster.clone(),
-            key: key,
-            partition: partition,
+            key,
+            partition,
         }
     }
 
@@ -49,7 +49,7 @@ impl<'a> SingleCommand<'a> {
         // Empty the socket to be safe.
         let sz = conn.buffer.read_i64(None)?;
         let header_length = conn.buffer.read_u8(None)? as i64;
-        let receive_size = ((sz & 0xFFFFFFFFFFFF) - header_length) as usize;
+        let receive_size = ((sz & 0xFFFF_FFFF_FFFF) - header_length) as usize;
 
         // Read remaining message bytes.
         if receive_size > 0 {

--- a/src/commands/touch_command.rs
+++ b/src/commands/touch_command.rs
@@ -67,9 +67,9 @@ impl<'a> Command for TouchCommand<'a> {
             return Err(err);
         }
 
-        try!(conn.buffer.reset_offset());
+        conn.buffer.reset_offset()?;
 
-        let result_code = ResultCode::from(try!(conn.buffer.read_u8(Some(13))) & 0xFF);
+        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))? & 0xFF);
         if result_code != ResultCode::Ok {
             bail!(ErrorKind::ServerError(result_code));
         }

--- a/src/commands/touch_command.rs
+++ b/src/commands/touch_command.rs
@@ -15,14 +15,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use errors::*;
-use Key;
-use ResultCode;
 use cluster::{Cluster, Node};
 use commands::buffer;
 use commands::{Command, SingleCommand};
+use errors::*;
 use net::Connection;
 use policy::WritePolicy;
+use Key;
+use ResultCode;
 
 pub struct TouchCommand<'a> {
     single_command: SingleCommand<'a>,
@@ -33,7 +33,7 @@ impl<'a> TouchCommand<'a> {
     pub fn new(policy: &'a WritePolicy, cluster: Arc<Cluster>, key: &'a Key) -> Self {
         TouchCommand {
             single_command: SingleCommand::new(cluster, key),
-            policy: policy,
+            policy,
         }
     }
 
@@ -69,7 +69,7 @@ impl<'a> Command for TouchCommand<'a> {
 
         conn.buffer.reset_offset()?;
 
-        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))? & 0xFF);
+        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))?);
         if result_code != ResultCode::Ok {
             bail!(ErrorKind::ServerError(result_code));
         }

--- a/src/commands/write_command.rs
+++ b/src/commands/write_command.rs
@@ -84,9 +84,9 @@ impl<'a, 'b, A: AsRef<Bin<'b>>> Command for WriteCommand<'a, A> {
             return Err(err);
         }
 
-        try!(conn.buffer.reset_offset());
+        conn.buffer.reset_offset()?;
 
-        let result_code = ResultCode::from(try!(conn.buffer.read_u8(Some(13))) & 0xFF);
+        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))? & 0xFF);
         if result_code != ResultCode::Ok {
             bail!(ErrorKind::ServerError(result_code));
         }

--- a/src/commands/write_command.rs
+++ b/src/commands/write_command.rs
@@ -15,16 +15,16 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use errors::*;
-use Bin;
-use Key;
-use ResultCode;
 use cluster::{Cluster, Node};
 use commands::buffer;
 use commands::{Command, SingleCommand};
+use errors::*;
 use net::Connection;
 use operations::OperationType;
 use policy::WritePolicy;
+use Bin;
+use Key;
+use ResultCode;
 
 pub struct WriteCommand<'a, A: 'a> {
     single_command: SingleCommand<'a>,
@@ -43,9 +43,9 @@ impl<'a, 'b, A: AsRef<Bin<'b>>> WriteCommand<'a, A> {
     ) -> Self {
         WriteCommand {
             single_command: SingleCommand::new(cluster, key),
-            bins: bins,
-            policy: policy,
-            operation: operation,
+            bins,
+            policy,
+            operation,
         }
     }
 
@@ -86,7 +86,7 @@ impl<'a, 'b, A: AsRef<Bin<'b>>> Command for WriteCommand<'a, A> {
 
         conn.buffer.reset_offset()?;
 
-        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))? & 0xFF);
+        let result_code = ResultCode::from(conn.buffer.read_u8(Some(13))?);
         if result_code != ResultCode::Ok {
             bail!(ErrorKind::ServerError(result_code));
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,31 +22,29 @@
 //! ```rust
 //! use aerospike::*;
 //!
-//! fn main() {
-//!     let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
-//!     let policy = ClientPolicy::default();
-//!     let client = Client::new(&policy, &hosts).expect("Failed to connect to cluster");
-//!     let key = as_key!("test", "test", "someKey");
-//!     match client.get(&ReadPolicy::default(), &key, Bins::None) {
-//!         Ok(record) => {
-//!             match record.time_to_live() {
-//!                 None => println!("record never expires"),
-//!                 Some(duration) => println!("ttl: {} secs", duration.as_secs()),
-//!             }
-//!         },
-//!         Err(Error(ErrorKind::ServerError(ResultCode::KeyNotFoundError), _)) => {
-//!             println!("No such record: {}", key);
-//!         },
-//!         Err(err) => {
-//!             println!("Error fetching record: {}", err);
-//!             for err in err.iter().skip(1) {
-//!                 println!("Caused by: {}", err);
-//!             }
-//!             // The backtrace is not always generated. Try to run this example
-//!             // with `RUST_BACKTRACE=1`.
-//!             if let Some(backtrace) = err.backtrace() {
-//!                 println!("Backtrace: {:?}", backtrace);
-//!             }
+//! let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+//! let policy = ClientPolicy::default();
+//! let client = Client::new(&policy, &hosts).expect("Failed to connect to cluster");
+//! let key = as_key!("test", "test", "someKey");
+//! match client.get(&ReadPolicy::default(), &key, Bins::None) {
+//!     Ok(record) => {
+//!         match record.time_to_live() {
+//!             None => println!("record never expires"),
+//!             Some(duration) => println!("ttl: {} secs", duration.as_secs()),
+//!         }
+//!     },
+//!     Err(Error(ErrorKind::ServerError(ResultCode::KeyNotFoundError), _)) => {
+//!         println!("No such record: {}", key);
+//!     },
+//!     Err(err) => {
+//!         println!("Error fetching record: {}", err);
+//!         for err in err.iter().skip(1) {
+//!             println!("Caused by: {}", err);
+//!         }
+//!         // The backtrace is not always generated. Try to run this example
+//!         // with `RUST_BACKTRACE=1`.
+//!         if let Some(backtrace) = err.backtrace() {
+//!             println!("Backtrace: {:?}", backtrace);
 //!         }
 //!     }
 //! }

--- a/src/key.rs
+++ b/src/key.rs
@@ -115,10 +115,13 @@ mod tests {
         ($x:expr) => (hex::encode(as_key!("namespace", "set", $x).digest))
     }
     macro_rules! str_repeat {
-        ($c:expr, $n:expr) => (str::from_utf8(&vec![$c as u8; $n]).unwrap())
+        ($c:expr, $n:expr) => {
+            str::from_utf8(&[$c as u8; $n]).unwrap()
+        };
     }
 
     #[test]
+    #[allow(clippy::cognitive_complexity)]
     fn int_keys() {
         assert_eq!(digest!(0), "93d943aae37b017ad7e011b0c1d2e2143c2fb37d");
         assert_eq!(digest!(-1), "22116d253745e29fc63fdf760b6e26f7e197e01d");
@@ -211,7 +214,7 @@ mod tests {
             "b42e64afbfccb05912a609179228d9249ea1c1a0"
         );
         assert_eq!(
-            digest!(str_repeat!('+', 100000)),
+            digest!(str_repeat!('+', 100_000)),
             "0a3e888c20bb8958537ddd4ba835e4070bd51740"
         );
 
@@ -233,27 +236,27 @@ mod tests {
             "327e2877b8815c7aeede0d5a8620d4ef8df4a4b4"
         );
         assert_eq!(
-            digest!(vec!['s' as u8; 1]),
+            digest!(vec![b's'; 1]),
             "ca2d96dc9a184d15a7fa2927565e844e9254e001"
         );
         assert_eq!(
-            digest!(vec!['a' as u8; 10]),
+            digest!(vec![b'a'; 10]),
             "d10982327b2b04c7360579f252e164a75f83cd99"
         );
         assert_eq!(
-            digest!(vec!['m' as u8; 100]),
+            digest!(vec![b'm'; 100]),
             "475786aa4ee664532a7d1ea69cb02e4695fcdeed"
         );
         assert_eq!(
-            digest!(vec!['t' as u8; 1000]),
+            digest!(vec![b't'; 1000]),
             "5a32b507518a49bf47fdaa3deca53803f5b2e8c3"
         );
         assert_eq!(
-            digest!(vec!['-' as u8; 10000]),
+            digest!(vec![b'-'; 10000]),
             "ed65c63f7a1f8c6697eb3894b6409a95461fd982"
         );
         assert_eq!(
-            digest!(vec!['+' as u8; 100000]),
+            digest!(vec![b'+'; 100_000]),
             "fe19770c371774ba1a1532438d4851b8a773a9e6"
         );
     }
@@ -261,7 +264,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Data type is not supported as Key value.")]
     fn unsupported_float_key() {
-        as_key!("namespace", "set", 3.1415);
+        as_key!("namespace", "set", 4.1415);
     }
 
     #[test]

--- a/src/key.rs
+++ b/src/key.rs
@@ -58,7 +58,7 @@ impl Key {
             user_key: Some(key),
         };
 
-        try!(key.compute_digest());
+        key.compute_digest()?;
         Ok(key)
     }
 
@@ -67,7 +67,7 @@ impl Key {
         hash.input(self.set_name.as_bytes());
         if let Some(ref user_key) = self.user_key {
             hash.input(&[user_key.particle_type() as u8]);
-            try!(user_key.write_key_bytes(&mut hash));
+            user_key.write_key_bytes(&mut hash)?;
         } else {
             unreachable!()
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -19,8 +19,8 @@ use std::result::Result as StdResult;
 use errors::*;
 use Value;
 
-use ripemd160::Ripemd160;
 use ripemd160::digest::Digest;
+use ripemd160::Ripemd160;
 
 /// Unique record identifier. Records can be identified using a specified namespace, an optional
 /// set name and a user defined key which must be uique within a set. Records can also be
@@ -112,7 +112,9 @@ mod tests {
     use std::str;
 
     macro_rules! digest {
-        ($x:expr) => (hex::encode(as_key!("namespace", "set", $x).digest))
+        ($x:expr) => {
+            hex::encode(as_key!("namespace", "set", $x).digest)
+        };
     }
     macro_rules! str_repeat {
         ($c:expr, $n:expr) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 #![warn(missing_docs)]
 #![doc(test(attr(allow(unused_variables), allow(unused_assignments), allow(unused_mut),
                  allow(unused_attributes), allow(dead_code), deny(warnings))))]
+// TODO: Remove and fix all warnings
+#![allow(bare_trait_objects, ellipsis_inclusive_range_patterns, clippy::all)]
 
 //! A pure-rust client for the Aerospike NoSQL database.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,14 @@
 // the License.
 
 #![warn(missing_docs)]
-#![doc(test(attr(allow(unused_variables), allow(unused_assignments), allow(unused_mut),
-                 allow(unused_attributes), allow(dead_code), deny(warnings))))]
-// TODO: Remove and fix all warnings
-#![allow(clippy::all)]
+#![doc(test(attr(
+    allow(unused_variables),
+    allow(unused_assignments),
+    allow(unused_mut),
+    allow(unused_attributes),
+    allow(dead_code),
+    deny(warnings)
+)))]
 
 //! A pure-rust client for the Aerospike NoSQL database.
 //!
@@ -134,9 +138,11 @@ pub use errors::{Error, ErrorKind, Result};
 pub use key::Key;
 pub use net::Host;
 pub use operations::{MapPolicy, MapReturnType, MapWriteMode};
-pub use policy::{BatchPolicy, ClientPolicy, CommitLevel, Concurrency, ConsistencyLevel,
-                 Expiration, GenerationPolicy, Policy, Priority, QueryPolicy, ReadPolicy,
-                 RecordExistsAction, ScanPolicy, WritePolicy};
+pub use policy::{
+    BatchPolicy, ClientPolicy, CommitLevel, Concurrency, ConsistencyLevel, Expiration,
+    GenerationPolicy, Policy, Priority, QueryPolicy, ReadPolicy, RecordExistsAction, ScanPolicy,
+    WritePolicy,
+};
 pub use query::{CollectionIndexType, IndexType, Recordset, Statement, UDFLang};
 pub use record::Record;
 pub use result_code::ResultCode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,24 @@
     allow(dead_code),
     deny(warnings)
 )))]
+#![warn(clippy::all, clippy::pedantic, clippy::nursery)]
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::checked_conversions,
+    clippy::copy_iterator,
+    clippy::fallible_impl_from,
+    clippy::module_name_repetitions,
+    clippy::must_use_candidate,
+    clippy::needless_pass_by_value,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::unknown_clippy_lints,
+    clippy::unseparated_literal_suffix,
+    clippy::unused_self,
+    clippy::use_self
+)]
 
 //! A pure-rust client for the Aerospike NoSQL database.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![doc(test(attr(allow(unused_variables), allow(unused_assignments), allow(unused_mut),
                  allow(unused_attributes), allow(dead_code), deny(warnings))))]
 // TODO: Remove and fix all warnings
-#![allow(bare_trait_objects, clippy::all)]
+#![allow(clippy::all)]
 
 //! A pure-rust client for the Aerospike NoSQL database.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 #![doc(test(attr(allow(unused_variables), allow(unused_assignments), allow(unused_mut),
                  allow(unused_attributes), allow(dead_code), deny(warnings))))]
 // TODO: Remove and fix all warnings
-#![allow(bare_trait_objects, ellipsis_inclusive_range_patterns, clippy::all)]
+#![allow(bare_trait_objects, clippy::all)]
 
 //! A pure-rust client for the Aerospike NoSQL database.
 //!

--- a/src/msgpack/decoder.rs
+++ b/src/msgpack/decoder.rs
@@ -122,15 +122,15 @@ fn unpack_value(buf: &mut Buffer) -> Result<Value> {
         0xc0 => Ok(Value::Nil),
         0xc2 => Ok(Value::from(false)),
         0xc3 => Ok(Value::from(true)),
-        0xc4 => {
+        0xc4 | 0xd9 => {
             let count = buf.read_u8(None)?;
             Ok(unpack_blob(buf, count as usize)?)
         }
-        0xc5 => {
+        0xc5 | 0xda => {
             let count = buf.read_u16(None)?;
             Ok(unpack_blob(buf, count as usize)?)
         }
-        0xc6 => {
+        0xc6 | 0xdb => {
             let count = buf.read_u32(None)?;
             Ok(unpack_blob(buf, count as usize)?)
         }
@@ -192,18 +192,6 @@ fn unpack_value(buf: &mut Buffer) -> Result<Value> {
             buf.skip_bytes(count);
             Ok(Value::Nil)
         }
-        0xd9 => {
-            let count = buf.read_u8(None)?;
-            Ok(unpack_blob(buf, count as usize)?)
-        }
-        0xda => {
-            let count = buf.read_u16(None)?;
-            Ok(unpack_blob(buf, count as usize)?)
-        }
-        0xdb => {
-            let count = buf.read_u32(None)?;
-            Ok(unpack_blob(buf, count as usize)?)
-        }
         0xdc => {
             let count = buf.read_u16(None)?;
             unpack_list(buf, count as usize)
@@ -221,7 +209,7 @@ fn unpack_value(buf: &mut Buffer) -> Result<Value> {
             unpack_map(buf, count as usize)
         }
         0xe0..=0xff => {
-            let value = obj_type as i16 - 0xe0 - 32;
+            let value = i16::from(obj_type) - 0xe0 - 32;
             Ok(Value::from(value))
         }
         _ => Err(

--- a/src/msgpack/decoder.rs
+++ b/src/msgpack/decoder.rs
@@ -16,9 +16,9 @@
 use std::collections::HashMap;
 use std::vec::Vec;
 
-use errors::*;
-use commands::ParticleType;
 use commands::buffer::Buffer;
+use commands::ParticleType;
+use errors::*;
 use value::*;
 
 pub fn unpack_value_list(buf: &mut Buffer) -> Result<Value> {
@@ -26,7 +26,7 @@ pub fn unpack_value_list(buf: &mut Buffer) -> Result<Value> {
         return Ok(Value::List(vec![]));
     }
 
-    let ltype: u8 = buf.read_u8(None)? & 0xff;
+    let ltype: u8 = buf.read_u8(None)?;
 
     let count: usize = match ltype {
         0x90..=0x9f => (ltype & 0x0f) as usize,
@@ -43,7 +43,7 @@ pub fn unpack_value_map(buf: &mut Buffer) -> Result<Value> {
         return Ok(Value::from(HashMap::with_capacity(0)));
     }
 
-    let ltype: u8 = buf.read_u8(None)? & 0xff;
+    let ltype: u8 = buf.read_u8(None)?;
 
     let count: usize = match ltype {
         0x80..=0x8f => (ltype & 0x0f) as usize,
@@ -124,15 +124,15 @@ fn unpack_value(buf: &mut Buffer) -> Result<Value> {
         0xc3 => Ok(Value::from(true)),
         0xc4 => {
             let count = buf.read_u8(None)?;
-            return Ok(Value::from(unpack_blob(buf, count as usize)?));
+            Ok(unpack_blob(buf, count as usize)?)
         }
         0xc5 => {
             let count = buf.read_u16(None)?;
-            return Ok(Value::from(unpack_blob(buf, count as usize)?));
+            Ok(unpack_blob(buf, count as usize)?)
         }
         0xc6 => {
             let count = buf.read_u32(None)?;
-            return Ok(Value::from(unpack_blob(buf, count as usize)?));
+            Ok(unpack_blob(buf, count as usize)?)
         }
         0xc7 => {
             warn!("Skipping over type extension with 8 bit header and bytes");
@@ -194,15 +194,15 @@ fn unpack_value(buf: &mut Buffer) -> Result<Value> {
         }
         0xd9 => {
             let count = buf.read_u8(None)?;
-            Ok(Value::from(unpack_blob(buf, count as usize)?))
+            Ok(unpack_blob(buf, count as usize)?)
         }
         0xda => {
             let count = buf.read_u16(None)?;
-            Ok(Value::from(unpack_blob(buf, count as usize)?))
+            Ok(unpack_blob(buf, count as usize)?)
         }
         0xdb => {
             let count = buf.read_u32(None)?;
-            Ok(Value::from(unpack_blob(buf, count as usize)?))
+            Ok(unpack_blob(buf, count as usize)?)
         }
         0xdc => {
             let count = buf.read_u16(None)?;

--- a/src/msgpack/decoder.rs
+++ b/src/msgpack/decoder.rs
@@ -29,7 +29,7 @@ pub fn unpack_value_list(buf: &mut Buffer) -> Result<Value> {
     let ltype: u8 = buf.read_u8(None)? & 0xff;
 
     let count: usize = match ltype {
-        0x90...0x9f => (ltype & 0x0f) as usize,
+        0x90..=0x9f => (ltype & 0x0f) as usize,
         0xdc => buf.read_u16(None)? as usize,
         0xdd => buf.read_u32(None)? as usize,
         _ => unreachable!(),
@@ -46,7 +46,7 @@ pub fn unpack_value_map(buf: &mut Buffer) -> Result<Value> {
     let ltype: u8 = buf.read_u8(None)? & 0xff;
 
     let count: usize = match ltype {
-        0x80...0x8f => (ltype & 0x0f) as usize,
+        0x80..=0x8f => (ltype & 0x0f) as usize,
         0xde => buf.read_u16(None)? as usize,
         0xdf => buf.read_u32(None)? as usize,
         _ => unreachable!(),
@@ -115,10 +115,10 @@ fn unpack_value(buf: &mut Buffer) -> Result<Value> {
     let obj_type = buf.read_u8(None)?;
 
     match obj_type {
-        0x00...0x7f => Ok(Value::from(obj_type)),
-        0x80...0x8f => unpack_map(buf, (obj_type & 0x0f) as usize),
-        0x90...0x9f => unpack_list(buf, (obj_type & 0x0f) as usize),
-        0xa0...0xbf => unpack_blob(buf, (obj_type & 0x1f) as usize),
+        0x00..=0x7f => Ok(Value::from(obj_type)),
+        0x80..=0x8f => unpack_map(buf, (obj_type & 0x0f) as usize),
+        0x90..=0x9f => unpack_list(buf, (obj_type & 0x0f) as usize),
+        0xa0..=0xbf => unpack_blob(buf, (obj_type & 0x1f) as usize),
         0xc0 => Ok(Value::Nil),
         0xc2 => Ok(Value::from(false)),
         0xc3 => Ok(Value::from(true)),
@@ -220,7 +220,7 @@ fn unpack_value(buf: &mut Buffer) -> Result<Value> {
             let count = buf.read_u32(None)?;
             unpack_map(buf, count as usize)
         }
-        0xe0...0xff => {
+        0xe0..=0xff => {
             let value = obj_type as i16 - 0xe0 - 32;
             Ok(Value::from(value))
         }

--- a/src/msgpack/encoder.rs
+++ b/src/msgpack/encoder.rs
@@ -213,27 +213,31 @@ fn pack_geo_json(buf: &mut Option<&mut Buffer>, val: &str) -> Result<usize> {
 fn pack_integer(buf: &mut Option<&mut Buffer>, val: i64) -> Result<usize> {
     match val {
         val if val >= 0 && val < 2 ^ 7 => pack_half_byte(buf, val as u8),
-        val if val >= 2 ^ 7 && val < i8::MAX as i64 => pack_byte(buf, MSGPACK_MARKER_I8, val as u8),
-        val if val >= i8::MAX as i64 && val < i16::MAX as i64 => {
+        val if val >= 2 ^ 7 && val < i64::from(i8::max_value()) => {
+            pack_byte(buf, MSGPACK_MARKER_I8, val as u8)
+        }
+        val if val >= i64::from(i8::max_value()) && val < i64::from(i16::max_value()) => {
             pack_i16(buf, MSGPACK_MARKER_I16, val as i16)
         }
-        val if val >= i16::MAX as i64 && val < i32::MAX as i64 => {
+        val if val >= i64::from(i16::max_value()) && val < i64::from(i32::max_value()) => {
             pack_i32(buf, MSGPACK_MARKER_I32, val as i32)
         }
-        val if val >= i32::MAX as i64 => pack_i64(buf, MSGPACK_MARKER_I32, val),
+        val if val >= i64::from(i32::max_value()) => pack_i64(buf, MSGPACK_MARKER_I32, val),
 
         // Negative values
         val if val >= -32 && val < 0 => {
             pack_half_byte(buf, 0xe0 | ((Wrapping(val as u8) + Wrapping(32)).0))
         }
-        val if val >= i8::MIN as i64 && val < -32 => pack_byte(buf, MSGPACK_MARKER_NI8, val as u8),
-        val if val >= i16::MIN as i64 && val < i8::MIN as i64 => {
+        val if val >= i64::from(i8::min_value()) && val < -32 => {
+            pack_byte(buf, MSGPACK_MARKER_NI8, val as u8)
+        }
+        val if val >= i64::from(i16::min_value()) && val < i64::from(i8::min_value()) => {
             pack_i16(buf, MSGPACK_MARKER_NI16, val as i16)
         }
-        val if val >= i32::MIN as i64 && val < i16::MIN as i64 => {
+        val if val >= i64::from(i32::min_value()) && val < i64::from(i16::min_value()) => {
             pack_i32(buf, MSGPACK_MARKER_NI32, val as i32)
         }
-        val if val < i32::MIN as i64 => pack_i64(buf, MSGPACK_MARKER_NI64, val),
+        val if val < i64::from(i32::min_value()) => pack_i64(buf, MSGPACK_MARKER_NI64, val),
         _ => unreachable!(),
     }
 }
@@ -263,7 +267,7 @@ fn pack_i64(buf: &mut Option<&mut Buffer>, marker: u8, val: i64) -> Result<usize
 }
 
 fn pack_u64(buf: &mut Option<&mut Buffer>, val: u64) -> Result<usize> {
-    if val <= i64::MAX as u64 {
+    if val <= i64::max_value() as u64 {
         return pack_integer(buf, val as i64);
     }
 

--- a/src/msgpack/encoder.rs
+++ b/src/msgpack/encoder.rs
@@ -13,13 +13,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::{i16, i32, i64, i8};
 use std::collections::HashMap;
 use std::num::Wrapping;
+use std::{i16, i32, i64, i8};
 
-use errors::*;
-use commands::ParticleType;
 use commands::buffer::Buffer;
+use commands::ParticleType;
+use errors::*;
 use operations::cdt::{CdtArgument, CdtOperation};
 use value::*;
 

--- a/src/msgpack/mod.rs
+++ b/src/msgpack/mod.rs
@@ -13,5 +13,5 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-pub mod encoder;
 pub mod decoder;
+pub mod encoder;

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -131,7 +131,7 @@ impl Connection {
         self.bytes_read = 0;
     }
 
-    pub fn bytes_read(&self) -> usize {
+    pub const fn bytes_read(&self) -> usize {
         self.bytes_read
     }
 }

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -18,10 +18,10 @@ use std::net::{Shutdown, TcpStream, ToSocketAddrs};
 use std::ops::Add;
 use std::time::{Duration, Instant};
 
+use commands::admin_command::AdminCommand;
+use commands::buffer::Buffer;
 use errors::*;
 use policy::ClientPolicy;
-use commands::buffer::Buffer;
-use commands::admin_command::AdminCommand;
 
 #[derive(Debug)]
 pub struct Connection {

--- a/src/net/connection_pool.rs
+++ b/src/net/connection_pool.rs
@@ -64,25 +64,22 @@ impl Queue {
         let mut internals = self.0.internals.lock();
         let connection;
         loop {
-            match internals.connections.pop_front() {
-                Some(IdleConnection(mut conn)) => {
-                    if conn.is_idle() {
-                        internals.num_conns -= 1;
-                        conn.close();
-                        continue;
-                    }
-                    connection = conn;
-                    break;
+            if let Some(IdleConnection(mut conn)) = internals.connections.pop_front() {
+                if conn.is_idle() {
+                    internals.num_conns -= 1;
+                    conn.close();
+                    continue;
                 }
-                None => {
-                    if internals.num_conns >= self.0.capacity {
-                        bail!(ErrorKind::NoMoreConnections);
-                    }
-                    let conn = Connection::new(&self.0.host, &self.0.policy)?;
-                    internals.num_conns += 1;
-                    connection = conn;
-                    break;
+                connection = conn;
+                break;
+            } else {
+                if internals.num_conns >= self.0.capacity {
+                    bail!(ErrorKind::NoMoreConnections);
                 }
+                let conn = Connection::new(&self.0.host, &self.0.policy)?;
+                internals.num_conns += 1;
+                connection = conn;
+                break;
             }
         }
 

--- a/src/net/connection_pool.rs
+++ b/src/net/connection_pool.rs
@@ -53,9 +53,9 @@ impl Queue {
         };
         let shared = SharedQueue {
             internals: Mutex::new(internals),
-            capacity: capacity,
-            host: host,
-            policy: policy,
+            capacity,
+            host,
+            policy,
         };
         Queue(Arc::new(shared))
     }
@@ -143,8 +143,8 @@ impl ConnectionPool {
         let num_queues = policy.conn_pools_per_node;
         let queues = ConnectionPool::initialize_queues(num_conns, num_queues, host, policy);
         ConnectionPool {
-            num_queues: num_queues,
-            queues: queues,
+            num_queues,
+            queues,
             queue_counter: AtomicUsize::default(),
         }
     }

--- a/src/net/host.rs
+++ b/src/net/host.rs
@@ -86,7 +86,7 @@ impl ToHosts for String {
 
 impl<'a> ToHosts for &'a str {
     fn to_hosts(&self) -> Result<Vec<Host>> {
-        self.to_string().to_hosts()
+        (*self).to_string().to_hosts()
     }
 }
 

--- a/src/net/host.rs
+++ b/src/net/host.rs
@@ -36,7 +36,7 @@ impl Host {
     pub fn new(name: &str, port: u16) -> Self {
         Host {
             name: name.to_string(),
-            port: port,
+            port,
         }
     }
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -13,13 +13,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-pub use self::host::Host;
-pub use self::host::ToHosts;
 pub use self::connection::Connection;
 pub use self::connection_pool::ConnectionPool;
 pub use self::connection_pool::PooledConnection;
+pub use self::host::Host;
+pub use self::host::ToHosts;
 
-pub mod host;
 mod connection;
 mod connection_pool;
+pub mod host;
 mod parser;

--- a/src/net/parser.rs
+++ b/src/net/parser.rs
@@ -13,10 +13,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use Host;
 use errors::*;
-use std::str::Chars;
 use std::iter::Peekable;
+use std::str::Chars;
+use Host;
 
 pub struct Parser<'a> {
     s: Peekable<Chars<'a>>,
@@ -27,7 +27,7 @@ impl<'a> Parser<'a> {
     pub fn new(s: &'a str, default_port: u16) -> Self {
         Parser {
             s: s.chars().peekable(),
-            default_port: default_port,
+            default_port,
         }
     }
 

--- a/src/net/parser.rs
+++ b/src/net/parser.rs
@@ -34,7 +34,7 @@ impl<'a> Parser<'a> {
     pub fn read_hosts(&mut self) -> Result<Vec<Host>> {
         let mut hosts = Vec::new();
         loop {
-            let addr = try!(self.read_addr_tuple());
+            let addr = self.read_addr_tuple()?;
             let (host, _tls_name, port) = match addr.len() {
                 3 => (addr[0].clone(), Some(addr[1].clone()), addr[2].parse()?),
                 2 => {
@@ -64,7 +64,7 @@ impl<'a> Parser<'a> {
     fn read_addr_tuple(&mut self) -> Result<Vec<String>> {
         let mut parts = Vec::new();
         loop {
-            let part = try!(self.read_addr_part());
+            let part = self.read_addr_part()?;
             parts.push(part);
             match self.peek() {
                 Some(&c) if c == ':' => self.next_char(),

--- a/src/operations/cdt.rs
+++ b/src/operations/cdt.rs
@@ -93,12 +93,12 @@ impl<'a> CdtOperation<'a> {
     }
 
     pub fn estimate_size(&self) -> Result<usize> {
-        let size: usize = try!(encoder::pack_cdt_op(&mut None, self));
+        let size: usize = encoder::pack_cdt_op(&mut None, self)?;
         Ok(size)
     }
 
     pub fn write_to(&self, buffer: &mut Buffer) -> Result<usize> {
-        let size: usize = try!(encoder::pack_cdt_op(&mut Some(buffer), self));
+        let size: usize = encoder::pack_cdt_op(&mut Some(buffer), self)?;
         Ok(size)
     }
 }

--- a/src/operations/cdt.rs
+++ b/src/operations/cdt.rs
@@ -15,11 +15,11 @@
 
 use std::collections::HashMap;
 
-use errors::*;
-use Value;
-use msgpack::encoder;
-use commands::ParticleType;
 use commands::buffer::Buffer;
+use commands::ParticleType;
+use errors::*;
+use msgpack::encoder;
+use Value;
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]

--- a/src/operations/cdt.rs
+++ b/src/operations/cdt.rs
@@ -88,7 +88,7 @@ pub struct CdtOperation<'a> {
 }
 
 impl<'a> CdtOperation<'a> {
-    pub fn particle_type(&self) -> ParticleType {
+    pub const fn particle_type(&self) -> ParticleType {
         ParticleType::BLOB
     }
 

--- a/src/operations/lists.rs
+++ b/src/operations/lists.rs
@@ -28,12 +28,12 @@
 //! * Index -3, Count 3: Last three items in list.
 //! * Index -5, Count 4: Range between fifth to last item to second to last item inclusive.
 //!
-//! If an index is out of bounds, a paramter error will be returned. If a range is partially out of
+//! If an index is out of bounds, a parameter error will be returned. If a range is partially out of
 //! bounds, the valid part of the range will be returned.
 
-use Value;
-use operations::{Operation, OperationBin, OperationData, OperationType};
 use operations::cdt::{CdtArgument, CdtOpType, CdtOperation};
+use operations::{Operation, OperationBin, OperationData, OperationType};
+use Value;
 
 /// Create list append operation. Server appends value to the end of list bin. Server returns
 /// list size.
@@ -52,7 +52,7 @@ pub fn append<'a>(bin: &'a str, value: &'a Value) -> Operation<'a> {
 /// Create list append items operation. Server appends each input list item to the end of list
 /// bin. Server returns list size.
 pub fn append_items<'a>(bin: &'a str, values: &'a [Value]) -> Operation<'a> {
-    assert!(values.len() > 0);
+    assert!(!values.is_empty());
 
     let cdt_op = CdtOperation {
         op: CdtOpType::ListAppendItems,
@@ -82,7 +82,7 @@ pub fn insert<'a>(bin: &'a str, index: i64, value: &'a Value) -> Operation<'a> {
 /// Create list insert items operation. Server inserts each input list item starting at the
 /// specified index of the list bin. Server returns list size.
 pub fn insert_items<'a>(bin: &'a str, index: i64, values: &'a [Value]) -> Operation<'a> {
-    assert!(values.len() > 0);
+    assert!(!values.is_empty());
 
     let cdt_op = CdtOperation {
         op: CdtOpType::ListInsertItems,

--- a/src/operations/maps.rs
+++ b/src/operations/maps.rs
@@ -42,9 +42,9 @@
 
 use std::collections::HashMap;
 
-use Value;
-use operations::{Operation, OperationBin, OperationData, OperationType};
 use operations::cdt::{CdtArgument, CdtOpType, CdtOperation};
+use operations::{Operation, OperationBin, OperationData, OperationType};
+use Value;
 
 /// Map storage order.
 #[derive(Debug, Clone, Copy)]
@@ -134,10 +134,7 @@ pub struct MapPolicy {
 impl MapPolicy {
     /// Create a new map policy given the ordering for the map and the write mode.
     pub fn new(order: MapOrder, write_mode: MapWriteMode) -> Self {
-        MapPolicy {
-            order: order,
-            write_mode: write_mode,
-        }
+        MapPolicy { order, write_mode }
     }
 }
 
@@ -216,7 +213,7 @@ pub fn put_item<'a>(
     }
     let cdt_op = CdtOperation {
         op: map_write_op(policy, false),
-        args: args,
+        args,
     };
     Operation {
         op: OperationType::CdtWrite,
@@ -230,6 +227,7 @@ pub fn put_item<'a>(
 ///
 /// The required map policy dictates the type of map to create when it does not exist. The map
 /// policy also specifies the mode used when writing items to the map.
+#[allow(clippy::implicit_hasher)]
 pub fn put_items<'a>(
     policy: &'a MapPolicy,
     bin: &'a str,
@@ -241,7 +239,7 @@ pub fn put_items<'a>(
     }
     let cdt_op = CdtOperation {
         op: map_write_op(policy, true),
-        args: args,
+        args,
     };
     Operation {
         op: OperationType::CdtWrite,
@@ -270,7 +268,7 @@ pub fn increment_value<'a>(
     }
     let cdt_op = CdtOperation {
         op: CdtOpType::MapIncrement,
-        args: args,
+        args,
     };
     Operation {
         op: OperationType::CdtWrite,
@@ -299,7 +297,7 @@ pub fn decrement_value<'a>(
     }
     let cdt_op = CdtOperation {
         op: CdtOpType::MapDecrement,
-        args: args,
+        args,
     };
     Operation {
         op: OperationType::CdtWrite,
@@ -383,7 +381,7 @@ pub fn remove_by_key_range<'a>(
     }
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByKeyInterval,
-        args: args,
+        args,
     };
     Operation {
         op: OperationType::CdtWrite,
@@ -453,7 +451,7 @@ pub fn remove_by_value_range<'a>(
     }
     let cdt_op = CdtOperation {
         op: CdtOpType::MapRemoveByValueInterval,
-        args: args,
+        args,
     };
     Operation {
         op: OperationType::CdtWrite,
@@ -583,7 +581,7 @@ pub fn size(bin: &str) -> Operation {
     }
 }
 
-/// Create map get by key operation. Server selects the map item idenfieid by the key and
+/// Create map get by key operation. Server selects the map item identified by the key and
 /// returns the selected data specified by `return_type`.
 pub fn get_by_key<'a>(bin: &'a str, key: &'a Value, return_type: MapReturnType) -> Operation<'a> {
     let cdt_op = CdtOperation {
@@ -619,7 +617,7 @@ pub fn get_by_key_range<'a>(
     }
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByKeyInterval,
-        args: args,
+        args,
     };
     Operation {
         op: OperationType::CdtRead,
@@ -668,7 +666,7 @@ pub fn get_by_value_range<'a>(
     }
     let cdt_op = CdtOperation {
         op: CdtOpType::MapGetByValueInterval,
-        args: args,
+        args,
     };
     Operation {
         op: OperationType::CdtRead,
@@ -735,7 +733,7 @@ pub fn get_by_index_range_from(bin: &str, index: i64, return_type: MapReturnType
     }
 }
 
-/// Create map get by rank operation. Server selects the mamp item identified by rank and
+/// Create map get by rank operation. Server selects the map item identified by rank and
 /// returns the selected data specified by `return_type`.
 pub fn get_by_rank(bin: &str, rank: i64, return_type: MapReturnType) -> Operation {
     let cdt_op = CdtOperation {
@@ -749,7 +747,7 @@ pub fn get_by_rank(bin: &str, rank: i64, return_type: MapReturnType) -> Operatio
     }
 }
 
-/// Create map get ranke range operation. Server selects `count` map items at the specified
+/// Create map get rank range operation. Server selects `count` map items at the specified
 /// rank and returns the selected data specified by `return_type`.
 pub fn get_by_rank_range(
     bin: &str,

--- a/src/operations/maps.rs
+++ b/src/operations/maps.rs
@@ -133,7 +133,7 @@ pub struct MapPolicy {
 
 impl MapPolicy {
     /// Create a new map policy given the ordering for the map and the write mode.
-    pub fn new(order: MapOrder, write_mode: MapWriteMode) -> Self {
+    pub const fn new(order: MapOrder, write_mode: MapWriteMode) -> Self {
         MapPolicy { order, write_mode }
     }
 }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -17,18 +17,18 @@
 
 #[doc(hidden)]
 pub mod cdt;
-pub mod scalar;
 pub mod lists;
 pub mod maps;
+pub mod scalar;
 
+use self::cdt::CdtOperation;
 pub use self::maps::{MapOrder, MapPolicy, MapReturnType, MapWriteMode};
 pub use self::scalar::*;
-use self::cdt::CdtOperation;
 
+use commands::buffer::Buffer;
+use commands::ParticleType;
 use errors::*;
 use Value;
-use commands::ParticleType;
-use commands::buffer::Buffer;
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -86,9 +86,9 @@ impl<'a> Operation<'a> {
         };
         size += match self.data {
             OperationData::None => 0,
-            OperationData::Value(value) => try!(value.estimate_size()),
+            OperationData::Value(value) => value.estimate_size()?,
             OperationData::CdtListOp(ref cdt_op) | OperationData::CdtMapOp(ref cdt_op) => {
-                try!(cdt_op.estimate_size())
+                cdt_op.estimate_size()?
             }
         };
 
@@ -100,22 +100,22 @@ impl<'a> Operation<'a> {
         let mut size: usize = 0;
 
         // remove the header size from the estimate
-        let op_size = try!(self.estimate_size());
+        let op_size = self.estimate_size()?;
 
-        size += try!(buffer.write_u32(op_size as u32 + 4));
-        size += try!(buffer.write_u8(self.op as u8));
+        size += buffer.write_u32(op_size as u32 + 4)?;
+        size += buffer.write_u8(self.op as u8)?;
 
         match self.data {
             OperationData::None => {
-                size += try!(self.write_op_header_to(buffer, ParticleType::NULL as u8));
+                size += self.write_op_header_to(buffer, ParticleType::NULL as u8)?;
             }
             OperationData::Value(value) => {
-                size += try!(self.write_op_header_to(buffer, value.particle_type() as u8));
-                size += try!(value.write_to(buffer));
+                size += self.write_op_header_to(buffer, value.particle_type() as u8)?;
+                size += value.write_to(buffer)?;
             }
             OperationData::CdtListOp(ref cdt_op) | OperationData::CdtMapOp(ref cdt_op) => {
-                size += try!(self.write_op_header_to(buffer, cdt_op.particle_type() as u8));
-                size += try!(cdt_op.write_to(buffer));
+                size += self.write_op_header_to(buffer, cdt_op.particle_type() as u8)?;
+                size += cdt_op.write_to(buffer)?;
             }
         };
 
@@ -124,15 +124,15 @@ impl<'a> Operation<'a> {
 
     #[doc(hidden)]
     fn write_op_header_to(&self, buffer: &mut Buffer, particle_type: u8) -> Result<usize> {
-        let mut size = try!(buffer.write_u8(particle_type as u8));
-        size += try!(buffer.write_u8(0));
+        let mut size = buffer.write_u8(particle_type as u8)?;
+        size += buffer.write_u8(0)?;
         match self.bin {
             OperationBin::Name(bin) => {
-                size += try!(buffer.write_u8(bin.len() as u8));
-                size += try!(buffer.write_str(bin));
+                size += buffer.write_u8(bin.len() as u8)?;
+                size += buffer.write_str(bin)?;
             }
             OperationBin::None | OperationBin::All => {
-                size += try!(buffer.write_u8(0));
+                size += buffer.write_u8(0)?;
             }
         }
         Ok(size)

--- a/src/operations/scalar.rs
+++ b/src/operations/scalar.rs
@@ -19,7 +19,7 @@ use operations::*;
 use Bin;
 
 /// Create read all record bins database operation.
-pub fn get<'a>() -> Operation<'a> {
+pub const fn get<'a>() -> Operation<'a> {
     Operation {
         op: OperationType::Read,
         bin: OperationBin::All,
@@ -28,7 +28,7 @@ pub fn get<'a>() -> Operation<'a> {
 }
 
 /// Create read record header database operation.
-pub fn get_header<'a>() -> Operation<'a> {
+pub const fn get_header<'a>() -> Operation<'a> {
     Operation {
         op: OperationType::Read,
         bin: OperationBin::None,
@@ -82,7 +82,7 @@ pub fn add<'a>(bin: &'a Bin) -> Operation<'a> {
 }
 
 /// Create touch database operation.
-pub fn touch<'a>() -> Operation<'a> {
+pub const fn touch<'a>() -> Operation<'a> {
     Operation {
         op: OperationType::Touch,
         bin: OperationBin::None,

--- a/src/operations/scalar.rs
+++ b/src/operations/scalar.rs
@@ -15,8 +15,8 @@
 
 //! String/number bin operations. Create operations used by the client's `operate()` method.
 
-use Bin;
 use operations::*;
+use Bin;
 
 /// Create read all record bins database operation.
 pub fn get<'a>() -> Operation<'a> {

--- a/src/policy/client_policy.rs
+++ b/src/policy/client_policy.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
 use std::collections::HashMap;
+use std::time::Duration;
 
-use errors::*;
 use commands::admin_command::AdminCommand;
+use errors::*;
 
 /// `ClientPolicy` encapsulates parameters for client policy command.
 #[derive(Debug, Clone)]

--- a/src/policy/expiration.rs
+++ b/src/policy/expiration.rs
@@ -15,9 +15,9 @@
 
 use std::u32;
 
-const NAMESPACE_DEFAULT: u32 = 0x00000000;
-const NEVER_EXPIRE: u32 = 0xFFFFFFFF; // -1 as i32
-const DONT_UPDATE: u32 = 0xFFFFFFFE; // -2 as i32
+const NAMESPACE_DEFAULT: u32 = 0x0000_0000;
+const NEVER_EXPIRE: u32 = 0xFFFF_FFFF; // -1 as i32
+const DONT_UPDATE: u32 = 0xFFFF_FFFE; // -2 as i32
 
 /// Record expiration, also known as time-to-live (TTL).
 #[derive(Debug, Clone, Copy)]

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -15,20 +15,20 @@
 
 //! Policy types encapsulate optional parameters for various client operations.
 
-mod expiration;
-mod priority;
-mod consistency_level;
-mod generation_policy;
-mod record_exists_action;
-mod commit_level;
-mod concurrency;
+mod admin_policy;
 mod batch_policy;
 mod client_policy;
-mod read_policy;
-mod write_policy;
-mod scan_policy;
+mod commit_level;
+mod concurrency;
+mod consistency_level;
+mod expiration;
+mod generation_policy;
+mod priority;
 mod query_policy;
-mod admin_policy;
+mod read_policy;
+mod record_exists_action;
+mod scan_policy;
+mod write_policy;
 
 pub use self::admin_policy::AdminPolicy;
 pub use self::batch_policy::BatchPolicy;
@@ -45,8 +45,8 @@ pub use self::record_exists_action::RecordExistsAction;
 pub use self::scan_policy::ScanPolicy;
 pub use self::write_policy::WritePolicy;
 
-use std::time::{Duration, Instant};
 use std::option::Option;
+use std::time::{Duration, Instant};
 
 /// Trait implemented by most policy types; policies that implement this trait typically encompass
 /// an instance of `BasePolicy`.

--- a/src/policy/read_policy.rs
+++ b/src/policy/read_policy.rs
@@ -13,10 +13,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::time::Duration;
-use Priority;
-use ConsistencyLevel;
 use policy::BasePolicy;
+use std::time::Duration;
+use ConsistencyLevel;
+use Priority;
 
 /// `ReadPolicy` excapsulates parameters for transaction policy attributes
 /// used in all database operation calls.
@@ -28,7 +28,7 @@ impl Default for ReadPolicy {
             priority: Priority::Default,
             timeout: Some(Duration::new(30, 0)),
             max_retries: Some(2),
-            sleep_between_retries: Some(Duration::new(0, 500000000)),
+            sleep_between_retries: Some(Duration::new(0, 500_000_000)),
             consistency_level: ConsistencyLevel::ConsistencyOne,
         }
     }

--- a/src/policy/write_policy.rs
+++ b/src/policy/write_policy.rs
@@ -14,10 +14,10 @@
 // the License.
 
 use policy::{BasePolicy, PolicyLike};
-use RecordExistsAction;
-use GenerationPolicy;
 use CommitLevel;
 use Expiration;
+use GenerationPolicy;
+use RecordExistsAction;
 
 /// `WritePolicy` encapsulates parameters for all write operations.
 pub struct WritePolicy {

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -75,22 +75,22 @@ impl Filter {
         // bin name size(1) + particle type size(1)
         //     + begin particle size(4) + end particle size(4) = 10
         Ok(
-            self.bin_name.len() + try!(self.begin.estimate_size()) + try!(self.end.estimate_size())
+            self.bin_name.len() + self.begin.estimate_size()? + self.end.estimate_size()?
                 + 10,
         )
     }
 
     #[doc(hidden)]
     pub fn write(&self, buffer: &mut Buffer) -> Result<()> {
-        try!(buffer.write_u8(self.bin_name.len() as u8));
-        try!(buffer.write_str(&self.bin_name));
-        try!(buffer.write_u8(self.value_particle_type.clone() as u8));
+        buffer.write_u8(self.bin_name.len() as u8)?;
+        buffer.write_str(&self.bin_name)?;
+        buffer.write_u8(self.value_particle_type.clone() as u8)?;
 
-        try!(buffer.write_u32(try!(self.begin.estimate_size()) as u32));
-        try!(self.begin.write_to(buffer));
+        buffer.write_u32(self.begin.estimate_size()? as u32)?;
+        self.begin.write_to(buffer)?;
 
-        try!(buffer.write_u32(try!(self.end.estimate_size()) as u32));
-        try!(self.end.write_to(buffer));
+        buffer.write_u32(self.end.estimate_size()? as u32)?;
+        self.end.write_to(buffer)?;
 
         Ok(())
     }

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -14,9 +14,9 @@
 // the License.
 
 use errors::*;
+use query::Filter;
 use Bins;
 use Value;
-use query::Filter;
 
 #[derive(Clone)]
 pub struct Aggregation {
@@ -66,7 +66,7 @@ impl Statement {
         Statement {
             namespace: namespace.to_owned(),
             set_name: set_name.to_owned(),
-            bins: bins,
+            bins,
             index_name: None,
             aggregation: None,
             filters: None,

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -83,21 +83,17 @@ impl Statement {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// # fn main() {
+    ///
     /// let mut stmt = Statement::new("foo", "bar", Bins::from(["name", "age"]));
     /// stmt.add_filter(as_range!("baz", 0, 100));
-    /// # }
     /// ```
     pub fn add_filter(&mut self, filter: Filter) {
-        match self.filters {
-            Some(ref mut filters) => {
-                filters.push(filter.to_owned());
-            }
-            None => {
-                let mut filters = vec![];
-                filters.push(filter.to_owned());
-                self.filters = Some(filters);
-            }
+        if let Some(ref mut filters) = self.filters {
+            filters.push(filter);
+        } else {
+            let mut filters = vec![];
+            filters.push(filter);
+            self.filters = Some(filters);
         }
     }
 

--- a/src/record.rs
+++ b/src/record.rs
@@ -45,7 +45,7 @@ pub struct Record {
 impl Record {
     /// Construct a new Record. For internal use only.
     #[doc(hidden)]
-    pub fn new(
+    pub const fn new(
         key: Option<Key>,
         bins: HashMap<String, Value>,
         generation: u32,
@@ -65,7 +65,7 @@ impl Record {
         match self.expiration {
             0 => None,
             secs_since_epoch => {
-                let expiration = *CITRUSLEAF_EPOCH + Duration::new(secs_since_epoch as u64, 0);
+                let expiration = *CITRUSLEAF_EPOCH + Duration::new(u64::from(secs_since_epoch), 0);
                 match expiration.duration_since(SystemTime::now()) {
                     Ok(d) => Some(d),
                     // Record was not expired at server but it looks expired at client

--- a/src/record.rs
+++ b/src/record.rs
@@ -79,16 +79,16 @@ impl Record {
 
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        try!(write!(f, "key: {:?}", self.key));
-        try!(write!(f, ", bins: {{"));
+        write!(f, "key: {:?}", self.key)?;
+        write!(f, ", bins: {{")?;
         for (i, (k, v)) in self.bins.iter().enumerate() {
             if i > 0 {
-                try!(write!(f, ", "))
+                write!(f, ", ")?
             }
-            try!(write!(f, "{}: {}", k, v));
+            write!(f, "{}: {}", k, v)?;
         }
-        try!(write!(f, "}}, generation: {}", self.generation));
-        try!(write!(f, ", ttl: "));
+        write!(f, "}}, generation: {}", self.generation)?;
+        write!(f, ", ttl: ")?;
         match self.time_to_live() {
             None => "none".fmt(f),
             Some(duration) => duration.as_secs().fmt(f),

--- a/src/record.rs
+++ b/src/record.rs
@@ -17,12 +17,12 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use Value;
 use Key;
+use Value;
 
 lazy_static! {
   // Fri Jan  1 00:00:00 UTC 2010
-  pub static ref CITRUSLEAF_EPOCH: SystemTime = UNIX_EPOCH + Duration::new(1262304000, 0);
+  pub static ref CITRUSLEAF_EPOCH: SystemTime = UNIX_EPOCH + Duration::new(1_262_304_000, 0);
 }
 
 /// Container object for a database record.
@@ -52,10 +52,10 @@ impl Record {
         expiration: u32,
     ) -> Self {
         Record {
-            key: key,
-            bins: bins,
-            generation: generation,
-            expiration: expiration,
+            key,
+            bins,
+            generation,
+            expiration,
         }
     }
 
@@ -99,8 +99,8 @@ impl fmt::Display for Record {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{Duration, SystemTime};
     use std::collections::HashMap;
+    use std::time::{Duration, SystemTime};
 
     #[test]
     fn ttl_expiration_future() {
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn ttl_expiration_past() {
-        let record = Record::new(None, HashMap::new(), 0, 0x0d00d21c);
+        let record = Record::new(None, HashMap::new(), 0, 0x0d00_d21c);
         assert_eq!(record.time_to_live(), Some(Duration::new(1u64, 0)));
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -559,33 +559,33 @@ pub fn bytes_to_particle(ptype: u8, buf: &mut Buffer, len: usize) -> Result<Valu
     match ParticleType::from(ptype) {
         ParticleType::NULL => Ok(Value::Nil),
         ParticleType::INTEGER => {
-            let val = try!(buf.read_i64(None));
+            let val = buf.read_i64(None)?;
             Ok(Value::Int(val))
         }
         ParticleType::FLOAT => {
-            let val = try!(buf.read_f64(None));
+            let val = buf.read_f64(None)?;
             Ok(Value::Float(FloatValue::from(val)))
         }
         ParticleType::STRING => {
-            let val = try!(buf.read_str(len));
+            let val = buf.read_str(len)?;
             Ok(Value::String(val))
         }
         ParticleType::GEOJSON => {
-            try!(buf.skip(1));
-            let ncells = try!(buf.read_i16(None)) as usize;
+            buf.skip(1)?;
+            let ncells = buf.read_i16(None)? as usize;
             let header_size: usize = ncells * 8;
 
-            try!(buf.skip(header_size));
-            let val = try!(buf.read_str(len - header_size - 3));
+            buf.skip(header_size)?;
+            let val = buf.read_str(len - header_size - 3)?;
             Ok(Value::GeoJSON(val))
         }
-        ParticleType::BLOB => Ok(Value::Blob(try!(buf.read_blob(len)))),
+        ParticleType::BLOB => Ok(Value::Blob(buf.read_blob(len)?)),
         ParticleType::LIST => {
-            let val = try!(decoder::unpack_value_list(buf));
+            let val = decoder::unpack_value_list(buf)?;
             Ok(val)
         }
         ParticleType::MAP => {
-            let val = try!(decoder::unpack_value_map(buf));
+            let val = decoder::unpack_value_map(buf)?;
             Ok(val)
         }
         ParticleType::DIGEST => Ok(Value::from("A DIGEST, NOT IMPLEMENTED YET!")),

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -13,9 +13,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// TODO: Remove and fix all warnings
-#![allow(clippy::all)]
-
 extern crate aerospike;
 extern crate env_logger;
 #[macro_use]
@@ -38,14 +35,14 @@ fn cluster_name() {
 fn node_names() {
     let client = common::client();
     let names = client.node_names();
-    assert!(names.len() >= 1);
+    assert!(!names.is_empty());
 }
 
 #[test]
 fn nodes() {
     let client = common::client();
     let nodes = client.nodes();
-    assert!(nodes.len() >= 1);
+    assert!(!nodes.is_empty());
 }
 
 #[test]

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -13,6 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+// TODO: Remove and fix all warnings
+#![allow(clippy::all)]
+
 extern crate aerospike;
 extern crate env_logger;
 #[macro_use]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -14,40 +14,33 @@
 // the License.
 
 #![allow(dead_code)]
-// TODO: Remove and fix all warnings
-#![allow(unused_mut, clippy::all)]
 
 use std::env;
 use std::sync::Arc;
 
 use rand;
-use rand::Rng;
 use rand::distributions::Alphanumeric;
+use rand::Rng;
 
 use aerospike::{Client, ClientPolicy};
 
 lazy_static! {
     static ref AEROSPIKE_HOSTS: String =
-        env::var("AEROSPIKE_HOSTS").unwrap_or(String::from("127.0.0.1"));
-
+        env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| String::from("127.0.0.1"));
     static ref AEROSPIKE_NAMESPACE: String =
-        env::var("AEROSPIKE_NAMESPACE").unwrap_or(String::from("test"));
-
+        env::var("AEROSPIKE_NAMESPACE").unwrap_or_else(|_| String::from("test"));
     static ref AEROSPIKE_CLUSTER: Option<String> = env::var("AEROSPIKE_CLUSTER").ok();
-
     static ref GLOBAL_CLIENT_POLICY: ClientPolicy = {
         let mut policy = ClientPolicy::default();
         if let Ok(user) = env::var("AEROSPIKE_USER") {
-            let password = env::var("AEROSPIKE_PASSWORD").unwrap_or(String::new());
+            let password = env::var("AEROSPIKE_PASSWORD").unwrap_or_default();
             policy.set_user_password(user, password).unwrap();
         }
         policy.cluster_name = AEROSPIKE_CLUSTER.clone();
         policy
     };
-
-    static ref GLOBAL_CLIENT: Arc<Client> = {
-        Arc::new(Client::new(&GLOBAL_CLIENT_POLICY, &*AEROSPIKE_HOSTS).unwrap())
-    };
+    static ref GLOBAL_CLIENT: Arc<Client> =
+        { Arc::new(Client::new(&GLOBAL_CLIENT_POLICY, &*AEROSPIKE_HOSTS).unwrap()) };
 }
 
 pub fn hosts() -> &'static str {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -60,6 +60,6 @@ pub fn client() -> Arc<Client> {
 }
 
 pub fn rand_str(sz: usize) -> String {
-    let mut rng = rand::thread_rng();
+    let rng = rand::thread_rng();
     rng.sample_iter(&Alphanumeric).take(sz).collect()
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -14,6 +14,8 @@
 // the License.
 
 #![allow(dead_code)]
+// TODO: Remove and fix all warnings
+#![allow(unused_mut, clippy::all)]
 
 use std::env;
 use std::sync::Arc;

--- a/tests/src/cdt_list.rs
+++ b/tests/src/cdt_list.rs
@@ -13,12 +13,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use env_logger;
 use common;
+use env_logger;
 
-use aerospike::{Bins, ReadPolicy, Value, WritePolicy};
 use aerospike::operations;
 use aerospike::operations::lists;
+use aerospike::{Bins, ReadPolicy, Value, WritePolicy};
 
 #[test]
 fn cdt_list() {

--- a/tests/src/cdt_map.rs
+++ b/tests/src/cdt_map.rs
@@ -15,11 +15,11 @@
 
 use std::collections::HashMap;
 
-use env_logger;
 use common;
+use env_logger;
 
-use aerospike::{Bins, MapPolicy, MapReturnType, ReadPolicy, WritePolicy};
 use aerospike::operations::maps;
+use aerospike::{Bins, MapPolicy, MapReturnType, ReadPolicy, WritePolicy};
 
 #[test]
 fn map_operations() {

--- a/tests/src/index.rs
+++ b/tests/src/index.rs
@@ -16,8 +16,8 @@
 use std::thread;
 use std::time::Duration;
 
-use env_logger;
 use common;
+use env_logger;
 
 use aerospike::*;
 

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -15,8 +15,8 @@
 
 use std::collections::HashMap;
 
-use aerospike::{Bins, ReadPolicy, Value, WritePolicy};
 use aerospike::operations;
+use aerospike::{Bins, ReadPolicy, Value, WritePolicy};
 
 use env_logger;
 
@@ -46,7 +46,7 @@ fn connect() {
             "bin Geo",
             as_geo!(format!(
                 r#"{{ "type": "Point", "coordinates": [{}, {}] }}"#,
-                17.119381, 19.45612
+                17.119_381, 19.45612
             ))
         ),
         as_bin!("bin-name-len-15", "max. bin name length is 15 chars"),

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -13,15 +13,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-// TODO: Remove and fix all warnings
-#![allow(clippy::all)]
-
+mod batch;
+mod cdt_list;
+mod cdt_map;
+mod index;
 mod kv;
 mod query;
 mod scan;
-mod udf;
-mod cdt_list;
-mod cdt_map;
-mod batch;
-mod index;
 mod truncate;
+mod udf;

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -13,6 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+// TODO: Remove and fix all warnings
+#![allow(clippy::all)]
+
 mod kv;
 mod query;
 mod scan;

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -190,7 +190,7 @@ fn query_node() {
             let mut statement = Statement::new(namespace, &set_name, Bins::All);
             statement.add_filter(as_range!("bin", 0, 99));
             let rs = client.query_node(&qpolicy, node, statement).unwrap();
-            let ok = (&*rs).filter(|r| r.is_ok()).count();
+            let ok = (&*rs).filter(Result::is_ok).count();
             count.fetch_add(ok, Ordering::Relaxed);
         }));
     }

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -13,13 +13,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use env_logger;
 use common;
+use env_logger;
 
 use aerospike::*;
 

--- a/tests/src/scan.rs
+++ b/tests/src/scan.rs
@@ -13,12 +13,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread;
 
-use env_logger;
 use common;
+use env_logger;
 
 use aerospike::{Bins, ScanPolicy, WritePolicy};
 

--- a/tests/src/scan.rs
+++ b/tests/src/scan.rs
@@ -54,7 +54,7 @@ fn scan_single_consumer() {
         .scan(&spolicy, namespace, &set_name, Bins::All)
         .unwrap();
 
-    let count = (&*rs).filter(|r| r.is_ok()).count();
+    let count = (&*rs).filter(Result::is_ok).count();
     assert_eq!(count, EXPECTED);
 }
 
@@ -79,7 +79,7 @@ fn scan_multi_consumer() {
         let count = count.clone();
         let rs = rs.clone();
         threads.push(thread::spawn(move || {
-            let ok = (&*rs).filter(|r| r.is_ok()).count();
+            let ok = (&*rs).filter(Result::is_ok).count();
             count.fetch_add(ok, Ordering::Relaxed);
         }));
     }
@@ -111,7 +111,7 @@ fn scan_node() {
             let rs = client
                 .scan_node(&spolicy, node, namespace, &set_name, Bins::All)
                 .unwrap();
-            let ok = (&*rs).filter(|r| r.is_ok()).count();
+            let ok = (&*rs).filter(Result::is_ok).count();
             count.fetch_add(ok, Ordering::Relaxed);
         }));
     }

--- a/tests/src/truncate.rs
+++ b/tests/src/truncate.rs
@@ -15,8 +15,8 @@
 
 use aerospike::WritePolicy;
 
-use env_logger;
 use common;
+use env_logger;
 
 #[test]
 fn truncate() {

--- a/tests/src/udf.rs
+++ b/tests/src/udf.rs
@@ -16,13 +16,13 @@
 use std::thread;
 use std::time::Duration;
 
-use env_logger;
 use common;
+use env_logger;
 
-use aerospike::{Error, ErrorKind};
 use aerospike::UDFLang;
 use aerospike::Value;
 use aerospike::WritePolicy;
+use aerospike::{Error, ErrorKind};
 
 #[test]
 fn execute_udf() {

--- a/tools/benchmark/src/cli.rs
+++ b/tools/benchmark/src/cli.rs
@@ -13,9 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+use std::convert::AsRef;
 use std::env;
 use std::str::FromStr;
-use std::convert::AsRef;
 
 use clap::{App, Arg};
 use num_cpus;
@@ -120,7 +120,8 @@ fn build_cli() -> App<'static, 'static> {
             Arg::from_usage(
                 "-w, --workload 'Workload definition: I | RU (see below for \
                  details)'",
-            ).default_value("I"),
+            )
+            .default_value("I"),
         )
         .arg(
             Arg::from_usage("-Y, --connPoolsPerNode 'Number of connection pools per node'")

--- a/tools/benchmark/src/main.rs
+++ b/tools/benchmark/src/main.rs
@@ -25,22 +25,22 @@ extern crate log;
 extern crate num_cpus;
 extern crate rand;
 
-mod percent;
 mod cli;
-mod workers;
-mod stats;
 mod generator;
+mod percent;
+mod stats;
+mod workers;
 
+use std::sync::mpsc;
 use std::sync::Arc;
 use std::thread;
-use std::sync::mpsc;
 
 use aerospike::{Client, ClientPolicy};
 
 use cli::Options;
+use generator::KeyPartitions;
 use stats::Collector;
 use workers::Worker;
-use generator::KeyPartitions;
 
 fn main() {
     env_logger::init().unwrap();

--- a/tools/benchmark/src/percent.rs
+++ b/tools/benchmark/src/percent.rs
@@ -16,8 +16,8 @@
 use std::cmp::Ordering;
 use std::str::FromStr;
 
-use rand::Rng;
 use rand::distributions::{Distribution, Standard};
+use rand::Rng;
 
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Debug)]
 pub struct Percent(u8);

--- a/tools/benchmark/src/stats.rs
+++ b/tools/benchmark/src/stats.rs
@@ -13,9 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::time::{Duration, Instant};
-use std::sync::mpsc::Receiver;
 use std::f64;
+use std::sync::mpsc::Receiver;
+use std::time::{Duration, Instant};
 
 use workers::Status;
 

--- a/tools/benchmark/src/workers.rs
+++ b/tools/benchmark/src/workers.rs
@@ -13,20 +13,20 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::str::FromStr;
-use std::sync::Arc;
-use std::sync::mpsc::Sender;
 use std::boxed::Box;
+use std::str::FromStr;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use rand::prelude::*;
 
-use aerospike::{Client, ErrorKind, Key, ReadPolicy, ResultCode, WritePolicy};
-use aerospike::Result as asResult;
 use aerospike::Error as asError;
+use aerospike::Result as asResult;
+use aerospike::{Client, ErrorKind, Key, ReadPolicy, ResultCode, WritePolicy};
 
-use percent::Percent;
 use generator::KeyRange;
+use percent::Percent;
 use stats::Histogram;
 
 lazy_static! {


### PR DESCRIPTION
When working on my previous PR I got lots of deprecation and other warnings. So I went ahead and fixed all of them. Although the changes are simple, they are many so I split the work up into separate commits to simplify the review.

After fixing all the main warnings I ran `clippy` and the story continued. In the end I enabled more clippy lints and also ran clippy with nightly which gave even more warnings.

The disabled clippy lints are made either because the required changes to fix them would be rather big or the suggestions are incompatible with Rust 1.34.0.

Unfortunately the clippy of 1.34.0 doesn't work as some dependencies use configurations of newer versions.