### PR TITLE
Move to rust edition 2018

### DIFF
--- a/.travis/aerospike.conf
+++ b/.travis/aerospike.conf
@@ -52,4 +52,5 @@ namespace test {
   memory-size 1G
   default-ttl 30d # 30 days, use 0 to never expire/evict.
   storage-engine memory
+  allow-ttl-without-nsup true
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "aerospike"
 version = "0.4.0"
+edition = "2018"
 authors = ["Khosrow Afroozeh <khosrow@aerospike.com>", "Jan Hecking <jhecking@aerospike.com>"]
 description = "Aerospike Client for Rust"
 keywords = ["aerospike", "nosql", "distributed", "database"]

--- a/benches/client_server.rs
+++ b/benches/client_server.rs
@@ -14,8 +14,6 @@
 // the License.
 
 #[macro_use]
-extern crate aerospike;
-#[macro_use]
 extern crate bencher;
 #[macro_use]
 extern crate lazy_static;
@@ -24,6 +22,7 @@ extern crate rand;
 use aerospike::{Bins, ReadPolicy, WritePolicy};
 
 use bencher::Bencher;
+use aerospike::{as_bin, as_key};
 
 #[path = "../tests/common/mod.rs"]
 mod common;

--- a/src/batch/batch_executor.rs
+++ b/src/batch/batch_executor.rs
@@ -21,13 +21,13 @@ use std::sync::Arc;
 use parking_lot::Mutex;
 use scoped_pool::Pool;
 
-use batch::BatchRead;
-use cluster::partition::Partition;
-use cluster::{Cluster, Node};
-use commands::BatchReadCommand;
-use errors::*;
-use policy::{BatchPolicy, Concurrency};
-use Key;
+use crate::batch::BatchRead;
+use crate::cluster::partition::Partition;
+use crate::cluster::{Cluster, Node};
+use crate::commands::BatchReadCommand;
+use crate::errors::{Error, Result};
+use crate::policy::{BatchPolicy, Concurrency};
+use crate::Key;
 
 pub struct BatchExecutor {
     cluster: Arc<Cluster>,

--- a/src/batch/batch_read.rs
+++ b/src/batch/batch_read.rs
@@ -13,9 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use Bins;
-use Key;
-use Record;
+use crate::Bins;
+use crate::Key;
+use crate::Record;
 
 /// Key and bin names used in batch read commands where variable bins are needed for each key.
 pub struct BatchRead<'a> {

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -15,7 +15,7 @@
 
 use std::convert::From;
 
-use value::Value;
+use crate::value::Value;
 
 /// Container object for a record bin, comprising a name and a value.
 pub struct Bin<'a> {
@@ -132,7 +132,7 @@ impl<'a> From<[&'a str; 6]> for Bins {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{Bins, From};
 
     #[test]
     fn into_bins() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,31 +21,19 @@ use std::sync::Arc;
 use std::thread;
 use std::vec::Vec;
 
-use base64;
 use scoped_pool::Pool;
 
-use batch::BatchExecutor;
-use cluster::{Cluster, Node};
-use commands::{
+use crate::batch::BatchExecutor;
+use crate::cluster::{Cluster, Node};
+use crate::commands::{
     DeleteCommand, ExecuteUDFCommand, ExistsCommand, OperateCommand, QueryCommand, ReadCommand,
     ScanCommand, TouchCommand, WriteCommand,
 };
-use errors::*;
-use net::ToHosts;
-use operations::{Operation, OperationType};
-use policy::{BatchPolicy, ClientPolicy, QueryPolicy, ReadPolicy, ScanPolicy, WritePolicy};
-use BatchRead;
-use Bin;
-use Bins;
-use CollectionIndexType;
-use IndexType;
-use Key;
-use Record;
-use Recordset;
-use ResultCode;
-use Statement;
-use UDFLang;
-use Value;
+use crate::errors::{ErrorKind, Result, ResultExt};
+use crate::net::ToHosts;
+use crate::operations::{Operation, OperationType};
+use crate::policy::{BatchPolicy, ClientPolicy, QueryPolicy, ReadPolicy, ScanPolicy, WritePolicy};
+use crate::{BatchRead, Bin, Bins, CollectionIndexType, IndexType, Key, Record, Recordset, ResultCode, Statement, Value, UDFLang};
 
 /// Instantiate a Client instance to access an Aerospike database cluster and perform database
 /// operations.
@@ -854,9 +842,10 @@ impl Client {
         index_type: IndexType,
         collection_index_type: CollectionIndexType,
     ) -> Result<()> {
-        let cit_str: String = match collection_index_type {
-            CollectionIndexType::Default => "".to_string(),
-            _ => format!("indextype={};", collection_index_type),
+        let cit_str: String = if let CollectionIndexType::Default = collection_index_type { 
+            "".to_string() 
+        } else { 
+            format!("indextype={};", collection_index_type) 
         };
         let cmd = format!(
             "sindex-create:ns={};set={};indexname={};numbins=1;{}indexdata={},{};\
@@ -875,9 +864,10 @@ impl Client {
         set_name: &str,
         index_name: &str,
     ) -> Result<()> {
-        let set_name: String = match set_name {
-            "" => "".to_string(),
-            _ => format!("set={};", set_name),
+        let set_name: String = if let "" = set_name { 
+            "".to_string() 
+        } else { 
+            format!("set={};", set_name) 
         };
         let cmd = format!(
             "sindex-delete:ns={};{}indexname={}",

--- a/src/cluster/mod.rs
+++ b/src/cluster/mod.rs
@@ -35,9 +35,9 @@ use self::node_validator::NodeValidator;
 use self::partition::Partition;
 use self::partition_tokenizer::PartitionTokenizer;
 
-use errors::*;
-use net::Host;
-use policy::ClientPolicy;
+use crate::errors::{ErrorKind, Result};
+use crate::net::Host;
+use crate::policy::ClientPolicy;
 
 // Cluster encapsulates the aerospike cluster nodes and manages
 // them.

--- a/src/cluster/node.rs
+++ b/src/cluster/node.rs
@@ -24,11 +24,11 @@ use std::time::Duration;
 
 use parking_lot::RwLock;
 
-use cluster::node_validator::NodeValidator;
-use commands::Message;
-use errors::*;
-use net::{ConnectionPool, Host, PooledConnection};
-use policy::ClientPolicy;
+use crate::cluster::node_validator::NodeValidator;
+use crate::commands::Message;
+use crate::errors::{ErrorKind, Result, ResultExt};
+use crate::net::{ConnectionPool, Host, PooledConnection};
+use crate::policy::ClientPolicy;
 
 pub const PARTITIONS: usize = 4096;
 

--- a/src/cluster/node_validator.rs
+++ b/src/cluster/node_validator.rs
@@ -16,13 +16,14 @@ use std::net::ToSocketAddrs;
 use std::str;
 use std::vec::Vec;
 
-use cluster::Cluster;
-use commands::Message;
-use errors::*;
-use net::{Connection, Host};
-use policy::ClientPolicy;
+use crate::cluster::Cluster;
+use crate::commands::Message;
+use crate::errors::{ErrorKind, Result, ResultExt};
+use crate::net::{Connection, Host};
+use crate::policy::ClientPolicy;
 
 // Validates a Database server node
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Clone)]
 pub struct NodeValidator {
     pub name: String,

--- a/src/cluster/partition.rs
+++ b/src/cluster/partition.rs
@@ -17,8 +17,8 @@ use std::io::Cursor;
 
 use byteorder::{LittleEndian, ReadBytesExt};
 
-use cluster::node;
-use Key;
+use crate::cluster::node;
+use crate::Key;
 
 // Validates a Database server node
 #[derive(Debug, Clone)]

--- a/src/cluster/partition_tokenizer.rs
+++ b/src/cluster/partition_tokenizer.rs
@@ -18,14 +18,13 @@ use std::str;
 use std::sync::Arc;
 use std::vec::Vec;
 
-use base64;
 use parking_lot::RwLock;
 
-use cluster::node;
-use cluster::Node;
-use commands::Message;
-use errors::*;
-use net::Connection;
+use crate::cluster::node;
+use crate::cluster::Node;
+use crate::commands::Message;
+use crate::errors::{ErrorKind, Result};
+use crate::net::Connection;
 
 const REPLICAS_NAME: &str = "replicas-master";
 

--- a/src/commands/admin_command.rs
+++ b/src/commands/admin_command.rs
@@ -18,12 +18,12 @@ use std::str;
 
 use pwhash::bcrypt::{self, BcryptSetup, BcryptVariant};
 
-use cluster::Cluster;
-use errors::*;
-use net::Connection;
-use net::PooledConnection;
-use policy::AdminPolicy;
-use ResultCode;
+use crate::cluster::Cluster;
+use crate::errors::{ErrorKind, Result};
+use crate::net::Connection;
+use crate::net::PooledConnection;
+use crate::ResultCode;
+use crate::policy::AdminPolicy;
 
 // Commands
 const AUTHENTICATE: u8 = 0;

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -15,14 +15,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::{Cluster, Node};
-use commands::buffer;
-use commands::{Command, SingleCommand};
-use errors::*;
-use net::Connection;
-use policy::WritePolicy;
-use Key;
-use ResultCode;
+use crate::cluster::{Cluster, Node};
+use crate::commands::{Command, SingleCommand, buffer};
+use crate::errors::{ErrorKind, Result};
+use crate::net::Connection;
+use crate::policy::WritePolicy;
+use crate::{ResultCode, Key};
 
 pub struct DeleteCommand<'a> {
     single_command: SingleCommand<'a>,

--- a/src/commands/execute_udf_command.rs
+++ b/src/commands/execute_udf_command.rs
@@ -16,14 +16,12 @@ use std::str;
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::{Cluster, Node};
-use commands::{Command, ReadCommand, SingleCommand};
-use errors::*;
-use net::Connection;
-use policy::WritePolicy;
-use Bins;
-use Key;
-use Value;
+use crate::cluster::{Cluster, Node};
+use crate::commands::{Command, ReadCommand, SingleCommand};
+use crate::errors::Result;
+use crate::net::Connection;
+use crate::policy::WritePolicy;
+use crate::{Value, Key, Bins};
 
 pub struct ExecuteUDFCommand<'a> {
     pub read_command: ReadCommand<'a>,

--- a/src/commands/exists_command.rs
+++ b/src/commands/exists_command.rs
@@ -15,14 +15,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::{Cluster, Node};
-use commands::buffer;
-use commands::{Command, SingleCommand};
-use errors::*;
-use net::Connection;
-use policy::WritePolicy;
-use Key;
-use ResultCode;
+use crate::cluster::{Cluster, Node};
+use crate::commands::{Command, SingleCommand, buffer};
+use crate::errors::{ErrorKind, Result};
+use crate::net::Connection;
+use crate::policy::WritePolicy;
+use crate::{ResultCode, Key};
 
 pub struct ExistsCommand<'a> {
     single_command: SingleCommand<'a>,

--- a/src/commands/info_command.rs
+++ b/src/commands/info_command.rs
@@ -18,8 +18,8 @@ use std::collections::HashMap;
 use std::io::{Cursor, Write};
 use std::str;
 
-use errors::*;
-use net::Connection;
+use crate::errors::Result;
+use crate::net::Connection;
 
 #[derive(Debug, Clone)]
 pub struct Message {
@@ -80,8 +80,8 @@ impl Message {
 
         for tuple in response.split('\n') {
             let mut kv = tuple.split('\t');
-            let key = kv.nth(0);
-            let val = kv.nth(0);
+            let key = kv.next();
+            let val = kv.next();
 
             match (key, val) {
                 (Some(key), Some(val)) => result.insert(key.to_string(), val.to_string()),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,10 +49,10 @@ pub use self::stream_command::StreamCommand;
 pub use self::touch_command::TouchCommand;
 pub use self::write_command::WriteCommand;
 
-use cluster::Node;
-use errors::*;
-use net::Connection;
-use ResultCode;
+use crate::cluster::Node;
+use crate::errors::{Error, ErrorKind, Result};
+use crate::net::Connection;
+use crate::ResultCode;
 
 // Command interface describes all commands available
 pub trait Command {

--- a/src/commands/operate_command.rs
+++ b/src/commands/operate_command.rs
@@ -15,14 +15,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::{Cluster, Node};
-use commands::{Command, ReadCommand, SingleCommand};
-use errors::*;
-use net::Connection;
-use operations::Operation;
-use policy::WritePolicy;
-use Bins;
-use Key;
+use crate::cluster::{Cluster, Node};
+use crate::commands::{Command, ReadCommand, SingleCommand};
+use crate::errors::Result;
+use crate::net::Connection;
+use crate::operations::Operation;
+use crate::policy::WritePolicy;
+use crate::{Key, Bins};
 
 pub struct OperateCommand<'a> {
     pub read_command: ReadCommand<'a>,

--- a/src/commands/query_command.rs
+++ b/src/commands/query_command.rs
@@ -15,13 +15,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::Node;
-use commands::{Command, SingleCommand, StreamCommand};
-use errors::*;
-use net::Connection;
-use policy::QueryPolicy;
-use Recordset;
-use Statement;
+use crate::cluster::Node;
+use crate::commands::{Command, SingleCommand, StreamCommand};
+use crate::errors::Result;
+use crate::net::Connection;
+use crate::policy::QueryPolicy;
+use crate::{Statement, Recordset};
 
 pub struct QueryCommand<'a> {
     stream_command: StreamCommand,

--- a/src/commands/read_command.rs
+++ b/src/commands/read_command.rs
@@ -17,18 +17,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::{Cluster, Node};
-use commands::buffer;
-use commands::{Command, SingleCommand};
-use errors::*;
-use net::Connection;
-use policy::ReadPolicy;
-use value::bytes_to_particle;
-use Bins;
-use Key;
-use Record;
-use ResultCode;
-use Value;
+use crate::cluster::{Cluster, Node};
+use crate::commands::buffer;
+use crate::commands::{Command, SingleCommand};
+use crate::errors::{ErrorKind, Result};
+use crate::net::Connection;
+use crate::policy::ReadPolicy;
+use crate::value::bytes_to_particle;
+use crate::{Bins, Record, Value, ResultCode, Key};
 
 pub struct ReadCommand<'a> {
     pub single_command: SingleCommand<'a>,

--- a/src/commands/scan_command.rs
+++ b/src/commands/scan_command.rs
@@ -16,13 +16,12 @@ use std::str;
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::Node;
-use commands::{Command, SingleCommand, StreamCommand};
-use errors::*;
-use net::Connection;
-use policy::ScanPolicy;
-use Bins;
-use Recordset;
+use crate::cluster::Node;
+use crate::commands::{Command, SingleCommand, StreamCommand};
+use crate::errors::Result;
+use crate::net::Connection;
+use crate::policy::ScanPolicy;
+use crate::{Recordset, Bins};
 
 pub struct ScanCommand<'a> {
     stream_command: StreamCommand,

--- a/src/commands/single_command.rs
+++ b/src/commands/single_command.rs
@@ -16,13 +16,13 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Instant;
 
-use cluster::partition::Partition;
-use cluster::{Cluster, Node};
-use commands::{self, Command};
-use errors::*;
-use net::Connection;
-use policy::Policy;
-use Key;
+use crate::cluster::partition::Partition;
+use crate::cluster::{Cluster, Node};
+use crate::commands::{self};
+use crate::errors::{ErrorKind, Result, ResultExt};
+use crate::net::Connection;
+use crate::policy::Policy;
+use crate::Key;
 
 pub struct SingleCommand<'a> {
     cluster: Arc<Cluster>,
@@ -63,7 +63,7 @@ impl<'a> SingleCommand<'a> {
     // EXECUTE
     //
 
-    pub fn execute(policy: &dyn Policy, cmd: &'a mut dyn Command) -> Result<()> {
+    pub fn execute(policy: &dyn Policy, cmd: &'a mut dyn commands::Command) -> Result<()> {
         let mut iterations = 0;
 
         // set timeout outside the loop

--- a/src/commands/stream_command.rs
+++ b/src/commands/stream_command.rs
@@ -17,18 +17,15 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use cluster::Node;
-use commands::buffer;
-use commands::field_type::FieldType;
-use commands::Command;
-use errors::*;
-use net::Connection;
-use query::Recordset;
-use value::bytes_to_particle;
-use Key;
-use Record;
-use ResultCode;
-use Value;
+use crate::cluster::Node;
+use crate::commands::buffer;
+use crate::commands::field_type::FieldType;
+use crate::commands::Command;
+use crate::errors::{ErrorKind, Result};
+use crate::net::Connection;
+use crate::query::Recordset;
+use crate::value::bytes_to_particle;
+use crate::{Record, Value, ResultCode, Key};
 
 pub struct StreamCommand {
     node: Arc<Node>,

--- a/src/commands/touch_command.rs
+++ b/src/commands/touch_command.rs
@@ -15,14 +15,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::{Cluster, Node};
-use commands::buffer;
-use commands::{Command, SingleCommand};
-use errors::*;
-use net::Connection;
-use policy::WritePolicy;
-use Key;
-use ResultCode;
+use crate::cluster::{Cluster, Node};
+use crate::commands::buffer;
+use crate::commands::{Command, SingleCommand};
+use crate::errors::{ErrorKind, Result};
+use crate::net::Connection;
+use crate::policy::WritePolicy;
+use crate::{ResultCode, Key};
 
 pub struct TouchCommand<'a> {
     single_command: SingleCommand<'a>,

--- a/src/commands/write_command.rs
+++ b/src/commands/write_command.rs
@@ -15,16 +15,14 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use cluster::{Cluster, Node};
-use commands::buffer;
-use commands::{Command, SingleCommand};
-use errors::*;
-use net::Connection;
-use operations::OperationType;
-use policy::WritePolicy;
-use Bin;
-use Key;
-use ResultCode;
+use crate::cluster::{Cluster, Node};
+use crate::commands::buffer;
+use crate::commands::{Command, SingleCommand};
+use crate::errors::{ErrorKind, Result};
+use crate::net::Connection;
+use crate::operations::OperationType;
+use crate::policy::WritePolicy;
+use crate::{Bin, ResultCode, Key};
 
 pub struct WriteCommand<'a, A: 'a> {
     single_command: SingleCommand<'a>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -52,7 +52,7 @@
 
 #![allow(missing_docs)]
 
-use ResultCode;
+use crate::ResultCode;
 
 error_chain! {
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -16,8 +16,8 @@
 use std::fmt;
 use std::result::Result as StdResult;
 
-use errors::*;
-use Value;
+use crate::errors::Result;
+use crate::Value;
 
 use ripemd160::digest::Digest;
 use ripemd160::Ripemd160;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //!
 //! ```text
 //! [dependencies]
-//! aerospike = "0.1.0"
+//! aerospike = "0.4.0"
 //! ```
 //!
 //! # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,8 @@
     clippy::unknown_clippy_lints,
     clippy::unseparated_literal_suffix,
     clippy::unused_self,
-    clippy::use_self
+    clippy::use_self,
+    clippy::missing_errors_doc
 )]
 
 //! A pure-rust client for the Aerospike NoSQL database.

--- a/src/msgpack/decoder.rs
+++ b/src/msgpack/decoder.rs
@@ -16,10 +16,10 @@
 use std::collections::HashMap;
 use std::vec::Vec;
 
-use commands::buffer::Buffer;
-use commands::ParticleType;
-use errors::*;
-use value::*;
+use crate::commands::buffer::Buffer;
+use crate::commands::ParticleType;
+use crate::errors::{ErrorKind, Result};
+use crate::value::Value;
 
 pub fn unpack_value_list(buf: &mut Buffer) -> Result<Value> {
     if buf.data_buffer.is_empty() {

--- a/src/msgpack/encoder.rs
+++ b/src/msgpack/encoder.rs
@@ -17,11 +17,11 @@ use std::collections::HashMap;
 use std::num::Wrapping;
 use std::{i16, i32, i64, i8};
 
-use commands::buffer::Buffer;
-use commands::ParticleType;
-use errors::*;
-use operations::cdt::{CdtArgument, CdtOperation};
-use value::*;
+use crate::commands::buffer::Buffer;
+use crate::commands::ParticleType;
+use crate::errors::Result;
+use crate::operations::cdt::{CdtArgument, CdtOperation};
+use crate::value::{FloatValue, Value};
 
 pub fn pack_value(buf: &mut Option<&mut Buffer>, val: &Value) -> Result<usize> {
     match *val {

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -18,10 +18,10 @@ use std::net::{Shutdown, TcpStream, ToSocketAddrs};
 use std::ops::Add;
 use std::time::{Duration, Instant};
 
-use commands::admin_command::AdminCommand;
-use commands::buffer::Buffer;
-use errors::*;
-use policy::ClientPolicy;
+use crate::commands::admin_command::AdminCommand;
+use crate::commands::buffer::Buffer;
+use crate::errors::Result;
+use crate::policy::ClientPolicy;
 
 #[derive(Debug)]
 pub struct Connection {

--- a/src/net/connection_pool.rs
+++ b/src/net/connection_pool.rs
@@ -21,9 +21,9 @@ use std::time::Duration;
 
 use parking_lot::Mutex;
 
-use errors::*;
-use net::{Connection, Host};
-use policy::ClientPolicy;
+use crate::errors::{Error, ErrorKind, Result};
+use crate::net::{Connection, Host};
+use crate::policy::ClientPolicy;
 
 #[derive(Debug)]
 struct IdleConnection(Connection);

--- a/src/net/host.rs
+++ b/src/net/host.rs
@@ -18,8 +18,8 @@ use std::io;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::vec::IntoIter;
 
-use errors::*;
-use net::parser::Parser;
+use crate::errors::{ErrorKind, Result, ResultExt};
+use crate::net::parser::Parser;
 
 /// Host name/port of database server.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -92,7 +92,7 @@ impl<'a> ToHosts for &'a str {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{Host, ToHosts};
 
     #[test]
     fn to_hosts() {

--- a/src/net/parser.rs
+++ b/src/net/parser.rs
@@ -13,10 +13,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use errors::*;
+use crate::errors::{ErrorKind, Result};
 use std::iter::Peekable;
 use std::str::Chars;
-use Host;
+use crate::Host;
 
 pub struct Parser<'a> {
     s: Peekable<Chars<'a>>,
@@ -106,8 +106,7 @@ impl<'a> Parser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use Host;
+    use super::{Host, Parser};
 
     #[test]
     fn read_addr_part() {

--- a/src/operations/cdt.rs
+++ b/src/operations/cdt.rs
@@ -15,11 +15,11 @@
 
 use std::collections::HashMap;
 
-use commands::buffer::Buffer;
-use commands::ParticleType;
-use errors::*;
-use msgpack::encoder;
-use Value;
+use crate::commands::buffer::Buffer;
+use crate::commands::ParticleType;
+use crate::errors::Result;
+use crate::msgpack::encoder;
+use crate::Value;
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]

--- a/src/operations/lists.rs
+++ b/src/operations/lists.rs
@@ -31,9 +31,9 @@
 //! If an index is out of bounds, a parameter error will be returned. If a range is partially out of
 //! bounds, the valid part of the range will be returned.
 
-use operations::cdt::{CdtArgument, CdtOpType, CdtOperation};
-use operations::{Operation, OperationBin, OperationData, OperationType};
-use Value;
+use crate::operations::cdt::{CdtArgument, CdtOpType, CdtOperation};
+use crate::operations::{Operation, OperationBin, OperationData, OperationType};
+use crate::Value;
 
 /// Create list append operation. Server appends value to the end of list bin. Server returns
 /// list size.

--- a/src/operations/maps.rs
+++ b/src/operations/maps.rs
@@ -42,9 +42,9 @@
 
 use std::collections::HashMap;
 
-use operations::cdt::{CdtArgument, CdtOpType, CdtOperation};
-use operations::{Operation, OperationBin, OperationData, OperationType};
-use Value;
+use crate::operations::cdt::{CdtArgument, CdtOpType, CdtOperation};
+use crate::operations::{Operation, OperationBin, OperationData, OperationType};
+use crate::Value;
 
 /// Map storage order.
 #[derive(Debug, Clone, Copy)]

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -25,10 +25,10 @@ use self::cdt::CdtOperation;
 pub use self::maps::{MapOrder, MapPolicy, MapReturnType, MapWriteMode};
 pub use self::scalar::*;
 
-use commands::buffer::Buffer;
-use commands::ParticleType;
-use errors::*;
-use Value;
+use crate::commands::buffer::Buffer;
+use crate::commands::ParticleType;
+use crate::errors::Result;
+use crate::Value;
 
 #[derive(Debug, Clone, Copy)]
 #[doc(hidden)]

--- a/src/operations/scalar.rs
+++ b/src/operations/scalar.rs
@@ -15,8 +15,8 @@
 
 //! String/number bin operations. Create operations used by the client's `operate()` method.
 
-use operations::*;
-use Bin;
+use crate::operations::{Operation, OperationBin, OperationData, OperationType};
+use crate::Bin;
 
 /// Create read all record bins database operation.
 pub const fn get<'a>() -> Operation<'a> {

--- a/src/policy/batch_policy.rs
+++ b/src/policy/batch_policy.rs
@@ -13,7 +13,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use policy::{BasePolicy, Concurrency, PolicyLike};
+use crate::policy::{BasePolicy, Concurrency, PolicyLike};
 
 /// `BatchPolicy` encapsulates parameters for all batch operations.
 pub struct BatchPolicy {

--- a/src/policy/client_policy.rs
+++ b/src/policy/client_policy.rs
@@ -15,8 +15,8 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use commands::admin_command::AdminCommand;
-use errors::*;
+use crate::commands::admin_command::AdminCommand;
+use crate::errors::Result;
 
 /// `ClientPolicy` encapsulates parameters for client policy command.
 #[derive(Debug, Clone)]

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -14,6 +14,7 @@
 // the License.
 
 //! Policy types encapsulate optional parameters for various client operations.
+#![allow(clippy::missing_errors_doc)]
 
 mod admin_policy;
 mod batch_policy;

--- a/src/policy/query_policy.rs
+++ b/src/policy/query_policy.rs
@@ -13,7 +13,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use policy::{BasePolicy, PolicyLike};
+use crate::policy::{BasePolicy, PolicyLike};
 
 /// `QueryPolicy` encapsulates parameters for query operations.
 #[derive(Debug, Clone)]

--- a/src/policy/read_policy.rs
+++ b/src/policy/read_policy.rs
@@ -13,10 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use policy::BasePolicy;
+use crate::policy::BasePolicy;
 use std::time::Duration;
-use ConsistencyLevel;
-use Priority;
+use crate::{Priority, ConsistencyLevel};
 
 /// `ReadPolicy` excapsulates parameters for transaction policy attributes
 /// used in all database operation calls.

--- a/src/policy/scan_policy.rs
+++ b/src/policy/scan_policy.rs
@@ -13,7 +13,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use policy::{BasePolicy, PolicyLike};
+use crate::policy::{BasePolicy, PolicyLike};
 
 /// `ScanPolicy` encapsulates optional parameters used in scan operations.
 #[derive(Debug, Clone)]

--- a/src/policy/write_policy.rs
+++ b/src/policy/write_policy.rs
@@ -13,11 +13,8 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use policy::{BasePolicy, PolicyLike};
-use CommitLevel;
-use Expiration;
-use GenerationPolicy;
-use RecordExistsAction;
+use crate::policy::{BasePolicy, PolicyLike};
+use crate::{CommitLevel, Expiration, GenerationPolicy, RecordExistsAction};
 
 /// `WritePolicy` encapsulates parameters for all write operations.
 pub struct WritePolicy {

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -13,11 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use commands::buffer::Buffer;
-use commands::ParticleType;
-use errors::*;
-use CollectionIndexType;
-use Value;
+use crate::commands::{buffer::Buffer, ParticleType};
+use crate::errors::Result;
+use crate::{Value, CollectionIndexType};
 
 /// Query filter definition. Currently, only one filter is allowed in a Statement, and must be on a
 /// bin which has a secondary index defined.
@@ -246,7 +244,7 @@ macro_rules! as_regions_containing_point {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::CollectionIndexType;
 
     #[test]
     fn geo_filter_macros() {

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -14,6 +14,7 @@
 // the License.
 
 //! Types and methods used for database queries and scans.
+#![allow(clippy::missing_errors_doc)]
 
 pub use self::filter::Filter;
 pub use self::index_types::{CollectionIndexType, IndexType};

--- a/src/query/recordset.rs
+++ b/src/query/recordset.rs
@@ -21,8 +21,8 @@ use std::thread;
 use crossbeam_queue::SegQueue;
 use rand::Rng;
 
-use errors::*;
-use Record;
+use crate::errors::Result;
+use crate::Record;
 
 /// Virtual collection of records retrieved through queries and scans. During a query/scan,
 /// multiple threads will retrieve records from the server nodes and put these records on an

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -13,10 +13,10 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use errors::*;
-use query::Filter;
-use Bins;
-use Value;
+use crate::errors::{ErrorKind, Result};
+use crate::query::Filter;
+use crate::Bins;
+use crate::Value;
 
 #[derive(Clone)]
 pub struct Aggregation {

--- a/src/record.rs
+++ b/src/record.rs
@@ -17,8 +17,8 @@ use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use Key;
-use Value;
+use crate::Key;
+use crate::Value;
 
 lazy_static! {
   // Fri Jan  1 00:00:00 UTC 2010
@@ -98,7 +98,7 @@ impl fmt::Display for Record {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{CITRUSLEAF_EPOCH, Record};
     use std::collections::HashMap;
     use std::time::{Duration, SystemTime};
 

--- a/src/result_code.rs
+++ b/src/result_code.rs
@@ -377,7 +377,7 @@ impl fmt::Display for ResultCode {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::ResultCode;
 
     #[test]
     fn from_result_code() {

--- a/src/value.rs
+++ b/src/value.rs
@@ -26,10 +26,10 @@ use ripemd160::Ripemd160;
 
 use std::vec::Vec;
 
-use commands::buffer::Buffer;
-use commands::ParticleType;
-use errors::*;
-use msgpack::{decoder, encoder};
+use crate::commands::buffer::Buffer;
+use crate::commands::ParticleType;
+use crate::errors::Result;
+use crate::msgpack::{decoder, encoder};
 
 /// Container for floating point bin values stored in the Aerospike database.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -708,7 +708,7 @@ macro_rules! as_map {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::Value;
 
     #[test]
     fn as_string() {

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -13,7 +13,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-extern crate aerospike;
 extern crate env_logger;
 #[macro_use]
 extern crate lazy_static;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -12,9 +12,6 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
-#[macro_use]
-extern crate aerospike;
 extern crate env_logger;
 #[macro_use]
 extern crate lazy_static;

--- a/tests/src/batch.rs
+++ b/tests/src/batch.rs
@@ -15,11 +15,11 @@
 
 use aerospike::BatchRead;
 use aerospike::Bins;
-use aerospike::{BatchPolicy, Concurrency, WritePolicy};
+use aerospike::{BatchPolicy, Concurrency, WritePolicy, as_bin, as_key};
 
 use env_logger;
 
-use common;
+use crate::common;
 
 #[test]
 fn batch_get() {

--- a/tests/src/cdt_list.rs
+++ b/tests/src/cdt_list.rs
@@ -13,12 +13,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use common;
+use crate::common;
 use env_logger;
 
 use aerospike::operations;
 use aerospike::operations::lists;
-use aerospike::{Bins, ReadPolicy, Value, WritePolicy};
+use aerospike::{Bins, ReadPolicy, Value, WritePolicy, as_key, as_list, as_bin, as_values, as_val};
 
 #[test]
 fn cdt_list() {

--- a/tests/src/cdt_map.rs
+++ b/tests/src/cdt_map.rs
@@ -15,11 +15,11 @@
 
 use std::collections::HashMap;
 
-use common;
+use crate::common;
 use env_logger;
 
 use aerospike::operations::maps;
-use aerospike::{Bins, MapPolicy, MapReturnType, ReadPolicy, WritePolicy};
+use aerospike::{Bins, MapPolicy, MapReturnType, ReadPolicy, WritePolicy, as_list, as_val, as_key, as_map, as_bin};
 
 #[test]
 fn map_operations() {

--- a/tests/src/index.rs
+++ b/tests/src/index.rs
@@ -16,7 +16,7 @@
 use std::thread;
 use std::time::Duration;
 
-use common;
+use crate::common;
 use env_logger;
 
 use aerospike::*;

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -12,15 +12,13 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-
 use std::collections::HashMap;
-
 use aerospike::operations;
-use aerospike::{Bins, ReadPolicy, Value, WritePolicy};
+use aerospike::{Bins, ReadPolicy, Value, WritePolicy, as_map, as_geo, as_val, as_list, as_blob, as_key, as_bin};
 
 use env_logger;
 
-use common;
+use crate::common;
 
 #[test]
 fn connect() {

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
-use common;
+use crate::common;
 use env_logger;
 
 use aerospike::*;

--- a/tests/src/scan.rs
+++ b/tests/src/scan.rs
@@ -17,10 +17,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
 
-use common;
+use crate::common;
 use env_logger;
 
-use aerospike::{Bins, ScanPolicy, WritePolicy};
+use aerospike::{Bins, ScanPolicy, WritePolicy, as_key, as_bin};
 
 const EXPECTED: usize = 1000;
 

--- a/tests/src/truncate.rs
+++ b/tests/src/truncate.rs
@@ -15,7 +15,7 @@
 
 use aerospike::WritePolicy;
 
-use common;
+use crate::common;
 use env_logger;
 
 #[test]

--- a/tests/src/udf.rs
+++ b/tests/src/udf.rs
@@ -16,13 +16,13 @@
 use std::thread;
 use std::time::Duration;
 
-use common;
+use crate::common;
 use env_logger;
 
 use aerospike::UDFLang;
 use aerospike::Value;
 use aerospike::WritePolicy;
-use aerospike::{Error, ErrorKind};
+use aerospike::{Error, ErrorKind, as_key, as_bin, as_val};
 
 #[test]
 fn execute_udf() {

--- a/tools/benchmark/src/stats.rs
+++ b/tools/benchmark/src/stats.rs
@@ -275,9 +275,9 @@ mod test {
             hist.add(Duration::from_millis(i), status);
         }
         assert_eq!(hist.buckets, [1, 1, 2, 4, 2, 0]);
-        assert_eq!(hist.min, 0.0);
-        assert_eq!(hist.max, 9.0);
-        assert_eq!(hist.sum, 45.0);
+        assert_eq!(hist.min, 0);
+        assert_eq!(hist.max, 9);
+        assert_eq!(hist.sum, 45);
         assert_eq!(hist.count, 10);
         assert_eq!(hist.errors, 3);
         assert_eq!(hist.timeouts, 3);
@@ -310,8 +310,8 @@ mod test {
 
         hist1.merge(hist2);
         assert_eq!(hist1.buckets, [1, 1, 4, 8, 2, 0]);
-        assert_eq!(hist1.min, 0.0);
-        assert_eq!(hist1.max, 9.0);
+        assert_eq!(hist1.min, 0);
+        assert_eq!(hist1.max, 9);
         assert_eq!(hist1.timeouts, 3);
         assert_eq!(hist1.errors, 2);
     }


### PR DESCRIPTION
- Move to rust edition 2018
- Removing most of `clippy` warnings.