### PR TITLE
Changing version on documentation

### DIFF
--- a/.travis/aerospike.conf
+++ b/.travis/aerospike.conf
@@ -52,4 +52,5 @@ namespace test {
   memory-size 1G
   default-ttl 30d # 30 days, use 0 to never expire/evict.
   storage-engine memory
+  allow-ttl-without-nsup true
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //!
 //! ```text
 //! [dependencies]
-//! aerospike = "0.1.0"
+//! aerospike = "0.4.0"
 //! ```
 //!
 //! # Examples


### PR DESCRIPTION
The current version is misleading and drives users to use an old version.

_+ fix aerospike configuration on Travis_ 