### PR TITLE
Update benchmark to use u128 and μs

### DIFF
--- a/tools/benchmark/src/main.rs
+++ b/tools/benchmark/src/main.rs
@@ -43,7 +43,7 @@ use stats::Collector;
 use workers::Worker;
 
 fn main() {
-    env_logger::init().unwrap();
+    let _ = env_logger::try_init();
     let options = cli::parse_options();
     info!("{:?}", options);
     let client = connect(&options);

--- a/tools/benchmark/src/workers.rs
+++ b/tools/benchmark/src/workers.rs
@@ -62,7 +62,7 @@ impl FromStr for Workload {
 pub struct Worker {
     histogram: Histogram,
     collector: Sender<Histogram>,
-    task: Box<Task>,
+    task: Box<dyn Task>,
 }
 
 impl Worker {
@@ -71,7 +71,7 @@ impl Worker {
         client: Arc<Client>,
         sender: Sender<Histogram>,
     ) -> Self {
-        let task: Box<Task> = match *workload {
+        let task: Box<dyn Task> = match *workload {
             Workload::Initialize => Box::new(InsertTask::new(client)),
             Workload::ReadUpdate { read_pct } => Box::new(ReadUpdateTask::new(client, read_pct)),
         };


### PR DESCRIPTION
Measure latencies in whole microseconds rather than fractional milliseconds. Uses the new `Duration::as_micros` function introduced in Rust v1.33.0.