### PR TITLE
Update min. Rust version to 1.38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.34.0
+  - 1.38.0
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
gimli@0.21.0 requires Rust v1.38 or later. It was added as a dependency
through error-chain@0.12.2.