### PR TITLE
Support for Predicate Filtering

### DIFF
--- a/benches/client_server.rs
+++ b/benches/client_server.rs
@@ -21,8 +21,8 @@ extern crate rand;
 
 use aerospike::{Bins, ReadPolicy, WritePolicy};
 
-use bencher::Bencher;
 use aerospike::{as_bin, as_key};
+use bencher::Bencher;
 
 #[path = "../tests/common/mod.rs"]
 mod common;

--- a/src/commands/admin_command.rs
+++ b/src/commands/admin_command.rs
@@ -22,8 +22,8 @@ use crate::cluster::Cluster;
 use crate::errors::{ErrorKind, Result};
 use crate::net::Connection;
 use crate::net::PooledConnection;
-use crate::ResultCode;
 use crate::policy::AdminPolicy;
+use crate::ResultCode;
 
 // Commands
 const AUTHENTICATE: u8 = 0;

--- a/src/commands/batch_read_command.rs
+++ b/src/commands/batch_read_command.rs
@@ -23,7 +23,7 @@ use crate::commands::{self, Command};
 use crate::errors::{ErrorKind, Result, ResultExt};
 use crate::net::Connection;
 use crate::policy::{BatchPolicy, Policy, PolicyLike};
-use crate::{BatchRead, Record, ResultCode, Value, value};
+use crate::{value, BatchRead, Record, ResultCode, Value};
 
 struct BatchRecord {
     batch_index: usize,

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -26,8 +26,8 @@ use crate::policy::{
     BatchPolicy, CommitLevel, ConsistencyLevel, GenerationPolicy, QueryPolicy, ReadPolicy,
     RecordExistsAction, ScanPolicy, WritePolicy,
 };
-use crate::{BatchRead, Bin, Bins, CollectionIndexType, Key, Statement, Value};
 use crate::query::predexp::PredExp;
+use crate::{BatchRead, Bin, Bins, CollectionIndexType, Key, Statement, Value};
 use std::sync::Arc;
 
 // Contains a read operation.
@@ -782,13 +782,12 @@ impl Buffer {
         self.end()
     }
 
-    fn estimate_predexp_size(&mut self, predexp: &[Arc<Box<dyn PredExp>>]) -> usize{
+    fn estimate_predexp_size(&mut self, predexp: &[Arc<Box<dyn PredExp>>]) -> usize {
         let mut size: usize = 0;
-        for pred in predexp{
-
+        for pred in predexp {
             size += pred.marshaled_size();
         }
-        return size
+        return size;
     }
 
     fn estimate_key_size(&mut self, key: &Key, send_key: bool) -> Result<u16> {
@@ -1010,7 +1009,7 @@ impl Buffer {
         Ok(())
     }
 
-    fn write_predexp(&mut self, predexp: &[Arc<Box<dyn PredExp>>], size: usize) -> Result<()>{
+    fn write_predexp(&mut self, predexp: &[Arc<Box<dyn PredExp>>], size: usize) -> Result<()> {
         self.write_field_header(size, FieldType::Predicate)?;
         for pred in predexp {
             pred.write(self)?;

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -27,6 +27,8 @@ use crate::policy::{
     RecordExistsAction, ScanPolicy, WritePolicy,
 };
 use crate::{BatchRead, Bin, Bins, CollectionIndexType, Key, Statement, Value};
+use crate::query::predexp::PredExp;
+use std::sync::Arc;
 
 // Contains a read operation.
 const INFO1_READ: u8 = 1;
@@ -595,6 +597,7 @@ impl Buffer {
         let mut field_count = 0;
         let mut filter_size = 0;
         let mut bin_name_size = 0;
+        let mut pred_size = 0;
 
         if statement.namespace != "" {
             self.data_offset += statement.namespace.len() + FIELD_HEADER_SIZE as usize;
@@ -611,6 +614,12 @@ impl Buffer {
                 self.data_offset += index_name.len() + FIELD_HEADER_SIZE as usize;
                 field_count += 1;
             }
+        }
+
+        if statement.predexp.len() > 0 {
+            pred_size += self.estimate_predexp_size(statement.predexp.clone());
+            self.data_offset += pred_size + FIELD_HEADER_SIZE as usize;
+            field_count += 1;
         }
 
         // Allocate space for TaskId field.
@@ -740,6 +749,10 @@ impl Buffer {
             self.write_u8(100)?;
         }
 
+        if statement.predexp.len() > 0 {
+            self.write_predexp(&statement.predexp, pred_size)?;
+        }
+
         if let Some(ref aggregation) = statement.aggregation {
             self.write_field_header(1, FieldType::UdfOp)?;
             if statement.bins.is_none() {
@@ -767,6 +780,15 @@ impl Buffer {
         }
 
         self.end()
+    }
+
+    fn estimate_predexp_size(&mut self, predexp: Vec<Arc<Box<dyn PredExp>>>) -> usize{
+        let mut size: usize = 0;
+        for pred in &predexp{
+
+            size += pred.marshaled_size();
+        }
+        return size
     }
 
     fn estimate_key_size(&mut self, key: &Key, send_key: bool) -> Result<u16> {
@@ -984,6 +1006,15 @@ impl Buffer {
         self.write_field_header(value.estimate_size()? + 1, ftype)?;
         self.write_u8(value.particle_type() as u8)?;
         value.write_to(self)?;
+
+        Ok(())
+    }
+
+    fn write_predexp(&mut self, predexp: &Vec<Arc<Box<dyn PredExp>>>, size: usize) -> Result<()>{
+        self.write_field_header(size, FieldType::Predicate)?;
+        for pred in predexp.iter() {
+            pred.write(self)?;
+        }
 
         Ok(())
     }

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -750,7 +750,7 @@ impl Buffer {
         }
 
         if statement.predexp.len() > 0 {
-            self.write_predexp(&statement.predexp, pred_size)?;
+            self.write_predexp(statement.predexp.as_slice(), pred_size)?;
         }
 
         if let Some(ref aggregation) = statement.aggregation {
@@ -1010,9 +1010,9 @@ impl Buffer {
         Ok(())
     }
 
-    fn write_predexp(&mut self, predexp: &Vec<Arc<Box<dyn PredExp>>>, size: usize) -> Result<()>{
+    fn write_predexp(&mut self, predexp: &[Arc<Box<dyn PredExp>>], size: usize) -> Result<()>{
         self.write_field_header(size, FieldType::Predicate)?;
-        for pred in predexp.iter() {
+        for pred in predexp {
             pred.write(self)?;
         }
 

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -617,7 +617,7 @@ impl Buffer {
         }
 
         if statement.predexp.len() > 0 {
-            pred_size += self.estimate_predexp_size(statement.predexp.clone());
+            pred_size += self.estimate_predexp_size(statement.predexp.as_slice());
             self.data_offset += pred_size + FIELD_HEADER_SIZE as usize;
             field_count += 1;
         }
@@ -782,9 +782,9 @@ impl Buffer {
         self.end()
     }
 
-    fn estimate_predexp_size(&mut self, predexp: Vec<Arc<Box<dyn PredExp>>>) -> usize{
+    fn estimate_predexp_size(&mut self, predexp: &[Arc<Box<dyn PredExp>>]) -> usize{
         let mut size: usize = 0;
-        for pred in &predexp{
+        for pred in predexp{
 
             size += pred.marshaled_size();
         }

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -20,12 +20,13 @@ use byteorder::{ByteOrder, NetworkEndian};
 use crate::batch::batch_executor::SharedSlice;
 use crate::commands::field_type::FieldType;
 use crate::errors::Result;
+use crate::msgpack::encoder;
+use crate::operations::{Operation, OperationBin, OperationData, OperationType};
 use crate::policy::{
     BatchPolicy, CommitLevel, ConsistencyLevel, GenerationPolicy, QueryPolicy, ReadPolicy,
-    RecordExistsAction, ScanPolicy, WritePolicy};
-use crate::{Key, Value, Statement, CollectionIndexType, Bins, Bin, BatchRead}; 
-use crate::operations::{Operation, OperationBin, OperationData, OperationType};
-use crate::msgpack::encoder;
+    RecordExistsAction, ScanPolicy, WritePolicy,
+};
+use crate::{BatchRead, Bin, Bins, CollectionIndexType, Key, Statement, Value};
 
 // Contains a read operation.
 const INFO1_READ: u8 = 1;

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -1012,6 +1012,7 @@ impl Buffer {
     fn write_predexp(&mut self, predexp: &[Arc<Box<dyn PredExp>>], size: usize) -> Result<()> {
         self.write_field_header(size, FieldType::Predicate)?;
         for pred in predexp {
+            // PredExp structs hold their own write function, varying on the predexp type.
             pred.write(self)?;
         }
 

--- a/src/commands/delete_command.rs
+++ b/src/commands/delete_command.rs
@@ -16,11 +16,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::cluster::{Cluster, Node};
-use crate::commands::{Command, SingleCommand, buffer};
+use crate::commands::{buffer, Command, SingleCommand};
 use crate::errors::{ErrorKind, Result};
 use crate::net::Connection;
 use crate::policy::WritePolicy;
-use crate::{ResultCode, Key};
+use crate::{Key, ResultCode};
 
 pub struct DeleteCommand<'a> {
     single_command: SingleCommand<'a>,

--- a/src/commands/execute_udf_command.rs
+++ b/src/commands/execute_udf_command.rs
@@ -21,7 +21,7 @@ use crate::commands::{Command, ReadCommand, SingleCommand};
 use crate::errors::Result;
 use crate::net::Connection;
 use crate::policy::WritePolicy;
-use crate::{Value, Key, Bins};
+use crate::{Bins, Key, Value};
 
 pub struct ExecuteUDFCommand<'a> {
     pub read_command: ReadCommand<'a>,

--- a/src/commands/exists_command.rs
+++ b/src/commands/exists_command.rs
@@ -16,11 +16,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::cluster::{Cluster, Node};
-use crate::commands::{Command, SingleCommand, buffer};
+use crate::commands::{buffer, Command, SingleCommand};
 use crate::errors::{ErrorKind, Result};
 use crate::net::Connection;
 use crate::policy::WritePolicy;
-use crate::{ResultCode, Key};
+use crate::{Key, ResultCode};
 
 pub struct ExistsCommand<'a> {
     single_command: SingleCommand<'a>,

--- a/src/commands/field_type.rs
+++ b/src/commands/field_type.rs
@@ -40,5 +40,5 @@ pub enum FieldType {
     QueryBinList = 40,
     BatchIndex = 41,
     BatchIndexWithSet = 42,
-    Predicate = 43
+    Predicate = 43,
 }

--- a/src/commands/field_type.rs
+++ b/src/commands/field_type.rs
@@ -40,4 +40,5 @@ pub enum FieldType {
     QueryBinList = 40,
     BatchIndex = 41,
     BatchIndexWithSet = 42,
+    Predicate = 43
 }

--- a/src/commands/operate_command.rs
+++ b/src/commands/operate_command.rs
@@ -21,7 +21,7 @@ use crate::errors::Result;
 use crate::net::Connection;
 use crate::operations::Operation;
 use crate::policy::WritePolicy;
-use crate::{Key, Bins};
+use crate::{Bins, Key};
 
 pub struct OperateCommand<'a> {
     pub read_command: ReadCommand<'a>,

--- a/src/commands/query_command.rs
+++ b/src/commands/query_command.rs
@@ -20,7 +20,7 @@ use crate::commands::{Command, SingleCommand, StreamCommand};
 use crate::errors::Result;
 use crate::net::Connection;
 use crate::policy::QueryPolicy;
-use crate::{Statement, Recordset};
+use crate::{Recordset, Statement};
 
 pub struct QueryCommand<'a> {
     stream_command: StreamCommand,

--- a/src/commands/read_command.rs
+++ b/src/commands/read_command.rs
@@ -24,7 +24,7 @@ use crate::errors::{ErrorKind, Result};
 use crate::net::Connection;
 use crate::policy::ReadPolicy;
 use crate::value::bytes_to_particle;
-use crate::{Bins, Record, Value, ResultCode, Key};
+use crate::{Bins, Key, Record, ResultCode, Value};
 
 pub struct ReadCommand<'a> {
     pub single_command: SingleCommand<'a>,

--- a/src/commands/scan_command.rs
+++ b/src/commands/scan_command.rs
@@ -21,7 +21,7 @@ use crate::commands::{Command, SingleCommand, StreamCommand};
 use crate::errors::Result;
 use crate::net::Connection;
 use crate::policy::ScanPolicy;
-use crate::{Recordset, Bins};
+use crate::{Bins, Recordset};
 
 pub struct ScanCommand<'a> {
     stream_command: StreamCommand,

--- a/src/commands/stream_command.rs
+++ b/src/commands/stream_command.rs
@@ -25,7 +25,7 @@ use crate::errors::{ErrorKind, Result};
 use crate::net::Connection;
 use crate::query::Recordset;
 use crate::value::bytes_to_particle;
-use crate::{Record, Value, ResultCode, Key};
+use crate::{Key, Record, ResultCode, Value};
 
 pub struct StreamCommand {
     node: Arc<Node>,

--- a/src/commands/touch_command.rs
+++ b/src/commands/touch_command.rs
@@ -21,7 +21,7 @@ use crate::commands::{Command, SingleCommand};
 use crate::errors::{ErrorKind, Result};
 use crate::net::Connection;
 use crate::policy::WritePolicy;
-use crate::{ResultCode, Key};
+use crate::{Key, ResultCode};
 
 pub struct TouchCommand<'a> {
     single_command: SingleCommand<'a>,

--- a/src/commands/write_command.rs
+++ b/src/commands/write_command.rs
@@ -22,7 +22,7 @@ use crate::errors::{ErrorKind, Result};
 use crate::net::Connection;
 use crate::operations::OperationType;
 use crate::policy::WritePolicy;
-use crate::{Bin, ResultCode, Key};
+use crate::{Bin, Key, ResultCode};
 
 pub struct WriteCommand<'a, A: 'a> {
     single_command: SingleCommand<'a>,

--- a/src/net/parser.rs
+++ b/src/net/parser.rs
@@ -14,9 +14,9 @@
 // the License.
 
 use crate::errors::{ErrorKind, Result};
+use crate::Host;
 use std::iter::Peekable;
 use std::str::Chars;
-use crate::Host;
 
 pub struct Parser<'a> {
     s: Peekable<Chars<'a>>,

--- a/src/policy/read_policy.rs
+++ b/src/policy/read_policy.rs
@@ -14,8 +14,8 @@
 // the License.
 
 use crate::policy::BasePolicy;
+use crate::{ConsistencyLevel, Priority};
 use std::time::Duration;
-use crate::{Priority, ConsistencyLevel};
 
 /// `ReadPolicy` excapsulates parameters for transaction policy attributes
 /// used in all database operation calls.

--- a/src/query/filter.rs
+++ b/src/query/filter.rs
@@ -15,7 +15,7 @@
 
 use crate::commands::{buffer::Buffer, ParticleType};
 use crate::errors::Result;
-use crate::{Value, CollectionIndexType};
+use crate::{CollectionIndexType, Value};
 
 /// Query filter definition. Currently, only one filter is allowed in a Statement, and must be on a
 /// bin which has a secondary index defined.

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -22,8 +22,12 @@ pub use self::recordset::Recordset;
 pub use self::statement::Statement;
 pub use self::udf::UDFLang;
 
+// Predicates
+pub use self::predexp::PredExpAnd;
+
 mod filter;
 mod index_types;
 mod recordset;
 mod statement;
 mod udf;
+mod predexp;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -18,10 +18,10 @@
 
 pub use self::filter::Filter;
 pub use self::index_types::{CollectionIndexType, IndexType};
+pub use self::predexp::*;
 pub use self::recordset::Recordset;
 pub use self::statement::Statement;
 pub use self::udf::UDFLang;
-pub use self::predexp::*;
 
 mod filter;
 mod index_types;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -21,13 +21,12 @@ pub use self::index_types::{CollectionIndexType, IndexType};
 pub use self::recordset::Recordset;
 pub use self::statement::Statement;
 pub use self::udf::UDFLang;
-
-// Predicates
-pub use self::predexp::PredExpAnd;
+pub use self::predexp::*;
 
 mod filter;
 mod index_types;
-mod predexp;
+/// Predicate Filtering
+pub mod predexp;
 mod recordset;
 mod statement;
 mod udf;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -27,7 +27,7 @@ pub use self::predexp::PredExpAnd;
 
 mod filter;
 mod index_types;
+mod predexp;
 mod recordset;
 mod statement;
 mod udf;
-mod predexp;

--- a/src/query/predexp.rs
+++ b/src/query/predexp.rs
@@ -1,52 +1,80 @@
 use crate::commands::buffer::Buffer;
 use crate::errors::Result;
 
-const _AS_PREDEXP_UNKNOWN_BIN: u16 = u16::max_value();
+#[doc(hidden)]
+pub const _AS_PREDEXP_UNKNOWN_BIN: u16 = u16::max_value();
+#[doc(hidden)]
+pub const _AS_PREDEXP_AND: u16 = 1;
+#[doc(hidden)]
+pub const _AS_PREDEXP_OR: u16 = 2;
+#[doc(hidden)]
+pub const _AS_PREDEXP_NOT: u16 = 3;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_VALUE: u16 = 10;
+#[doc(hidden)]
+pub const _AS_PREDEXP_STRING_VALUE: u16 = 11;
+#[doc(hidden)]
+pub const _AS_PREDEXP_GEOJSON_VALUE: u16 = 12;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_BIN: u16 = 100;
+#[doc(hidden)]
+pub const _AS_PREDEXP_STRING_BIN: u16 = 101;
+#[doc(hidden)]
+pub const _AS_PREDEXP_GEOJSON_BIN: u16 = 102;
+#[doc(hidden)]
+pub const _AS_PREDEXP_LIST_BIN: u16 = 103;
+#[doc(hidden)]
+pub const _AS_PREDEXP_MAP_BIN: u16 = 104;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_VAR: u16 = 120;
+#[doc(hidden)]
+pub const _AS_PREDEXP_STRING_VAR: u16 = 121;
+#[doc(hidden)]
+pub const _AS_PREDEXP_GEOJSON_VAR: u16 = 122;
+#[doc(hidden)]
+pub const _AS_PREDEXP_REC_DEVICE_SIZE: u16 = 150;
+#[doc(hidden)]
+pub const _AS_PREDEXP_REC_LAST_UPDATE: u16 = 151;
+#[doc(hidden)]
+pub const _AS_PREDEXP_REC_VOID_TIME: u16 = 152;
+#[doc(hidden)]
+pub const _AS_PREDEXP_REC_DIGEST_MODULO: u16 = 153;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_EQUAL: u16 = 200;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_UNEQUAL: u16 = 201;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_GREATER: u16 = 202;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_GREATEREQ: u16 = 203;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_LESS: u16 = 204;
+#[doc(hidden)]
+pub const _AS_PREDEXP_INTEGER_LESSEQ: u16 = 205;
+#[doc(hidden)]
+pub const _AS_PREDEXP_STRING_EQUAL: u16 = 210;
+#[doc(hidden)]
+pub const _AS_PREDEXP_STRING_UNEQUAL: u16 = 211;
+#[doc(hidden)]
+pub const _AS_PREDEXP_STRING_REGEX: u16 = 212;
+#[doc(hidden)]
+pub const _AS_PREDEXP_GEOJSON_WITHIN: u16 = 220;
+#[doc(hidden)]
+pub const _AS_PREDEXP_GEOJSON_CONTAINS: u16 = 221;
+#[doc(hidden)]
+pub const _AS_PREDEXP_LIST_ITERATE_OR: u16 = 250;
+#[doc(hidden)]
+pub const _AS_PREDEXP_MAPKEY_ITERATE_OR: u16 = 251;
+#[doc(hidden)]
+pub const _AS_PREDEXP_MAPVAL_ITERATE_OR: u16 = 252;
+#[doc(hidden)]
+pub const _AS_PREDEXP_LIST_ITERATE_AND: u16 = 253;
+#[doc(hidden)]
+pub const _AS_PREDEXP_MAPKEY_ITERATE_AND: u16 = 254;
+#[doc(hidden)]
+pub const _AS_PREDEXP_MAPVAL_ITERATE_AND: u16 = 255;
 
-const _AS_PREDEXP_AND: u16 = 1;
-const _AS_PREDEXP_OR: u16 = 2;
-const _AS_PREDEXP_NOT: u16 = 3;
-
-const _AS_PREDEXP_INTEGER_VALUE: u16 = 10;
-const _AS_PREDEXP_STRING_VALUE: u16 = 11;
-const _AS_PREDEXP_GEOJSON_VALUE: u16 = 12;
-
-const _AS_PREDEXP_INTEGER_BIN: u16 = 100;
-const _AS_PREDEXP_STRING_BIN: u16 = 101;
-const _AS_PREDEXP_GEOJSON_BIN: u16 = 102;
-const _AS_PREDEXP_LIST_BIN: u16 = 103;
-const _AS_PREDEXP_MAP_BIN: u16 = 104;
-
-const _AS_PREDEXP_INTEGER_VAR: u16 = 120;
-const _AS_PREDEXP_STRING_VAR: u16 = 121;
-const _AS_PREDEXP_GEOJSON_VAR: u16 = 122;
-
-const _AS_PREDEXP_REC_DEVICE_SIZE: u16 = 150;
-const _AS_PREDEXP_REC_LAST_UPDATE: u16 = 151;
-const _AS_PREDEXP_REC_VOID_TIME: u16 = 152;
-const _AS_PREDEXP_REC_DIGEST_MODULO: u16 = 153;
-
-const _AS_PREDEXP_INTEGER_EQUAL: u16 = 200;
-const _AS_PREDEXP_INTEGER_UNEQUAL: u16 = 201;
-const _AS_PREDEXP_INTEGER_GREATER: u16 = 202;
-const _AS_PREDEXP_INTEGER_GREATEREQ: u16 = 203;
-const _AS_PREDEXP_INTEGER_LESS: u16 = 204;
-const _AS_PREDEXP_INTEGER_LESSEQ: u16 = 205;
-
-const _AS_PREDEXP_STRING_EQUAL: u16 = 210;
-const _AS_PREDEXP_STRING_UNEQUAL: u16 = 211;
-const _AS_PREDEXP_STRING_REGEX: u16 = 212;
-
-const _AS_PREDEXP_GEOJSON_WITHIN: u16 = 220;
-const _AS_PREDEXP_GEOJSON_CONTAINS: u16 = 221;
-
-const _AS_PREDEXP_LIST_ITERATE_OR: u16 = 250;
-const _AS_PREDEXP_MAPKEY_ITERATE_OR: u16 = 251;
-const _AS_PREDEXP_MAPVAL_ITERATE_OR: u16 = 252;
-const _AS_PREDEXP_LIST_ITERATE_AND: u16 = 253;
-const _AS_PREDEXP_MAPKEY_ITERATE_AND: u16 = 254;
-const _AS_PREDEXP_MAPVAL_ITERATE_AND: u16 = 255;
-
+#[doc(hidden)]
 pub trait PredExp: Send + Sync {
     fn pred_string(&self) -> String;
     fn marshaled_size(&self) -> usize;
@@ -76,8 +104,9 @@ impl PredExpBase {
 /// Predicate for And
 #[derive(Debug, Clone)]
 pub struct PredExpAnd {
-    pred_exp_base: PredExpBase,
     #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Number of Predicates
     pub nexpr: u16,
 }
 
@@ -113,8 +142,9 @@ macro_rules! as_pred_and {
 /// Predicate for Or
 #[derive(Debug, Clone)]
 pub struct PredExpOr {
-    pred_exp_base: PredExpBase,
     #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Number of Predicates
     pub nexpr: u16,
 }
 
@@ -150,7 +180,8 @@ macro_rules! as_pred_or {
 /// Predicate for Negation
 #[derive(Debug, Clone)]
 pub struct PredExpNot {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
 }
 
 impl PredExp for PredExpNot {
@@ -183,7 +214,9 @@ macro_rules! as_pred_not {
 /// Predicate for Integer Values
 #[derive(Debug, Clone)]
 pub struct PredExpIntegerValue {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Value
     pub val: i64,
 }
 
@@ -220,7 +253,9 @@ macro_rules! as_pred_int_val {
 /// Predicate for Integer Values
 #[derive(Debug, Clone)]
 pub struct PredExpStringValue {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Value
     pub val: String,
 }
 
@@ -257,7 +292,9 @@ macro_rules! as_pred_str_val {
 /// Predicate for GeoJSON Values
 #[derive(Debug, Clone)]
 pub struct PredExpGeoJSONValue {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Value
     pub val: String,
 }
 
@@ -302,8 +339,11 @@ macro_rules! as_pred_geojson_val {
 /// Predicate for Bins
 #[derive(Debug, Clone)]
 pub struct PredExpBin {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Bin Name
     pub name: String,
+    /// Bin Type
     pub tag: u16,
 }
 
@@ -401,8 +441,11 @@ macro_rules! as_pred_map_bin {
 /// Predicate for Vars
 #[derive(Debug, Clone)]
 pub struct PredExpVar {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Var Name
     pub name: String,
+    /// Var Type
     pub tag: u16,
 }
 
@@ -464,7 +507,9 @@ macro_rules! as_pred_geojson_var {
 /// Predicate for MetaData (RecDeviceSize, RecLastUpdate, RecVoidTime)
 #[derive(Debug, Clone)]
 pub struct PredExpMD {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Predicate Type
     pub tag: u16, // not marshaled
 }
 
@@ -530,7 +575,9 @@ macro_rules! as_pred_rec_void_time {
 // This predicate is available in Aerospike server versions 3.12.1+
 #[derive(Debug, Clone)]
 pub struct PredExpMDDigestModulo {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Modulo
     pub modulo: i32, // not marshaled
 }
 
@@ -567,7 +614,9 @@ macro_rules! as_pred_rec_digest_modulo {
 /// Predicate for comparing
 #[derive(Debug, Clone)]
 pub struct PredExpCompare {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Compare Type
     pub tag: u16, // not marshaled
 }
 
@@ -712,7 +761,9 @@ macro_rules! as_pred_geojson_contains {
 /// Predicate for String Regex
 #[derive(Debug, Clone)]
 pub struct PredExpStringRegex {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Flags
     pub cflags: u32, // not marshaled
 }
 
@@ -749,8 +800,11 @@ macro_rules! as_pred_string_regex {
 /// Predicate for Iterators
 #[derive(Debug, Clone)]
 pub struct PredExpIter {
-    pred_exp_base: PredExpBase,
+    #[doc(hidden)]
+    pub pred_exp_base: PredExpBase,
+    /// Name
     pub name: String,
+    /// Iter Type
     pub tag: u16, // not marshaled
 }
 

--- a/src/query/predexp.rs
+++ b/src/query/predexp.rs
@@ -128,7 +128,7 @@ impl PredExp for PredExpAnd {
 
 /// Create "AND" Predicate
 #[macro_export]
-macro_rules! as_pred_and {
+macro_rules! as_predexp_and {
     ($nexpr:expr) => {{
         $crate::query::predexp::PredExpAnd {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -166,7 +166,7 @@ impl PredExp for PredExpOr {
 
 /// Create "OR" Predicate
 #[macro_export]
-macro_rules! as_pred_or {
+macro_rules! as_predexp_or {
     ($nexpr:expr) => {{
         $crate::query::predexp::PredExpOr {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -201,7 +201,7 @@ impl PredExp for PredExpNot {
 
 /// Create "NOT" Predicate
 #[macro_export]
-macro_rules! as_pred_not {
+macro_rules! as_predexp_not {
     () => {{
         $crate::query::predexp::PredExpNot {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -239,7 +239,7 @@ impl PredExp for PredExpIntegerValue {
 
 /// Create Integer Value Predicate
 #[macro_export]
-macro_rules! as_pred_int_val {
+macro_rules! as_predexp_integer_value {
     ($val:expr) => {{
         $crate::query::predexp::PredExpIntegerValue {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -278,7 +278,7 @@ impl PredExp for PredExpStringValue {
 
 /// Create String Value Predicate
 #[macro_export]
-macro_rules! as_pred_str_val {
+macro_rules! as_predexp_string_value {
     ($val:expr) => {{
         $crate::query::predexp::PredExpStringValue {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -325,7 +325,7 @@ impl PredExp for PredExpGeoJSONValue {
 
 /// Create GeoJSON Value Predicate
 #[macro_export]
-macro_rules! as_pred_geojson_val {
+macro_rules! as_predexp_geojson_value {
     ($val:expr) => {{
         $crate::query::predexp::PredExpGeoJSONValue {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -366,7 +366,7 @@ impl PredExp for PredExpBin {
 
 /// Create Unknown Bin Predicate
 #[macro_export]
-macro_rules! as_pred_unknown_bin {
+macro_rules! as_predexp_unknown_bin {
     ($name:expr) => {{
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -378,7 +378,7 @@ macro_rules! as_pred_unknown_bin {
 
 /// Create Integer Bin Predicate
 #[macro_export]
-macro_rules! as_pred_int_bin {
+macro_rules! as_predexp_integer_bin {
     ($name:expr) => {{
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -390,7 +390,7 @@ macro_rules! as_pred_int_bin {
 
 /// Create String Bin Predicate
 #[macro_export]
-macro_rules! as_pred_str_bin {
+macro_rules! as_predexp_string_bin {
     ($name:expr) => {{
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -402,7 +402,7 @@ macro_rules! as_pred_str_bin {
 
 /// Create GeoJSON Bin Predicate
 #[macro_export]
-macro_rules! as_pred_geojson_bin {
+macro_rules! as_predexp_geojson_bin {
     ($name:expr) => {{
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -414,7 +414,7 @@ macro_rules! as_pred_geojson_bin {
 
 /// Create List Bin Predicate
 #[macro_export]
-macro_rules! as_pred_list_bin {
+macro_rules! as_predexp_list_bin {
     ($name:expr) => {{
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -426,7 +426,7 @@ macro_rules! as_pred_list_bin {
 
 /// Create Map Bin Predicate
 #[macro_export]
-macro_rules! as_pred_map_bin {
+macro_rules! as_predexp_map_bin {
     ($name:expr) => {{
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -468,7 +468,7 @@ impl PredExp for PredExpVar {
 
 /// Create 64Bit Integer Var used in list/map iterations
 #[macro_export]
-macro_rules! as_pred_int_var {
+macro_rules! as_predexp_integer_var {
     ($name:expr) => {{
         $crate::query::predexp::PredExpVar {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -480,7 +480,7 @@ macro_rules! as_pred_int_var {
 
 /// Create String Var used in list/map iterations
 #[macro_export]
-macro_rules! as_pred_str_var {
+macro_rules! as_predexp_string_var {
     ($name:expr) => {{
         $crate::query::predexp::PredExpVar {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -492,7 +492,7 @@ macro_rules! as_pred_str_var {
 
 /// Create String Var used in list/map iterations
 #[macro_export]
-macro_rules! as_pred_geojson_var {
+macro_rules! as_predexp_geojson_var {
     ($name:expr) => {{
         $crate::query::predexp::PredExpVar {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -536,7 +536,7 @@ impl PredExp for PredExpMD {
 
 /// Create Record Size on Disk Predicate
 #[macro_export]
-macro_rules! as_pred_rec_device_size {
+macro_rules! as_predexp_rec_device_size {
     () => {{
         $crate::query::predexp::PredExpMD {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -547,7 +547,7 @@ macro_rules! as_pred_rec_device_size {
 
 /// Create Last Update Predicate
 #[macro_export]
-macro_rules! as_pred_rec_last_update {
+macro_rules! as_predexp_rec_last_update {
     () => {{
         $crate::query::predexp::PredExpMD {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -558,7 +558,7 @@ macro_rules! as_pred_rec_last_update {
 
 /// Create Record Expiration Time Predicate in nanoseconds since 1970-01-01 epoch as 64 bit integer
 #[macro_export]
-macro_rules! as_pred_rec_void_time {
+macro_rules! as_predexp_rec_void_time {
     () => {{
         $crate::query::predexp::PredExpMD {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -600,7 +600,7 @@ impl PredExp for PredExpMDDigestModulo {
 
 /// Creates a digest modulo record metadata value predicate expression.
 #[macro_export]
-macro_rules! as_pred_rec_digest_modulo {
+macro_rules! as_predexp_rec_digest_modulo {
     ($modulo:expr) => {{
         $crate::query::predexp::PredExpMDDigestModulo {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -648,7 +648,7 @@ impl PredExp for PredExpCompare {
 
 /// Creates Equal predicate for integer values
 #[macro_export]
-macro_rules! as_pred_int_eq {
+macro_rules! as_predexp_integer_equal {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -659,7 +659,7 @@ macro_rules! as_pred_int_eq {
 
 /// Creates NotEqual predicate for integer values
 #[macro_export]
-macro_rules! as_pred_int_uneq {
+macro_rules! as_predexp_integer_unequal {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -670,7 +670,7 @@ macro_rules! as_pred_int_uneq {
 
 /// Creates Greater Than predicate for integer values
 #[macro_export]
-macro_rules! as_pred_int_gt {
+macro_rules! as_predexp_integer_greater {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -681,7 +681,7 @@ macro_rules! as_pred_int_gt {
 
 /// Creates Greater Than Or Equal predicate for integer values
 #[macro_export]
-macro_rules! as_pred_int_gteq {
+macro_rules! as_predexp_integer_greatereq {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -692,7 +692,7 @@ macro_rules! as_pred_int_gteq {
 
 /// Creates Less Than predicate for integer values
 #[macro_export]
-macro_rules! as_pred_int_lt {
+macro_rules! as_predexp_integer_less {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -703,7 +703,7 @@ macro_rules! as_pred_int_lt {
 
 /// Creates Less Than Or Equal predicate for integer values
 #[macro_export]
-macro_rules! as_pred_int_lteq {
+macro_rules! as_predexp_integer_lesseq {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -714,7 +714,7 @@ macro_rules! as_pred_int_lteq {
 
 /// Creates Equal predicate for string values
 #[macro_export]
-macro_rules! as_pred_str_eq {
+macro_rules! as_predexp_string_equal {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -725,7 +725,7 @@ macro_rules! as_pred_str_eq {
 
 /// Creates Not Equal predicate for string values
 #[macro_export]
-macro_rules! as_pred_str_uneq {
+macro_rules! as_predexp_string_unequal {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -736,7 +736,7 @@ macro_rules! as_pred_str_uneq {
 
 /// Creates Within Region predicate for GeoJSON values
 #[macro_export]
-macro_rules! as_pred_geojson_within {
+macro_rules! as_predexp_geojson_within {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -747,7 +747,7 @@ macro_rules! as_pred_geojson_within {
 
 /// Creates Region Contains predicate for GeoJSON values
 #[macro_export]
-macro_rules! as_pred_geojson_contains {
+macro_rules! as_predexp_geojson_contains {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -786,7 +786,7 @@ impl PredExp for PredExpStringRegex {
 
 /// Creates a Regex predicate
 #[macro_export]
-macro_rules! as_pred_string_regex {
+macro_rules! as_predexp_string_regex {
     ($cflags:expr) => {{
         $crate::query::predexp::PredExpStringRegex {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -865,7 +865,7 @@ impl PredExp for PredExpIter {
 
 /// Creates an Or iterator predicate for list items
 #[macro_export]
-macro_rules! as_pred_list_iterate_or {
+macro_rules! as_predexp_list_iterate_or {
     ($name:expr) => {{
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -877,7 +877,7 @@ macro_rules! as_pred_list_iterate_or {
 
 /// Creates an And iterator predicate for list items
 #[macro_export]
-macro_rules! as_pred_list_iterate_and {
+macro_rules! as_predexp_list_iterate_and {
     ($name:expr) => {{
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -889,7 +889,7 @@ macro_rules! as_pred_list_iterate_and {
 
 /// Creates an Or iterator predicate on map keys
 #[macro_export]
-macro_rules! as_pred_mapkey_iterate_or {
+macro_rules! as_predexp_mapkey_iterate_or {
     ($name:expr) => {{
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -901,7 +901,7 @@ macro_rules! as_pred_mapkey_iterate_or {
 
 /// Creates an And iterator predicate on map keys
 #[macro_export]
-macro_rules! as_pred_mapkey_iterate_and {
+macro_rules! as_predexp_mapkey_iterate_and {
     ($name:expr) => {{
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -913,7 +913,7 @@ macro_rules! as_pred_mapkey_iterate_and {
 
 /// Creates an Or iterator predicate on map values
 #[macro_export]
-macro_rules! as_pred_mapval_iterate_or {
+macro_rules! as_predexp_mapval_iterate_or {
     ($name:expr) => {{
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -925,7 +925,7 @@ macro_rules! as_pred_mapval_iterate_or {
 
 /// Creates an And iterator predicate on map values
 #[macro_export]
-macro_rules! as_pred_mapval_iterate_and {
+macro_rules! as_predexp_mapval_iterate_and {
     ($name:expr) => {{
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
@@ -941,108 +941,108 @@ mod tests {
 
     #[test]
     fn predicate_macros() {
-        let pred_and = as_pred_and!(2);
+        let pred_and = as_predexp_and!(2);
         assert_eq!(pred_and.pred_string(), "AND");
         assert_eq!(pred_and.nexpr, 2);
 
-        let pred_or = as_pred_or!(2);
+        let pred_or = as_predexp_or!(2);
         assert_eq!(pred_or.pred_string(), "OR");
         assert_eq!(pred_or.nexpr, 2);
 
-        let pred_not = as_pred_not!();
+        let pred_not = as_predexp_not!();
         assert_eq!(pred_not.pred_string(), "NOT");
 
-        let pred_int_val = as_pred_int_val!(2);
+        let pred_int_val = as_predexp_integer_value!(2);
         assert_eq!(pred_int_val.pred_string(), "2");
         assert_eq!(pred_int_val.val, 2);
 
-        let pred_str_val = as_pred_str_val!(String::from("test"));
+        let pred_str_val = as_predexp_string_value!(String::from("test"));
         assert_eq!(pred_str_val.pred_string(), "test");
         assert_eq!(pred_str_val.val, "test");
 
-        let pred_geo_val = as_pred_geojson_val!(String::from("test"));
+        let pred_geo_val = as_predexp_geojson_value!(String::from("test"));
         assert_eq!(pred_geo_val.pred_string(), "test");
         assert_eq!(pred_geo_val.val, "test");
 
-        let bin_unknown = as_pred_unknown_bin!(String::from("test"));
+        let bin_unknown = as_predexp_unknown_bin!(String::from("test"));
         assert_eq!(bin_unknown.pred_string(), "test");
         assert_eq!(bin_unknown.tag, _AS_PREDEXP_UNKNOWN_BIN);
 
-        let int_bin = as_pred_int_bin!(String::from("test"));
+        let int_bin = as_predexp_integer_bin!(String::from("test"));
         assert_eq!(int_bin.pred_string(), "test");
         assert_eq!(int_bin.tag, _AS_PREDEXP_INTEGER_BIN);
 
-        let str_bin = as_pred_str_bin!(String::from("test"));
+        let str_bin = as_predexp_string_bin!(String::from("test"));
         assert_eq!(str_bin.pred_string(), "test");
         assert_eq!(str_bin.tag, _AS_PREDEXP_STRING_BIN);
 
-        let geo_bin = as_pred_geojson_bin!(String::from("test"));
+        let geo_bin = as_predexp_geojson_bin!(String::from("test"));
         assert_eq!(geo_bin.pred_string(), "test");
         assert_eq!(geo_bin.tag, _AS_PREDEXP_GEOJSON_BIN);
 
-        let list_bin = as_pred_list_bin!(String::from("test"));
+        let list_bin = as_predexp_list_bin!(String::from("test"));
         assert_eq!(list_bin.pred_string(), "test");
         assert_eq!(list_bin.tag, _AS_PREDEXP_LIST_BIN);
 
-        let map_bin = as_pred_map_bin!(String::from("test"));
+        let map_bin = as_predexp_map_bin!(String::from("test"));
         assert_eq!(map_bin.pred_string(), "test");
         assert_eq!(map_bin.tag, _AS_PREDEXP_MAP_BIN);
 
-        let int_var = as_pred_int_var!(String::from("test"));
+        let int_var = as_predexp_integer_var!(String::from("test"));
         assert_eq!(int_var.pred_string(), "test");
         assert_eq!(int_var.tag, _AS_PREDEXP_INTEGER_VAR);
 
-        let str_var = as_pred_str_var!(String::from("test"));
+        let str_var = as_predexp_string_var!(String::from("test"));
         assert_eq!(str_var.pred_string(), "test");
         assert_eq!(str_var.tag, _AS_PREDEXP_STRING_VAR);
 
-        let geo_var = as_pred_geojson_var!(String::from("test"));
+        let geo_var = as_predexp_geojson_var!(String::from("test"));
         assert_eq!(geo_var.pred_string(), "test");
         assert_eq!(geo_var.tag, _AS_PREDEXP_GEOJSON_VAR);
 
-        let dev_size = as_pred_rec_device_size!();
+        let dev_size = as_predexp_rec_device_size!();
         assert_eq!(dev_size.tag, _AS_PREDEXP_REC_DEVICE_SIZE);
 
-        let last_update = as_pred_rec_last_update!();
+        let last_update = as_predexp_rec_last_update!();
         assert_eq!(last_update.tag, _AS_PREDEXP_REC_LAST_UPDATE);
 
-        let void_time = as_pred_rec_void_time!();
+        let void_time = as_predexp_rec_void_time!();
         assert_eq!(void_time.tag, _AS_PREDEXP_REC_VOID_TIME);
 
-        let digest_modulo = as_pred_rec_digest_modulo!(10);
+        let digest_modulo = as_predexp_rec_digest_modulo!(10);
         assert_eq!(digest_modulo.modulo, 10);
 
-        let int_eq = as_pred_int_eq!();
+        let int_eq = as_predexp_integer_equal!();
         assert_eq!(int_eq.tag, _AS_PREDEXP_INTEGER_EQUAL);
 
-        let int_uneq = as_pred_int_uneq!();
+        let int_uneq = as_predexp_integer_unequal!();
         assert_eq!(int_uneq.tag, _AS_PREDEXP_INTEGER_UNEQUAL);
 
-        let int_gt = as_pred_int_gt!();
+        let int_gt = as_predexp_integer_greater!();
         assert_eq!(int_gt.tag, _AS_PREDEXP_INTEGER_GREATER);
 
-        let int_gteq = as_pred_int_gteq!();
+        let int_gteq = as_predexp_integer_greatereq!();
         assert_eq!(int_gteq.tag, _AS_PREDEXP_INTEGER_GREATEREQ);
 
-        let int_lt = as_pred_int_lt!();
+        let int_lt = as_predexp_integer_less!();
         assert_eq!(int_lt.tag, _AS_PREDEXP_INTEGER_LESS);
 
-        let int_lteq = as_pred_int_lteq!();
+        let int_lteq = as_predexp_integer_lesseq!();
         assert_eq!(int_lteq.tag, _AS_PREDEXP_INTEGER_LESSEQ);
 
-        let str_eq = as_pred_str_eq!();
+        let str_eq = as_predexp_string_equal!();
         assert_eq!(str_eq.tag, _AS_PREDEXP_STRING_EQUAL);
 
-        let str_uneq = as_pred_str_uneq!();
+        let str_uneq = as_predexp_string_unequal!();
         assert_eq!(str_uneq.tag, _AS_PREDEXP_STRING_UNEQUAL);
 
-        let geo_within = as_pred_geojson_within!();
+        let geo_within = as_predexp_geojson_within!();
         assert_eq!(geo_within.tag, _AS_PREDEXP_GEOJSON_WITHIN);
 
-        let geo_contains = as_pred_geojson_contains!();
+        let geo_contains = as_predexp_geojson_contains!();
         assert_eq!(geo_contains.tag, _AS_PREDEXP_GEOJSON_CONTAINS);
 
-        let string_reg = as_pred_string_regex!(5);
+        let string_reg = as_predexp_string_regex!(5);
         assert_eq!(string_reg.cflags, 5);
     }
 }

--- a/src/query/predexp.rs
+++ b/src/query/predexp.rs
@@ -1,0 +1,93 @@
+//const AS_PREDEXP_UNKNOWN_BIN: u16 = u16::
+
+use crate::commands::buffer::Buffer;
+use crate::errors::Result;
+
+const AS_PREDEXP_AND: u16 = 1;
+const AS_PREDEXP_OR:  u16 = 2;
+const AS_PREDEXP_NOT: u16 = 3;
+
+const AS_PREDEXP_INTEGER_VALUE: u16 = 10;
+const AS_PREDEXP_STRING_VALUE:  u16 = 11;
+const AS_PREDEXP_GEOJSON_VALUE: u16 = 12;
+
+const AS_PREDEXP_INTEGER_BIN: u16 = 100;
+const AS_PREDEXP_STRING_BIN:  u16 = 101;
+const AS_PREDEXP_GEOJSON_BIN: u16 = 102;
+const AS_PREDEXP_LIST_BIN:    u16 = 103;
+const AS_PREDEXP_MAP_BIN:     u16 = 104;
+
+const AS_PREDEXP_INTEGER_VAR: u16 = 120;
+const AS_PREDEXP_STRING_VAR:  u16 = 121;
+const AS_PREDEXP_GEOJSON_VAR: u16 = 122;
+
+const AS_PREDEXP_REC_DEVICE_SIZE:   u16 = 150;
+const AS_PREDEXP_REC_LAST_UPDATE:   u16 = 151;
+const AS_PREDEXP_REC_VOID_TIME:     u16 = 152;
+const AS_PREDEXP_REC_DIGEST_MODULO: u16 = 153;
+
+const AS_PREDEXP_INTEGER_EQUAL:     u16 = 200;
+const AS_PREDEXP_INTEGER_UNEQUAL:   u16 = 201;
+const AS_PREDEXP_INTEGER_GREATER:   u16 = 202;
+const AS_PREDEXP_INTEGER_GREATEREQ: u16 = 203;
+const AS_PREDEXP_INTEGER_LESS:      u16 = 204;
+const AS_PREDEXP_INTEGER_LESSEQ:    u16 = 205;
+
+const AS_PREDEXP_STRING_EQUAL:   u16 = 210;
+const AS_PREDEXP_STRING_UNEQUAL: u16 = 211;
+const AS_PREDEXP_STRING_REGEX:   u16 = 212;
+
+const AS_PREDEXP_GEOJSON_WITHIN:   u16 = 220;
+const AS_PREDEXP_GEOJSON_CONTAINS: u16 = 221;
+
+const AS_PREDEXP_LIST_ITERATE_OR:    u16 = 250;
+const AS_PREDEXP_MAPKEY_ITERATE_OR:  u16 = 251;
+const AS_PREDEXP_MAPVAL_ITERATE_OR:  u16 = 252;
+const AS_PREDEXP_LIST_ITERATE_AND:   u16 = 253;
+const AS_PREDEXP_MAPKEY_ITERATE_AND: u16 = 254;
+const AS_PREDEXP_MAPVAL_ITERATE_AND: u16 = 255;
+
+pub trait PredExp{
+    fn pred_string(&self) -> String;
+    fn marshaled_size(&self) -> u32;
+    fn write(&self, buffer: &mut Buffer) -> Result<()>;
+}
+
+#[derive(Debug, Clone)]
+struct PredExpBase {}
+
+impl PredExpBase {
+    #[doc(hidden)]
+    fn default_size(&self) -> u32 {
+        return 2+4; // size of TAG + size of LEN
+    }
+
+    #[doc(hidden)]
+    fn write(&self, buffer: &mut Buffer, tag: u16, len: u32) -> Result<()> {
+        buffer.write_u16(tag)?;
+        buffer.write_u32(len)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PredExpAnd {
+    pub pred_exp_base: PredExpBase,
+    pub nexpr: u16
+}
+
+impl PredExp for PredExpAnd {
+    fn pred_string(&self) -> String {
+        String::from("AND")
+    }
+
+    fn marshaled_size(&self) -> u32 {
+        self.pred_exp_base.default_size() + 2
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base.write(buffer, AS_PREDEXP_AND, 2);
+        buffer.write_u16(self.nexpr);
+        Ok(())
+    }
+}

--- a/src/query/predexp.rs
+++ b/src/query/predexp.rs
@@ -1,51 +1,51 @@
 use crate::commands::buffer::Buffer;
 use crate::errors::Result;
 
-const AS_PREDEXP_UNKNOWN_BIN: u16 = u16::max_value();
+const _AS_PREDEXP_UNKNOWN_BIN: u16 = u16::max_value();
 
-const AS_PREDEXP_AND: u16 = 1;
-const AS_PREDEXP_OR: u16 = 2;
-const AS_PREDEXP_NOT: u16 = 3;
+const _AS_PREDEXP_AND: u16 = 1;
+const _AS_PREDEXP_OR: u16 = 2;
+const _AS_PREDEXP_NOT: u16 = 3;
 
-const AS_PREDEXP_INTEGER_VALUE: u16 = 10;
-const AS_PREDEXP_STRING_VALUE: u16 = 11;
-const AS_PREDEXP_GEOJSON_VALUE: u16 = 12;
+const _AS_PREDEXP_INTEGER_VALUE: u16 = 10;
+const _AS_PREDEXP_STRING_VALUE: u16 = 11;
+const _AS_PREDEXP_GEOJSON_VALUE: u16 = 12;
 
-const AS_PREDEXP_INTEGER_BIN: u16 = 100;
-const AS_PREDEXP_STRING_BIN: u16 = 101;
-const AS_PREDEXP_GEOJSON_BIN: u16 = 102;
-const AS_PREDEXP_LIST_BIN: u16 = 103;
-const AS_PREDEXP_MAP_BIN: u16 = 104;
+const _AS_PREDEXP_INTEGER_BIN: u16 = 100;
+const _AS_PREDEXP_STRING_BIN: u16 = 101;
+const _AS_PREDEXP_GEOJSON_BIN: u16 = 102;
+const _AS_PREDEXP_LIST_BIN: u16 = 103;
+const _AS_PREDEXP_MAP_BIN: u16 = 104;
 
-const AS_PREDEXP_INTEGER_VAR: u16 = 120;
-const AS_PREDEXP_STRING_VAR: u16 = 121;
-const AS_PREDEXP_GEOJSON_VAR: u16 = 122;
+const _AS_PREDEXP_INTEGER_VAR: u16 = 120;
+const _AS_PREDEXP_STRING_VAR: u16 = 121;
+const _AS_PREDEXP_GEOJSON_VAR: u16 = 122;
 
-const AS_PREDEXP_REC_DEVICE_SIZE: u16 = 150;
-const AS_PREDEXP_REC_LAST_UPDATE: u16 = 151;
-const AS_PREDEXP_REC_VOID_TIME: u16 = 152;
-const AS_PREDEXP_REC_DIGEST_MODULO: u16 = 153;
+const _AS_PREDEXP_REC_DEVICE_SIZE: u16 = 150;
+const _AS_PREDEXP_REC_LAST_UPDATE: u16 = 151;
+const _AS_PREDEXP_REC_VOID_TIME: u16 = 152;
+const _AS_PREDEXP_REC_DIGEST_MODULO: u16 = 153;
 
-const AS_PREDEXP_INTEGER_EQUAL: u16 = 200;
-const AS_PREDEXP_INTEGER_UNEQUAL: u16 = 201;
-const AS_PREDEXP_INTEGER_GREATER: u16 = 202;
-const AS_PREDEXP_INTEGER_GREATEREQ: u16 = 203;
-const AS_PREDEXP_INTEGER_LESS: u16 = 204;
-const AS_PREDEXP_INTEGER_LESSEQ: u16 = 205;
+const _AS_PREDEXP_INTEGER_EQUAL: u16 = 200;
+const _AS_PREDEXP_INTEGER_UNEQUAL: u16 = 201;
+const _AS_PREDEXP_INTEGER_GREATER: u16 = 202;
+const _AS_PREDEXP_INTEGER_GREATEREQ: u16 = 203;
+const _AS_PREDEXP_INTEGER_LESS: u16 = 204;
+const _AS_PREDEXP_INTEGER_LESSEQ: u16 = 205;
 
-const AS_PREDEXP_STRING_EQUAL: u16 = 210;
-const AS_PREDEXP_STRING_UNEQUAL: u16 = 211;
-const AS_PREDEXP_STRING_REGEX: u16 = 212;
+const _AS_PREDEXP_STRING_EQUAL: u16 = 210;
+const _AS_PREDEXP_STRING_UNEQUAL: u16 = 211;
+const _AS_PREDEXP_STRING_REGEX: u16 = 212;
 
-const AS_PREDEXP_GEOJSON_WITHIN: u16 = 220;
-const AS_PREDEXP_GEOJSON_CONTAINS: u16 = 221;
+const _AS_PREDEXP_GEOJSON_WITHIN: u16 = 220;
+const _AS_PREDEXP_GEOJSON_CONTAINS: u16 = 221;
 
-const AS_PREDEXP_LIST_ITERATE_OR: u16 = 250;
-const AS_PREDEXP_MAPKEY_ITERATE_OR: u16 = 251;
-const AS_PREDEXP_MAPVAL_ITERATE_OR: u16 = 252;
-const AS_PREDEXP_LIST_ITERATE_AND: u16 = 253;
-const AS_PREDEXP_MAPKEY_ITERATE_AND: u16 = 254;
-const AS_PREDEXP_MAPVAL_ITERATE_AND: u16 = 255;
+const _AS_PREDEXP_LIST_ITERATE_OR: u16 = 250;
+const _AS_PREDEXP_MAPKEY_ITERATE_OR: u16 = 251;
+const _AS_PREDEXP_MAPVAL_ITERATE_OR: u16 = 252;
+const _AS_PREDEXP_LIST_ITERATE_AND: u16 = 253;
+const _AS_PREDEXP_MAPKEY_ITERATE_AND: u16 = 254;
+const _AS_PREDEXP_MAPVAL_ITERATE_AND: u16 = 255;
 
 pub trait PredExp: Send + Sync {
     fn pred_string(&self) -> String;
@@ -91,7 +91,7 @@ impl PredExp for PredExpAnd {
     }
 
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
-        self.pred_exp_base.write(buffer, AS_PREDEXP_AND, 2)?;
+        self.pred_exp_base.write(buffer, _AS_PREDEXP_AND, 2)?;
         buffer.write_u16(self.nexpr)?;
         Ok(())
     }
@@ -128,7 +128,7 @@ impl PredExp for PredExpOr {
     }
 
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
-        self.pred_exp_base.write(buffer, AS_PREDEXP_OR, 2)?;
+        self.pred_exp_base.write(buffer, _AS_PREDEXP_OR, 2)?;
         buffer.write_u16(self.nexpr)?;
         Ok(())
     }
@@ -163,7 +163,7 @@ impl PredExp for PredExpNot {
     }
 
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
-        self.pred_exp_base.write(buffer, AS_PREDEXP_NOT, 0)?;
+        self.pred_exp_base.write(buffer, _AS_PREDEXP_NOT, 0)?;
         Ok(())
     }
 }
@@ -198,7 +198,7 @@ impl PredExp for PredExpIntegerValue {
 
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
         self.pred_exp_base
-            .write(buffer, AS_PREDEXP_INTEGER_VALUE, 8)?;
+            .write(buffer, _AS_PREDEXP_INTEGER_VALUE, 8)?;
         buffer.write_i64(self.val)?;
         Ok(())
     }
@@ -235,7 +235,7 @@ impl PredExp for PredExpStringValue {
 
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
         self.pred_exp_base
-            .write(buffer, AS_PREDEXP_STRING_VALUE, self.val.len() as u32)?;
+            .write(buffer, _AS_PREDEXP_STRING_VALUE, self.val.len() as u32)?;
         buffer.write_str(&self.val)?;
         Ok(())
     }
@@ -276,7 +276,7 @@ impl PredExp for PredExpGeoJSONValue {
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
         self.pred_exp_base.write(
             buffer,
-            AS_PREDEXP_GEOJSON_VALUE,
+            _AS_PREDEXP_GEOJSON_VALUE,
             (1 + 2 + self.val.len()) as u32,
         )?;
         buffer.write_u8(0u8)?;
@@ -331,7 +331,7 @@ macro_rules! as_pred_unknown_bin {
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_UNKNOWN_BIN,
+            tag: $crate::query::predexp::_AS_PREDEXP_UNKNOWN_BIN,
         }
     }};
 }
@@ -343,7 +343,7 @@ macro_rules! as_pred_int_bin {
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_BIN,
+            tag: $crate::query::predexp::_AS_PREDEXP_INTEGER_BIN,
         }
     }};
 }
@@ -355,7 +355,7 @@ macro_rules! as_pred_str_bin {
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_STRING_BIN,
+            tag: $crate::query::predexp::_AS_PREDEXP_STRING_BIN,
         }
     }};
 }
@@ -367,7 +367,7 @@ macro_rules! as_pred_geojson_bin {
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_GEOJSON_BIN,
+            tag: $crate::query::predexp::_AS_PREDEXP_GEOJSON_BIN,
         }
     }};
 }
@@ -379,7 +379,7 @@ macro_rules! as_pred_list_bin {
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_LIST_BIN,
+            tag: $crate::query::predexp::_AS_PREDEXP_LIST_BIN,
         }
     }};
 }
@@ -391,7 +391,7 @@ macro_rules! as_pred_map_bin {
         $crate::query::predexp::PredExpBin {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_MAP_BIN,
+            tag: $crate::query::predexp::_AS_PREDEXP_MAP_BIN,
         }
     }};
 }
@@ -430,7 +430,7 @@ macro_rules! as_pred_int_var {
         $crate::query::predexp::PredExpVar {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_VAR,
+            tag: $crate::query::predexp::_AS_PREDEXP_INTEGER_VAR,
         }
     }};
 }
@@ -442,7 +442,7 @@ macro_rules! as_pred_str_var {
         $crate::query::predexp::PredExpVar {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_STRING_VAR,
+            tag: $crate::query::predexp::_AS_PREDEXP_STRING_VAR,
         }
     }};
 }
@@ -454,7 +454,7 @@ macro_rules! as_pred_geojson_var {
         $crate::query::predexp::PredExpVar {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_GEOJSON_VAR,
+            tag: $crate::query::predexp::_AS_PREDEXP_GEOJSON_VAR,
         }
     }};
 }
@@ -471,10 +471,10 @@ pub struct PredExpMD {
 impl PredExp for PredExpMD {
     fn pred_string(&self) -> String {
         match self.tag {
-            AS_PREDEXP_REC_DEVICE_SIZE => String::from("rec.DeviceSize"),
-            AS_PREDEXP_REC_LAST_UPDATE => String::from("rec.LastUpdate"),
-            AS_PREDEXP_REC_VOID_TIME => String::from("rec.Expiration"),
-            AS_PREDEXP_REC_DIGEST_MODULO => String::from("rec.DigestModulo"),
+            _AS_PREDEXP_REC_DEVICE_SIZE => String::from("rec.DeviceSize"),
+            _AS_PREDEXP_REC_LAST_UPDATE => String::from("rec.LastUpdate"),
+            _AS_PREDEXP_REC_VOID_TIME => String::from("rec.Expiration"),
+            _AS_PREDEXP_REC_DIGEST_MODULO => String::from("rec.DigestModulo"),
             _ => panic!("Invalid Metadata tag."),
         }
     }
@@ -495,7 +495,7 @@ macro_rules! as_pred_rec_device_size {
     () => {{
         $crate::query::predexp::PredExpMD {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_REC_DEVICE_SIZE,
+            tag: $crate::query::predexp::_AS_PREDEXP_REC_DEVICE_SIZE,
         }
     }};
 }
@@ -506,7 +506,7 @@ macro_rules! as_pred_rec_last_update {
     () => {{
         $crate::query::predexp::PredExpMD {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_REC_LAST_UPDATE,
+            tag: $crate::query::predexp::_AS_PREDEXP_REC_LAST_UPDATE,
         }
     }};
 }
@@ -517,7 +517,7 @@ macro_rules! as_pred_rec_void_time {
     () => {{
         $crate::query::predexp::PredExpMD {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_REC_VOID_TIME,
+            tag: $crate::query::predexp::_AS_PREDEXP_REC_VOID_TIME,
         }
     }};
 }
@@ -545,7 +545,7 @@ impl PredExp for PredExpMDDigestModulo {
 
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
         self.pred_exp_base
-            .write(buffer, AS_PREDEXP_REC_DIGEST_MODULO, 4)?;
+            .write(buffer, _AS_PREDEXP_REC_DIGEST_MODULO, 4)?;
         buffer.write_i32(self.modulo)?;
         Ok(())
     }
@@ -574,15 +574,15 @@ pub struct PredExpCompare {
 impl PredExp for PredExpCompare {
     fn pred_string(&self) -> String {
         match self.tag {
-            AS_PREDEXP_INTEGER_EQUAL | AS_PREDEXP_STRING_EQUAL => String::from("="),
-            AS_PREDEXP_INTEGER_UNEQUAL | AS_PREDEXP_STRING_UNEQUAL => String::from("!="),
-            AS_PREDEXP_INTEGER_GREATER => String::from(">"),
-            AS_PREDEXP_INTEGER_GREATEREQ => String::from(">="),
-            AS_PREDEXP_INTEGER_LESS => String::from("<"),
-            AS_PREDEXP_INTEGER_LESSEQ => String::from("<="),
-            AS_PREDEXP_STRING_REGEX => String::from("~="),
-            AS_PREDEXP_GEOJSON_CONTAINS => String::from("CONTAINS"),
-            AS_PREDEXP_GEOJSON_WITHIN => String::from("WITHIN"),
+            _AS_PREDEXP_INTEGER_EQUAL | _AS_PREDEXP_STRING_EQUAL => String::from("="),
+            _AS_PREDEXP_INTEGER_UNEQUAL | _AS_PREDEXP_STRING_UNEQUAL => String::from("!="),
+            _AS_PREDEXP_INTEGER_GREATER => String::from(">"),
+            _AS_PREDEXP_INTEGER_GREATEREQ => String::from(">="),
+            _AS_PREDEXP_INTEGER_LESS => String::from("<"),
+            _AS_PREDEXP_INTEGER_LESSEQ => String::from("<="),
+            _AS_PREDEXP_STRING_REGEX => String::from("~="),
+            _AS_PREDEXP_GEOJSON_CONTAINS => String::from("CONTAINS"),
+            _AS_PREDEXP_GEOJSON_WITHIN => String::from("WITHIN"),
             _ => panic!("unexpected predicate tag"),
         }
     }
@@ -603,7 +603,7 @@ macro_rules! as_pred_int_eq {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_EQUAL,
+            tag: $crate::query::predexp::_AS_PREDEXP_INTEGER_EQUAL,
         }
     }};
 }
@@ -614,7 +614,7 @@ macro_rules! as_pred_int_uneq {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_UNEQUAL,
+            tag: $crate::query::predexp::_AS_PREDEXP_INTEGER_UNEQUAL,
         }
     }};
 }
@@ -625,7 +625,7 @@ macro_rules! as_pred_int_gt {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_GREATER,
+            tag: $crate::query::predexp::_AS_PREDEXP_INTEGER_GREATER,
         }
     }};
 }
@@ -636,7 +636,7 @@ macro_rules! as_pred_int_gteq {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_GREATEREQ,
+            tag: $crate::query::predexp::_AS_PREDEXP_INTEGER_GREATEREQ,
         }
     }};
 }
@@ -647,7 +647,7 @@ macro_rules! as_pred_int_lt {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_LESS,
+            tag: $crate::query::predexp::_AS_PREDEXP_INTEGER_LESS,
         }
     }};
 }
@@ -658,7 +658,7 @@ macro_rules! as_pred_int_lteq {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_LESSEQ,
+            tag: $crate::query::predexp::_AS_PREDEXP_INTEGER_LESSEQ,
         }
     }};
 }
@@ -669,7 +669,7 @@ macro_rules! as_pred_str_eq {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_STRING_EQUAL,
+            tag: $crate::query::predexp::_AS_PREDEXP_STRING_EQUAL,
         }
     }};
 }
@@ -680,7 +680,7 @@ macro_rules! as_pred_str_uneq {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_STRING_UNEQUAL,
+            tag: $crate::query::predexp::_AS_PREDEXP_STRING_UNEQUAL,
         }
     }};
 }
@@ -691,7 +691,7 @@ macro_rules! as_pred_geojson_within {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_GEOJSON_WITHIN,
+            tag: $crate::query::predexp::_AS_PREDEXP_GEOJSON_WITHIN,
         }
     }};
 }
@@ -702,7 +702,7 @@ macro_rules! as_pred_geojson_contains {
     () => {{
         $crate::query::predexp::PredExpCompare {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
-            tag: $crate::query::predexp::AS_PREDEXP_GEOJSON_CONTAINS,
+            tag: $crate::query::predexp::_AS_PREDEXP_GEOJSON_CONTAINS,
         }
     }};
 }
@@ -727,7 +727,7 @@ impl PredExp for PredExpStringRegex {
 
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
         self.pred_exp_base
-            .write(buffer, AS_PREDEXP_STRING_REGEX, 4)?;
+            .write(buffer, _AS_PREDEXP_STRING_REGEX, 4)?;
         buffer.write_u32(self.cflags)?;
         Ok(())
     }
@@ -757,37 +757,37 @@ pub struct PredExpIter {
 impl PredExp for PredExpIter {
     fn pred_string(&self) -> String {
         match self.tag {
-            AS_PREDEXP_LIST_ITERATE_OR => {
+            _AS_PREDEXP_LIST_ITERATE_OR => {
                 let mut tagname = String::from("list_iterate_or using \"");
                 tagname.push_str(&self.name);
                 tagname.push_str("\":");
                 tagname
             }
-            AS_PREDEXP_MAPKEY_ITERATE_OR => {
+            _AS_PREDEXP_MAPKEY_ITERATE_OR => {
                 let mut tagname = String::from("mapkey_iterate_or using \"");
                 tagname.push_str(&self.name);
                 tagname.push_str("\":");
                 tagname
             }
-            AS_PREDEXP_MAPVAL_ITERATE_OR => {
+            _AS_PREDEXP_MAPVAL_ITERATE_OR => {
                 let mut tagname = String::from("mapval_iterate_or using \"");
                 tagname.push_str(&self.name);
                 tagname.push_str("\":");
                 tagname
             }
-            AS_PREDEXP_LIST_ITERATE_AND => {
+            _AS_PREDEXP_LIST_ITERATE_AND => {
                 let mut tagname = String::from("list_iterate_and using \"");
                 tagname.push_str(&self.name);
                 tagname.push_str("\":");
                 tagname
             }
-            AS_PREDEXP_MAPKEY_ITERATE_AND => {
+            _AS_PREDEXP_MAPKEY_ITERATE_AND => {
                 let mut tagname = String::from("mapkey_iterate_and using \"");
                 tagname.push_str(&self.name);
                 tagname.push_str("\":");
                 tagname
             }
-            AS_PREDEXP_MAPVAL_ITERATE_AND => {
+            _AS_PREDEXP_MAPVAL_ITERATE_AND => {
                 let mut tagname = String::from("mapvalue_iterate_and using \"");
                 tagname.push_str(&self.name);
                 tagname.push_str("\":");
@@ -803,7 +803,7 @@ impl PredExp for PredExpIter {
 
     fn write(&self, buffer: &mut Buffer) -> Result<()> {
         self.pred_exp_base
-            .write(buffer, AS_PREDEXP_STRING_REGEX, self.name.len() as u32)?;
+            .write(buffer, _AS_PREDEXP_STRING_REGEX, self.name.len() as u32)?;
         buffer.write_str(&self.name)?;
         Ok(())
     }
@@ -816,7 +816,7 @@ macro_rules! as_pred_list_iterate_or {
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_LIST_ITERATE_OR,
+            tag: $crate::query::predexp::_AS_PREDEXP_LIST_ITERATE_OR,
         }
     }};
 }
@@ -828,7 +828,7 @@ macro_rules! as_pred_list_iterate_and {
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_LIST_ITERATE_AND,
+            tag: $crate::query::predexp::_AS_PREDEXP_LIST_ITERATE_AND,
         }
     }};
 }
@@ -840,7 +840,7 @@ macro_rules! as_pred_mapkey_iterate_or {
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_MAPKEY_ITERATE_OR,
+            tag: $crate::query::predexp::_AS_PREDEXP_MAPKEY_ITERATE_OR,
         }
     }};
 }
@@ -852,7 +852,7 @@ macro_rules! as_pred_mapkey_iterate_and {
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_MAPKEY_ITERATE_AND,
+            tag: $crate::query::predexp::_AS_PREDEXP_MAPKEY_ITERATE_AND,
         }
     }};
 }
@@ -864,7 +864,7 @@ macro_rules! as_pred_mapval_iterate_or {
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_MAPVAL_ITERATE_OR,
+            tag: $crate::query::predexp::_AS_PREDEXP_MAPVAL_ITERATE_OR,
         }
     }};
 }
@@ -876,7 +876,7 @@ macro_rules! as_pred_mapval_iterate_and {
         $crate::query::predexp::PredExpIter {
             pred_exp_base: $crate::query::predexp::PredExpBase {},
             name: $name,
-            tag: $crate::query::predexp::AS_PREDEXP_MAPVAL_ITERATE_AND,
+            tag: $crate::query::predexp::_AS_PREDEXP_MAPVAL_ITERATE_AND,
         }
     }};
 }
@@ -912,81 +912,81 @@ mod tests {
 
         let bin_unknown = as_pred_unknown_bin!(String::from("test"));
         assert_eq!(bin_unknown.pred_string(), "test");
-        assert_eq!(bin_unknown.tag, AS_PREDEXP_UNKNOWN_BIN);
+        assert_eq!(bin_unknown.tag, _AS_PREDEXP_UNKNOWN_BIN);
 
         let int_bin = as_pred_int_bin!(String::from("test"));
         assert_eq!(int_bin.pred_string(), "test");
-        assert_eq!(int_bin.tag, AS_PREDEXP_INTEGER_BIN);
+        assert_eq!(int_bin.tag, _AS_PREDEXP_INTEGER_BIN);
 
         let str_bin = as_pred_str_bin!(String::from("test"));
         assert_eq!(str_bin.pred_string(), "test");
-        assert_eq!(str_bin.tag, AS_PREDEXP_STRING_BIN);
+        assert_eq!(str_bin.tag, _AS_PREDEXP_STRING_BIN);
 
         let geo_bin = as_pred_geojson_bin!(String::from("test"));
         assert_eq!(geo_bin.pred_string(), "test");
-        assert_eq!(geo_bin.tag, AS_PREDEXP_GEOJSON_BIN);
+        assert_eq!(geo_bin.tag, _AS_PREDEXP_GEOJSON_BIN);
 
         let list_bin = as_pred_list_bin!(String::from("test"));
         assert_eq!(list_bin.pred_string(), "test");
-        assert_eq!(list_bin.tag, AS_PREDEXP_LIST_BIN);
+        assert_eq!(list_bin.tag, _AS_PREDEXP_LIST_BIN);
 
         let map_bin = as_pred_map_bin!(String::from("test"));
         assert_eq!(map_bin.pred_string(), "test");
-        assert_eq!(map_bin.tag, AS_PREDEXP_MAP_BIN);
+        assert_eq!(map_bin.tag, _AS_PREDEXP_MAP_BIN);
 
         let int_var = as_pred_int_var!(String::from("test"));
         assert_eq!(int_var.pred_string(), "test");
-        assert_eq!(int_var.tag, AS_PREDEXP_INTEGER_VAR);
+        assert_eq!(int_var.tag, _AS_PREDEXP_INTEGER_VAR);
 
         let str_var = as_pred_str_var!(String::from("test"));
         assert_eq!(str_var.pred_string(), "test");
-        assert_eq!(str_var.tag, AS_PREDEXP_STRING_VAR);
+        assert_eq!(str_var.tag, _AS_PREDEXP_STRING_VAR);
 
         let geo_var = as_pred_geojson_var!(String::from("test"));
         assert_eq!(geo_var.pred_string(), "test");
-        assert_eq!(geo_var.tag, AS_PREDEXP_GEOJSON_VAR);
+        assert_eq!(geo_var.tag, _AS_PREDEXP_GEOJSON_VAR);
 
         let dev_size = as_pred_rec_device_size!();
-        assert_eq!(dev_size.tag, AS_PREDEXP_REC_DEVICE_SIZE);
+        assert_eq!(dev_size.tag, _AS_PREDEXP_REC_DEVICE_SIZE);
 
         let last_update = as_pred_rec_last_update!();
-        assert_eq!(last_update.tag, AS_PREDEXP_REC_LAST_UPDATE);
+        assert_eq!(last_update.tag, _AS_PREDEXP_REC_LAST_UPDATE);
 
         let void_time = as_pred_rec_void_time!();
-        assert_eq!(void_time.tag, AS_PREDEXP_REC_VOID_TIME);
+        assert_eq!(void_time.tag, _AS_PREDEXP_REC_VOID_TIME);
 
         let digest_modulo = as_pred_rec_digest_modulo!(10);
         assert_eq!(digest_modulo.modulo, 10);
 
         let int_eq = as_pred_int_eq!();
-        assert_eq!(int_eq.tag, AS_PREDEXP_INTEGER_EQUAL);
+        assert_eq!(int_eq.tag, _AS_PREDEXP_INTEGER_EQUAL);
 
         let int_uneq = as_pred_int_uneq!();
-        assert_eq!(int_uneq.tag, AS_PREDEXP_INTEGER_UNEQUAL);
+        assert_eq!(int_uneq.tag, _AS_PREDEXP_INTEGER_UNEQUAL);
 
         let int_gt = as_pred_int_gt!();
-        assert_eq!(int_gt.tag, AS_PREDEXP_INTEGER_GREATER);
+        assert_eq!(int_gt.tag, _AS_PREDEXP_INTEGER_GREATER);
 
         let int_gteq = as_pred_int_gteq!();
-        assert_eq!(int_gteq.tag, AS_PREDEXP_INTEGER_GREATEREQ);
+        assert_eq!(int_gteq.tag, _AS_PREDEXP_INTEGER_GREATEREQ);
 
         let int_lt = as_pred_int_lt!();
-        assert_eq!(int_lt.tag, AS_PREDEXP_INTEGER_LESS);
+        assert_eq!(int_lt.tag, _AS_PREDEXP_INTEGER_LESS);
 
         let int_lteq = as_pred_int_lteq!();
-        assert_eq!(int_lteq.tag, AS_PREDEXP_INTEGER_LESSEQ);
+        assert_eq!(int_lteq.tag, _AS_PREDEXP_INTEGER_LESSEQ);
 
         let str_eq = as_pred_str_eq!();
-        assert_eq!(str_eq.tag, AS_PREDEXP_STRING_EQUAL);
+        assert_eq!(str_eq.tag, _AS_PREDEXP_STRING_EQUAL);
 
         let str_uneq = as_pred_str_uneq!();
-        assert_eq!(str_uneq.tag, AS_PREDEXP_STRING_UNEQUAL);
+        assert_eq!(str_uneq.tag, _AS_PREDEXP_STRING_UNEQUAL);
 
         let geo_within = as_pred_geojson_within!();
-        assert_eq!(geo_within.tag, AS_PREDEXP_GEOJSON_WITHIN);
+        assert_eq!(geo_within.tag, _AS_PREDEXP_GEOJSON_WITHIN);
 
         let geo_contains = as_pred_geojson_contains!();
-        assert_eq!(geo_contains.tag, AS_PREDEXP_GEOJSON_CONTAINS);
+        assert_eq!(geo_contains.tag, _AS_PREDEXP_GEOJSON_CONTAINS);
 
         let string_reg = as_pred_string_regex!(5);
         assert_eq!(string_reg.cflags, 5);

--- a/src/query/predexp.rs
+++ b/src/query/predexp.rs
@@ -1,55 +1,55 @@
-const AS_PREDEXP_UNKNOWN_BIN: u16 = std::u16::MAX;
-
 use crate::commands::buffer::Buffer;
 use crate::errors::Result;
 
+const AS_PREDEXP_UNKNOWN_BIN: u16 = u16::max_value();
+
 const AS_PREDEXP_AND: u16 = 1;
-const AS_PREDEXP_OR:  u16 = 2;
+const AS_PREDEXP_OR: u16 = 2;
 const AS_PREDEXP_NOT: u16 = 3;
 
 const AS_PREDEXP_INTEGER_VALUE: u16 = 10;
-const AS_PREDEXP_STRING_VALUE:  u16 = 11;
+const AS_PREDEXP_STRING_VALUE: u16 = 11;
 const AS_PREDEXP_GEOJSON_VALUE: u16 = 12;
 
 const AS_PREDEXP_INTEGER_BIN: u16 = 100;
-const AS_PREDEXP_STRING_BIN:  u16 = 101;
+const AS_PREDEXP_STRING_BIN: u16 = 101;
 const AS_PREDEXP_GEOJSON_BIN: u16 = 102;
-const AS_PREDEXP_LIST_BIN:    u16 = 103;
-const AS_PREDEXP_MAP_BIN:     u16 = 104;
+const AS_PREDEXP_LIST_BIN: u16 = 103;
+const AS_PREDEXP_MAP_BIN: u16 = 104;
 
 const AS_PREDEXP_INTEGER_VAR: u16 = 120;
-const AS_PREDEXP_STRING_VAR:  u16 = 121;
+const AS_PREDEXP_STRING_VAR: u16 = 121;
 const AS_PREDEXP_GEOJSON_VAR: u16 = 122;
 
-const AS_PREDEXP_REC_DEVICE_SIZE:   u16 = 150;
-const AS_PREDEXP_REC_LAST_UPDATE:   u16 = 151;
-const AS_PREDEXP_REC_VOID_TIME:     u16 = 152;
+const AS_PREDEXP_REC_DEVICE_SIZE: u16 = 150;
+const AS_PREDEXP_REC_LAST_UPDATE: u16 = 151;
+const AS_PREDEXP_REC_VOID_TIME: u16 = 152;
 const AS_PREDEXP_REC_DIGEST_MODULO: u16 = 153;
 
-const AS_PREDEXP_INTEGER_EQUAL:     u16 = 200;
-const AS_PREDEXP_INTEGER_UNEQUAL:   u16 = 201;
-const AS_PREDEXP_INTEGER_GREATER:   u16 = 202;
+const AS_PREDEXP_INTEGER_EQUAL: u16 = 200;
+const AS_PREDEXP_INTEGER_UNEQUAL: u16 = 201;
+const AS_PREDEXP_INTEGER_GREATER: u16 = 202;
 const AS_PREDEXP_INTEGER_GREATEREQ: u16 = 203;
-const AS_PREDEXP_INTEGER_LESS:      u16 = 204;
-const AS_PREDEXP_INTEGER_LESSEQ:    u16 = 205;
+const AS_PREDEXP_INTEGER_LESS: u16 = 204;
+const AS_PREDEXP_INTEGER_LESSEQ: u16 = 205;
 
-const AS_PREDEXP_STRING_EQUAL:   u16 = 210;
+const AS_PREDEXP_STRING_EQUAL: u16 = 210;
 const AS_PREDEXP_STRING_UNEQUAL: u16 = 211;
-const AS_PREDEXP_STRING_REGEX:   u16 = 212;
+const AS_PREDEXP_STRING_REGEX: u16 = 212;
 
-const AS_PREDEXP_GEOJSON_WITHIN:   u16 = 220;
+const AS_PREDEXP_GEOJSON_WITHIN: u16 = 220;
 const AS_PREDEXP_GEOJSON_CONTAINS: u16 = 221;
 
-const AS_PREDEXP_LIST_ITERATE_OR:    u16 = 250;
-const AS_PREDEXP_MAPKEY_ITERATE_OR:  u16 = 251;
-const AS_PREDEXP_MAPVAL_ITERATE_OR:  u16 = 252;
-const AS_PREDEXP_LIST_ITERATE_AND:   u16 = 253;
+const AS_PREDEXP_LIST_ITERATE_OR: u16 = 250;
+const AS_PREDEXP_MAPKEY_ITERATE_OR: u16 = 251;
+const AS_PREDEXP_MAPVAL_ITERATE_OR: u16 = 252;
+const AS_PREDEXP_LIST_ITERATE_AND: u16 = 253;
 const AS_PREDEXP_MAPKEY_ITERATE_AND: u16 = 254;
 const AS_PREDEXP_MAPVAL_ITERATE_AND: u16 = 255;
 
-pub trait PredExp: Send + Sync{
+pub trait PredExp: Send + Sync {
     fn pred_string(&self) -> String;
-    fn marshaled_size(&self) -> u32;
+    fn marshaled_size(&self) -> usize;
     fn write(&self, buffer: &mut Buffer) -> Result<()>;
 }
 
@@ -59,8 +59,8 @@ pub struct PredExpBase {}
 
 impl PredExpBase {
     #[doc(hidden)]
-    fn default_size(&self) -> u32 {
-        return 2+4; // size of TAG + size of LEN
+    fn default_size(&self) -> usize {
+        return 2 + 4; // size of TAG + size of LEN
     }
 
     #[doc(hidden)]
@@ -78,7 +78,7 @@ impl PredExpBase {
 pub struct PredExpAnd {
     pred_exp_base: PredExpBase,
     #[doc(hidden)]
-    pub nexpr: u16
+    pub nexpr: u16,
 }
 
 impl PredExp for PredExpAnd {
@@ -86,7 +86,7 @@ impl PredExp for PredExpAnd {
         String::from("AND")
     }
 
-    fn marshaled_size(&self) -> u32 {
+    fn marshaled_size(&self) -> usize {
         self.pred_exp_base.default_size() + 2
     }
 
@@ -101,9 +101,9 @@ impl PredExp for PredExpAnd {
 #[macro_export]
 macro_rules! as_pred_and {
     ($nexpr:expr) => {{
-        $crate::query::predexp::PredExpAnd{
-            pred_exp_base: $crate::query::predexp::PredExpBase{},
-            nexpr: $nexpr
+        $crate::query::predexp::PredExpAnd {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            nexpr: $nexpr,
         }
     }};
 }
@@ -115,7 +115,7 @@ macro_rules! as_pred_and {
 pub struct PredExpOr {
     pred_exp_base: PredExpBase,
     #[doc(hidden)]
-    pub nexpr: u16
+    pub nexpr: u16,
 }
 
 impl PredExp for PredExpOr {
@@ -123,7 +123,7 @@ impl PredExp for PredExpOr {
         String::from("OR")
     }
 
-    fn marshaled_size(&self) -> u32 {
+    fn marshaled_size(&self) -> usize {
         self.pred_exp_base.default_size() + 2
     }
 
@@ -138,9 +138,9 @@ impl PredExp for PredExpOr {
 #[macro_export]
 macro_rules! as_pred_or {
     ($nexpr:expr) => {{
-        $crate::query::predexp::PredExpOr{
-            pred_exp_base: $crate::query::predexp::PredExpBase{},
-            nexpr: $nexpr
+        $crate::query::predexp::PredExpOr {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            nexpr: $nexpr,
         }
     }};
 }
@@ -158,7 +158,7 @@ impl PredExp for PredExpNot {
         String::from("NOT")
     }
 
-    fn marshaled_size(&self) -> u32 {
+    fn marshaled_size(&self) -> usize {
         self.pred_exp_base.default_size()
     }
 
@@ -172,19 +172,718 @@ impl PredExp for PredExpNot {
 #[macro_export]
 macro_rules! as_pred_not {
     () => {{
-        $crate::query::predexp::PredExpNot{
-            pred_exp_base: $crate::query::predexp::PredExpBase{}
+        $crate::query::predexp::PredExpNot {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
         }
     }};
 }
 
 // ------------------------------------- PredExpIntegerValue
 
+/// Predicate for Integer Values
+#[derive(Debug, Clone)]
+pub struct PredExpIntegerValue {
+    pred_exp_base: PredExpBase,
+    pub val: i64,
+}
 
+impl PredExp for PredExpIntegerValue {
+    fn pred_string(&self) -> String {
+        self.val.to_string()
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size() + 8
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base
+            .write(buffer, AS_PREDEXP_INTEGER_VALUE, 8)?;
+        buffer.write_i64(self.val)?;
+        Ok(())
+    }
+}
+
+/// Create Integer Value Predicate
+#[macro_export]
+macro_rules! as_pred_int_val {
+    ($val:expr) => {{
+        $crate::query::predexp::PredExpIntegerValue {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            val: $val,
+        }
+    }};
+}
+
+// ------------------------------------- PredExpStringValue
+
+/// Predicate for Integer Values
+#[derive(Debug, Clone)]
+pub struct PredExpStringValue {
+    pred_exp_base: PredExpBase,
+    pub val: String,
+}
+
+impl PredExp for PredExpStringValue {
+    fn pred_string(&self) -> String {
+        self.val.clone()
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size() + self.val.len()
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base
+            .write(buffer, AS_PREDEXP_STRING_VALUE, self.val.len() as u32)?;
+        buffer.write_str(&self.val)?;
+        Ok(())
+    }
+}
+
+/// Create String Value Predicate
+#[macro_export]
+macro_rules! as_pred_str_val {
+    ($val:expr) => {{
+        $crate::query::predexp::PredExpStringValue {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            val: $val,
+        }
+    }};
+}
+
+// ------------------------------------- PredExpGeoJSONValue
+
+/// Predicate for GeoJSON Values
+#[derive(Debug, Clone)]
+pub struct PredExpGeoJSONValue {
+    pred_exp_base: PredExpBase,
+    pub val: String,
+}
+
+impl PredExp for PredExpGeoJSONValue {
+    fn pred_string(&self) -> String {
+        self.val.clone()
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size()
+            + 1 // flags
+            + 2 // ncells
+            + self.val.len()
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base.write(
+            buffer,
+            AS_PREDEXP_GEOJSON_VALUE,
+            (1 + 2 + self.val.len()) as u32,
+        )?;
+        buffer.write_u8(0u8)?;
+        buffer.write_u16(0)?;
+        buffer.write_str(&self.val)?;
+        Ok(())
+    }
+}
+
+/// Create GeoJSON Value Predicate
+#[macro_export]
+macro_rules! as_pred_geojson_val {
+    ($val:expr) => {{
+        $crate::query::predexp::PredExpGeoJSONValue {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            val: $val,
+        }
+    }};
+}
+
+// ------------------------------------- PredExpBin
+
+/// Predicate for Bins
+#[derive(Debug, Clone)]
+pub struct PredExpBin {
+    pred_exp_base: PredExpBase,
+    pub name: String,
+    pub tag: u16,
+}
+
+impl PredExp for PredExpBin {
+    fn pred_string(&self) -> String {
+        self.name.clone()
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size() + self.name.len()
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base
+            .write(buffer, self.tag, (self.name.len()) as u32)?;
+        buffer.write_str(&self.name)?;
+        Ok(())
+    }
+}
+
+/// Create Unknown Bin Predicate
+#[macro_export]
+macro_rules! as_pred_unknown_bin {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpBin {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_UNKNOWN_BIN,
+        }
+    }};
+}
+
+/// Create Integer Bin Predicate
+#[macro_export]
+macro_rules! as_pred_int_bin {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpBin {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_BIN,
+        }
+    }};
+}
+
+/// Create String Bin Predicate
+#[macro_export]
+macro_rules! as_pred_str_bin {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpBin {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_STRING_BIN,
+        }
+    }};
+}
+
+/// Create GeoJSON Bin Predicate
+#[macro_export]
+macro_rules! as_pred_geojson_bin {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpBin {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_GEOJSON_BIN,
+        }
+    }};
+}
+
+/// Create List Bin Predicate
+#[macro_export]
+macro_rules! as_pred_list_bin {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpBin {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_LIST_BIN,
+        }
+    }};
+}
+
+/// Create Map Bin Predicate
+#[macro_export]
+macro_rules! as_pred_map_bin {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpBin {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_MAP_BIN,
+        }
+    }};
+}
+
+// ------------------------------------- PredExpVar
+
+/// Predicate for Vars
+#[derive(Debug, Clone)]
+pub struct PredExpVar {
+    pred_exp_base: PredExpBase,
+    pub name: String,
+    pub tag: u16,
+}
+
+impl PredExp for PredExpVar {
+    fn pred_string(&self) -> String {
+        self.name.clone()
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size() + self.name.len()
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base
+            .write(buffer, self.tag, (self.name.len()) as u32)?;
+        buffer.write_str(&self.name)?;
+        Ok(())
+    }
+}
+
+/// Create 64Bit Integer Var used in list/map iterations
+#[macro_export]
+macro_rules! as_pred_int_var {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpVar {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_VAR,
+        }
+    }};
+}
+
+/// Create String Var used in list/map iterations
+#[macro_export]
+macro_rules! as_pred_str_var {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpVar {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_STRING_VAR,
+        }
+    }};
+}
+
+/// Create String Var used in list/map iterations
+#[macro_export]
+macro_rules! as_pred_geojson_var {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpVar {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_GEOJSON_VAR,
+        }
+    }};
+}
+
+// ------------------------------------- PredExpMD
+
+/// Predicate for MetaData (RecDeviceSize, RecLastUpdate, RecVoidTime)
+#[derive(Debug, Clone)]
+pub struct PredExpMD {
+    pred_exp_base: PredExpBase,
+    pub tag: u16, // not marshaled
+}
+
+impl PredExp for PredExpMD {
+    fn pred_string(&self) -> String {
+        match self.tag {
+            AS_PREDEXP_REC_DEVICE_SIZE => String::from("rec.DeviceSize"),
+            AS_PREDEXP_REC_LAST_UPDATE => String::from("rec.LastUpdate"),
+            AS_PREDEXP_REC_VOID_TIME => String::from("rec.Expiration"),
+            AS_PREDEXP_REC_DIGEST_MODULO => String::from("rec.DigestModulo"),
+            _ => panic!("Invalid Metadata tag."),
+        }
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size()
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base.write(buffer, self.tag, 0)?;
+        Ok(())
+    }
+}
+
+/// Create Record Size on Disk Predicate
+#[macro_export]
+macro_rules! as_pred_rec_device_size {
+    () => {{
+        $crate::query::predexp::PredExpMD {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_REC_DEVICE_SIZE,
+        }
+    }};
+}
+
+/// Create Last Update Predicate
+#[macro_export]
+macro_rules! as_pred_rec_last_update {
+    () => {{
+        $crate::query::predexp::PredExpMD {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_REC_LAST_UPDATE,
+        }
+    }};
+}
+
+/// Create Record Expiration Time Predicate in nanoseconds since 1970-01-01 epoch as 64 bit integer
+#[macro_export]
+macro_rules! as_pred_rec_void_time {
+    () => {{
+        $crate::query::predexp::PredExpMD {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_REC_VOID_TIME,
+        }
+    }};
+}
+
+// ------------------------------------- PredExpMDDigestModulo
+
+/// Predicate Digest Modulo Metadata Value
+/// The digest modulo expression assumes the value of 4 bytes of the
+// record's key digest modulo as its argument.
+// This predicate is available in Aerospike server versions 3.12.1+
+#[derive(Debug, Clone)]
+pub struct PredExpMDDigestModulo {
+    pred_exp_base: PredExpBase,
+    pub modulo: i32, // not marshaled
+}
+
+impl PredExp for PredExpMDDigestModulo {
+    fn pred_string(&self) -> String {
+        String::from("rec.DigestModulo")
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size() + 4
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base
+            .write(buffer, AS_PREDEXP_REC_DIGEST_MODULO, 4)?;
+        buffer.write_i32(self.modulo)?;
+        Ok(())
+    }
+}
+
+/// Creates a digest modulo record metadata value predicate expression.
+#[macro_export]
+macro_rules! as_pred_rec_digest_modulo {
+    ($modulo:expr) => {{
+        $crate::query::predexp::PredExpMDDigestModulo {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            modulo: $modulo,
+        }
+    }};
+}
+
+// ------------------------------------- PredExpCompare
+
+/// Predicate for comparing
+#[derive(Debug, Clone)]
+pub struct PredExpCompare {
+    pred_exp_base: PredExpBase,
+    pub tag: u16, // not marshaled
+}
+
+impl PredExp for PredExpCompare {
+    fn pred_string(&self) -> String {
+        match self.tag {
+            AS_PREDEXP_INTEGER_EQUAL | AS_PREDEXP_STRING_EQUAL => String::from("="),
+            AS_PREDEXP_INTEGER_UNEQUAL | AS_PREDEXP_STRING_UNEQUAL => String::from("!="),
+            AS_PREDEXP_INTEGER_GREATER => String::from(">"),
+            AS_PREDEXP_INTEGER_GREATEREQ => String::from(">="),
+            AS_PREDEXP_INTEGER_LESS => String::from("<"),
+            AS_PREDEXP_INTEGER_LESSEQ => String::from("<="),
+            AS_PREDEXP_STRING_REGEX => String::from("~="),
+            AS_PREDEXP_GEOJSON_CONTAINS => String::from("CONTAINS"),
+            AS_PREDEXP_GEOJSON_WITHIN => String::from("WITHIN"),
+            _ => panic!("unexpected predicate tag"),
+        }
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size()
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base.write(buffer, self.tag, 0)?;
+        Ok(())
+    }
+}
+
+/// Creates Equal predicate for integer values
+#[macro_export]
+macro_rules! as_pred_int_eq {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_EQUAL,
+        }
+    }};
+}
+
+/// Creates NotEqual predicate for integer values
+#[macro_export]
+macro_rules! as_pred_int_uneq {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_UNEQUAL,
+        }
+    }};
+}
+
+/// Creates Greater Than predicate for integer values
+#[macro_export]
+macro_rules! as_pred_int_gt {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_GREATER,
+        }
+    }};
+}
+
+/// Creates Greater Than Or Equal predicate for integer values
+#[macro_export]
+macro_rules! as_pred_int_gteq {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_GREATEREQ,
+        }
+    }};
+}
+
+/// Creates Less Than predicate for integer values
+#[macro_export]
+macro_rules! as_pred_int_lt {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_LESS,
+        }
+    }};
+}
+
+/// Creates Less Than Or Equal predicate for integer values
+#[macro_export]
+macro_rules! as_pred_int_lteq {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_INTEGER_LESSEQ,
+        }
+    }};
+}
+
+/// Creates Equal predicate for string values
+#[macro_export]
+macro_rules! as_pred_str_eq {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_STRING_EQUAL,
+        }
+    }};
+}
+
+/// Creates Not Equal predicate for string values
+#[macro_export]
+macro_rules! as_pred_str_uneq {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_STRING_UNEQUAL,
+        }
+    }};
+}
+
+/// Creates Within Region predicate for GeoJSON values
+#[macro_export]
+macro_rules! as_pred_geojson_within {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_GEOJSON_WITHIN,
+        }
+    }};
+}
+
+/// Creates Region Contains predicate for GeoJSON values
+#[macro_export]
+macro_rules! as_pred_geojson_contains {
+    () => {{
+        $crate::query::predexp::PredExpCompare {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            tag: $crate::query::predexp::AS_PREDEXP_GEOJSON_CONTAINS,
+        }
+    }};
+}
+
+// ------------------------------------- PredExpStringRegex
+
+/// Predicate for String Regex
+#[derive(Debug, Clone)]
+pub struct PredExpStringRegex {
+    pred_exp_base: PredExpBase,
+    pub cflags: u32, // not marshaled
+}
+
+impl PredExp for PredExpStringRegex {
+    fn pred_string(&self) -> String {
+        String::from("regex:")
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size() + 4
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base
+            .write(buffer, AS_PREDEXP_STRING_REGEX, 4)?;
+        buffer.write_u32(self.cflags)?;
+        Ok(())
+    }
+}
+
+/// Creates a Regex predicate
+#[macro_export]
+macro_rules! as_pred_string_regex {
+    ($cflags:expr) => {{
+        $crate::query::predexp::PredExpStringRegex {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            cflags: $cflags,
+        }
+    }};
+}
+
+// ------------------------------------- PredExp???Iterate???
+
+/// Predicate for Iterators
+#[derive(Debug, Clone)]
+pub struct PredExpIter {
+    pred_exp_base: PredExpBase,
+    pub name: String,
+    pub tag: u16, // not marshaled
+}
+
+impl PredExp for PredExpIter {
+    fn pred_string(&self) -> String {
+        match self.tag {
+            AS_PREDEXP_LIST_ITERATE_OR => {
+                let mut tagname = String::from("list_iterate_or using \"");
+                tagname.push_str(&self.name);
+                tagname.push_str("\":");
+                tagname
+            }
+            AS_PREDEXP_MAPKEY_ITERATE_OR => {
+                let mut tagname = String::from("mapkey_iterate_or using \"");
+                tagname.push_str(&self.name);
+                tagname.push_str("\":");
+                tagname
+            }
+            AS_PREDEXP_MAPVAL_ITERATE_OR => {
+                let mut tagname = String::from("mapval_iterate_or using \"");
+                tagname.push_str(&self.name);
+                tagname.push_str("\":");
+                tagname
+            }
+            AS_PREDEXP_LIST_ITERATE_AND => {
+                let mut tagname = String::from("list_iterate_and using \"");
+                tagname.push_str(&self.name);
+                tagname.push_str("\":");
+                tagname
+            }
+            AS_PREDEXP_MAPKEY_ITERATE_AND => {
+                let mut tagname = String::from("mapkey_iterate_and using \"");
+                tagname.push_str(&self.name);
+                tagname.push_str("\":");
+                tagname
+            }
+            AS_PREDEXP_MAPVAL_ITERATE_AND => {
+                let mut tagname = String::from("mapvalue_iterate_and using \"");
+                tagname.push_str(&self.name);
+                tagname.push_str("\":");
+                tagname
+            }
+            _ => panic!("Invalid Metadata tag."),
+        }
+    }
+
+    fn marshaled_size(&self) -> usize {
+        self.pred_exp_base.default_size() + self.name.len()
+    }
+
+    fn write(&self, buffer: &mut Buffer) -> Result<()> {
+        self.pred_exp_base
+            .write(buffer, AS_PREDEXP_STRING_REGEX, self.name.len() as u32)?;
+        buffer.write_str(&self.name)?;
+        Ok(())
+    }
+}
+
+/// Creates an Or iterator predicate for list items
+#[macro_export]
+macro_rules! as_pred_list_iterate_or {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpIter {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_LIST_ITERATE_OR,
+        }
+    }};
+}
+
+/// Creates an And iterator predicate for list items
+#[macro_export]
+macro_rules! as_pred_list_iterate_and {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpIter {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_LIST_ITERATE_AND,
+        }
+    }};
+}
+
+/// Creates an Or iterator predicate on map keys
+#[macro_export]
+macro_rules! as_pred_mapkey_iterate_or {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpIter {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_MAPKEY_ITERATE_OR,
+        }
+    }};
+}
+
+/// Creates an And iterator predicate on map keys
+#[macro_export]
+macro_rules! as_pred_mapkey_iterate_and {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpIter {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_MAPKEY_ITERATE_AND,
+        }
+    }};
+}
+
+/// Creates an Or iterator predicate on map values
+#[macro_export]
+macro_rules! as_pred_mapval_iterate_or {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpIter {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_MAPVAL_ITERATE_OR,
+        }
+    }};
+}
+
+/// Creates an And iterator predicate on map values
+#[macro_export]
+macro_rules! as_pred_mapval_iterate_and {
+    ($name:expr) => {{
+        $crate::query::predexp::PredExpIter {
+            pred_exp_base: $crate::query::predexp::PredExpBase {},
+            name: $name,
+            tag: $crate::query::predexp::AS_PREDEXP_MAPVAL_ITERATE_AND,
+        }
+    }};
+}
 
 #[cfg(test)]
 mod tests {
-    use crate::query::predexp::PredExp;
+    use crate::query::predexp::*;
 
     #[test]
     fn predicate_macros() {
@@ -198,5 +897,98 @@ mod tests {
 
         let pred_not = as_pred_not!();
         assert_eq!(pred_not.pred_string(), "NOT");
+
+        let pred_int_val = as_pred_int_val!(2);
+        assert_eq!(pred_int_val.pred_string(), "2");
+        assert_eq!(pred_int_val.val, 2);
+
+        let pred_str_val = as_pred_str_val!(String::from("test"));
+        assert_eq!(pred_str_val.pred_string(), "test");
+        assert_eq!(pred_str_val.val, "test");
+
+        let pred_geo_val = as_pred_geojson_val!(String::from("test"));
+        assert_eq!(pred_geo_val.pred_string(), "test");
+        assert_eq!(pred_geo_val.val, "test");
+
+        let bin_unknown = as_pred_unknown_bin!(String::from("test"));
+        assert_eq!(bin_unknown.pred_string(), "test");
+        assert_eq!(bin_unknown.tag, AS_PREDEXP_UNKNOWN_BIN);
+
+        let int_bin = as_pred_int_bin!(String::from("test"));
+        assert_eq!(int_bin.pred_string(), "test");
+        assert_eq!(int_bin.tag, AS_PREDEXP_INTEGER_BIN);
+
+        let str_bin = as_pred_str_bin!(String::from("test"));
+        assert_eq!(str_bin.pred_string(), "test");
+        assert_eq!(str_bin.tag, AS_PREDEXP_STRING_BIN);
+
+        let geo_bin = as_pred_geojson_bin!(String::from("test"));
+        assert_eq!(geo_bin.pred_string(), "test");
+        assert_eq!(geo_bin.tag, AS_PREDEXP_GEOJSON_BIN);
+
+        let list_bin = as_pred_list_bin!(String::from("test"));
+        assert_eq!(list_bin.pred_string(), "test");
+        assert_eq!(list_bin.tag, AS_PREDEXP_LIST_BIN);
+
+        let map_bin = as_pred_map_bin!(String::from("test"));
+        assert_eq!(map_bin.pred_string(), "test");
+        assert_eq!(map_bin.tag, AS_PREDEXP_MAP_BIN);
+
+        let int_var = as_pred_int_var!(String::from("test"));
+        assert_eq!(int_var.pred_string(), "test");
+        assert_eq!(int_var.tag, AS_PREDEXP_INTEGER_VAR);
+
+        let str_var = as_pred_str_var!(String::from("test"));
+        assert_eq!(str_var.pred_string(), "test");
+        assert_eq!(str_var.tag, AS_PREDEXP_STRING_VAR);
+
+        let geo_var = as_pred_geojson_var!(String::from("test"));
+        assert_eq!(geo_var.pred_string(), "test");
+        assert_eq!(geo_var.tag, AS_PREDEXP_GEOJSON_VAR);
+
+        let dev_size = as_pred_rec_device_size!();
+        assert_eq!(dev_size.tag, AS_PREDEXP_REC_DEVICE_SIZE);
+
+        let last_update = as_pred_rec_last_update!();
+        assert_eq!(last_update.tag, AS_PREDEXP_REC_LAST_UPDATE);
+
+        let void_time = as_pred_rec_void_time!();
+        assert_eq!(void_time.tag, AS_PREDEXP_REC_VOID_TIME);
+
+        let digest_modulo = as_pred_rec_digest_modulo!(10);
+        assert_eq!(digest_modulo.modulo, 10);
+
+        let int_eq = as_pred_int_eq!();
+        assert_eq!(int_eq.tag, AS_PREDEXP_INTEGER_EQUAL);
+
+        let int_uneq = as_pred_int_uneq!();
+        assert_eq!(int_uneq.tag, AS_PREDEXP_INTEGER_UNEQUAL);
+
+        let int_gt = as_pred_int_gt!();
+        assert_eq!(int_gt.tag, AS_PREDEXP_INTEGER_GREATER);
+
+        let int_gteq = as_pred_int_gteq!();
+        assert_eq!(int_gteq.tag, AS_PREDEXP_INTEGER_GREATEREQ);
+
+        let int_lt = as_pred_int_lt!();
+        assert_eq!(int_lt.tag, AS_PREDEXP_INTEGER_LESS);
+
+        let int_lteq = as_pred_int_lteq!();
+        assert_eq!(int_lteq.tag, AS_PREDEXP_INTEGER_LESSEQ);
+
+        let str_eq = as_pred_str_eq!();
+        assert_eq!(str_eq.tag, AS_PREDEXP_STRING_EQUAL);
+
+        let str_uneq = as_pred_str_uneq!();
+        assert_eq!(str_uneq.tag, AS_PREDEXP_STRING_UNEQUAL);
+
+        let geo_within = as_pred_geojson_within!();
+        assert_eq!(geo_within.tag, AS_PREDEXP_GEOJSON_WITHIN);
+
+        let geo_contains = as_pred_geojson_contains!();
+        assert_eq!(geo_contains.tag, AS_PREDEXP_GEOJSON_CONTAINS);
+
+        let string_reg = as_pred_string_regex!(5);
+        assert_eq!(string_reg.cflags, 5);
     }
 }

--- a/src/query/predexp.rs
+++ b/src/query/predexp.rs
@@ -76,8 +76,11 @@ pub const _AS_PREDEXP_MAPVAL_ITERATE_AND: u16 = 255;
 
 #[doc(hidden)]
 pub trait PredExp: Send + Sync {
+    // Returns String Value of the Predicate action
     fn pred_string(&self) -> String;
+    // Returns the absolute size of the Predicate (default_size + additional-size)
     fn marshaled_size(&self) -> usize;
+    // Writes the PredExp to the Command Buffer
     fn write(&self, buffer: &mut Buffer) -> Result<()>;
 
     // Default Header Size

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -48,7 +48,7 @@ pub struct Statement {
     /// Optional Lua aggregation function parameters.
     pub aggregation: Option<Aggregation>,
 
-    /// Optional filter Predicate
+    /// Predicate Filter
     pub predexp: Vec<Arc<Box<dyn PredExp>>>,
 }
 
@@ -106,8 +106,8 @@ impl Statement {
     ///
     /// # Example
     ///
-    /// This example uses a numeric index on bin _baz_ in namespace _foo_ within set _bar_ to find
-    /// all records using a filter with the range 0 to 100 inclusive:
+    /// This Example uses a simple predexp Filter to find all records in namespace _foo_ and set _bar_
+    /// where the _age_ Bin is equal to 32.
     ///
     /// ```rust
     /// # use aerospike::*;

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -14,9 +14,10 @@
 // the License.
 
 use crate::errors::{ErrorKind, Result};
-use crate::query::Filter;
+use crate::query::{Filter};
 use crate::Bins;
 use crate::Value;
+use crate::query::predexp::PredExp;
 
 #[derive(Clone)]
 pub struct Aggregation {
@@ -26,7 +27,6 @@ pub struct Aggregation {
 }
 
 /// Query statement parameters.
-#[derive(Clone)]
 pub struct Statement {
     /// Namespace
     pub namespace: String,
@@ -46,6 +46,9 @@ pub struct Statement {
 
     /// Optional Lua aggregation function parameters.
     pub aggregation: Option<Aggregation>,
+
+    /// Optional filter Predicate
+    pub predexp: Vec<Box<dyn PredExp>>,
 }
 
 impl Statement {
@@ -70,6 +73,7 @@ impl Statement {
             index_name: None,
             aggregation: None,
             filters: None,
+            predexp: Vec::new()
         }
     }
 
@@ -95,6 +99,10 @@ impl Statement {
             filters.push(filter);
             self.filters = Some(filters);
         }
+    }
+
+    pub fn add_predicate<S: PredExp + 'static>(&mut self, predicate: S) {
+            self.predexp.push(Box::new(predicate));
     }
 
     /// Set Lua aggregation function parameters.

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -14,8 +14,8 @@
 // the License.
 
 use crate::errors::{ErrorKind, Result};
-use crate::query::Filter;
 use crate::query::predexp::PredExp;
+use crate::query::Filter;
 use crate::Bins;
 use crate::Value;
 use std::sync::Arc;

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -18,6 +18,7 @@ use crate::query::{Filter};
 use crate::Bins;
 use crate::Value;
 use crate::query::predexp::PredExp;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Aggregation {
@@ -48,7 +49,7 @@ pub struct Statement {
     pub aggregation: Option<Aggregation>,
 
     /// Optional filter Predicate
-    pub predexp: Vec<Box<dyn PredExp>>,
+    pub predexp: Vec<Arc<Box<dyn PredExp>>>,
 }
 
 impl Statement {
@@ -101,8 +102,24 @@ impl Statement {
         }
     }
 
+    /// Add a Predicate filter to the statement.
+    ///
+    /// # Example
+    ///
+    /// This example uses a numeric index on bin _baz_ in namespace _foo_ within set _bar_ to find
+    /// all records using a filter with the range 0 to 100 inclusive:
+    ///
+    /// ```rust
+    /// # use aerospike::*;
+    /// use aerospike::query::PredExpAnd;
+    ///
+    /// let mut stmt = Statement::new("foo", "bar", Bins::from(["name", "age"]));
+    /// stmt.add_predicate(PredExpIntegerBin::new("age"));
+    /// stmt.add_predicate(PredExpIntegerValue::new(5));
+    /// stmt.add_predicate(PredExpIntegerEqual::new());
+    /// ```
     pub fn add_predicate<S: PredExp + 'static>(&mut self, predicate: S) {
-            self.predexp.push(Box::new(predicate));
+            self.predexp.push(Arc::new(Box::new(predicate)));
     }
 
     /// Set Lua aggregation function parameters.

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -14,10 +14,10 @@
 // the License.
 
 use crate::errors::{ErrorKind, Result};
-use crate::query::{Filter};
+use crate::query::predexp::PredExp;
+use crate::query::Filter;
 use crate::Bins;
 use crate::Value;
-use crate::query::predexp::PredExp;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -74,7 +74,7 @@ impl Statement {
             index_name: None,
             aggregation: None,
             filters: None,
-            predexp: Vec::new()
+            predexp: Vec::new(),
         }
     }
 
@@ -119,7 +119,7 @@ impl Statement {
     /// stmt.add_predicate(PredExpIntegerEqual::new());
     /// ```
     pub fn add_predicate<S: PredExp + 'static>(&mut self, predicate: S) {
-            self.predexp.push(Arc::new(Box::new(predicate)));
+        self.predexp.push(Arc::new(Box::new(predicate)));
     }
 
     /// Set Lua aggregation function parameters.

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -113,9 +113,9 @@ impl Statement {
     /// # use aerospike::*;
     ///
     /// let mut stmt = Statement::new("foo", "bar", Bins::from(["name", "age"]));
-    /// stmt.add_predicate(as_pred_int_bin!("age".to_string()));
-    /// stmt.add_predicate(as_pred_int_val!(32));
-    /// stmt.add_predicate(as_pred_int_eq!());
+    /// stmt.add_predicate(as_predexp_integer_bin!("age".to_string()));
+    /// stmt.add_predicate(as_predexp_integer_value!(32));
+    /// stmt.add_predicate(as_predexp_integer_equal!());
     /// ```
     pub fn add_predicate<S: PredExp + 'static>(&mut self, predicate: S) {
         self.predexp.push(Arc::new(Box::new(predicate)));

--- a/src/query/statement.rs
+++ b/src/query/statement.rs
@@ -14,8 +14,8 @@
 // the License.
 
 use crate::errors::{ErrorKind, Result};
-use crate::query::predexp::PredExp;
 use crate::query::Filter;
+use crate::query::predexp::PredExp;
 use crate::Bins;
 use crate::Value;
 use std::sync::Arc;
@@ -111,12 +111,11 @@ impl Statement {
     ///
     /// ```rust
     /// # use aerospike::*;
-    /// use aerospike::query::PredExpAnd;
     ///
     /// let mut stmt = Statement::new("foo", "bar", Bins::from(["name", "age"]));
-    /// stmt.add_predicate(PredExpIntegerBin::new("age"));
-    /// stmt.add_predicate(PredExpIntegerValue::new(5));
-    /// stmt.add_predicate(PredExpIntegerEqual::new());
+    /// stmt.add_predicate(as_pred_int_bin!("age".to_string()));
+    /// stmt.add_predicate(as_pred_int_val!(32));
+    /// stmt.add_predicate(as_pred_int_eq!());
     /// ```
     pub fn add_predicate<S: PredExp + 'static>(&mut self, predicate: S) {
         self.predexp.push(Arc::new(Box::new(predicate)));

--- a/src/record.rs
+++ b/src/record.rs
@@ -98,7 +98,7 @@ impl fmt::Display for Record {
 
 #[cfg(test)]
 mod tests {
-    use super::{CITRUSLEAF_EPOCH, Record};
+    use super::{Record, CITRUSLEAF_EPOCH};
     use std::collections::HashMap;
     use std::time::{Duration, SystemTime};
 

--- a/tests/src/batch.rs
+++ b/tests/src/batch.rs
@@ -15,7 +15,7 @@
 
 use aerospike::BatchRead;
 use aerospike::Bins;
-use aerospike::{BatchPolicy, Concurrency, WritePolicy, as_bin, as_key};
+use aerospike::{as_bin, as_key, BatchPolicy, Concurrency, WritePolicy};
 
 use env_logger;
 

--- a/tests/src/cdt_list.rs
+++ b/tests/src/cdt_list.rs
@@ -18,7 +18,7 @@ use env_logger;
 
 use aerospike::operations;
 use aerospike::operations::lists;
-use aerospike::{Bins, ReadPolicy, Value, WritePolicy, as_key, as_list, as_bin, as_values, as_val};
+use aerospike::{as_bin, as_key, as_list, as_val, as_values, Bins, ReadPolicy, Value, WritePolicy};
 
 #[test]
 fn cdt_list() {

--- a/tests/src/cdt_map.rs
+++ b/tests/src/cdt_map.rs
@@ -19,7 +19,10 @@ use crate::common;
 use env_logger;
 
 use aerospike::operations::maps;
-use aerospike::{Bins, MapPolicy, MapReturnType, ReadPolicy, WritePolicy, as_list, as_val, as_key, as_map, as_bin};
+use aerospike::{
+    as_bin, as_key, as_list, as_map, as_val, Bins, MapPolicy, MapReturnType, ReadPolicy,
+    WritePolicy,
+};
 
 #[test]
 fn map_operations() {

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -12,9 +12,11 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-use std::collections::HashMap;
 use aerospike::operations;
-use aerospike::{Bins, ReadPolicy, Value, WritePolicy, as_map, as_geo, as_val, as_list, as_blob, as_key, as_bin};
+use aerospike::{
+    as_bin, as_blob, as_geo, as_key, as_list, as_map, as_val, Bins, ReadPolicy, Value, WritePolicy,
+};
+use std::collections::HashMap;
 
 use env_logger;
 

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -116,7 +116,7 @@ fn query_predexp() {
     let mut count = 0;
     for res in &*rs {
         match res {
-            Ok(rec) => {
+            Ok(_rec) => {
                 count += 1;
             }
             Err(err) => panic!(format!("{:?}", err)),

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -99,6 +99,33 @@ fn query_single_consumer() {
 }
 
 #[test]
+fn query_predexp(){
+    let _ = env_logger::try_init();
+
+    let client = common::client();
+    let namespace = common::namespace();
+    let set_name = create_test_set(EXPECTED);
+    let qpolicy = QueryPolicy::default();
+
+    // Filter Query
+    let mut statement = Statement::new(namespace, &set_name, Bins::All);
+    statement.add_predicate(as_pred_int_bin!("bin".to_string()));
+    statement.add_predicate(as_pred_int_val!(19));
+    statement.add_predicate(as_pred_int_lteq!());
+    let rs = client.query(&qpolicy, statement).unwrap();
+    let mut count = 0;
+    for res in &*rs {
+        match res {
+            Ok(rec) => {
+                count += 1;
+            }
+            Err(err) => panic!(format!("{:?}", err)),
+        }
+    }
+    assert_eq!(count, 20);
+}
+
+#[test]
 fn query_nobins() {
     let _ = env_logger::try_init();
 

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -99,7 +99,7 @@ fn query_single_consumer() {
 }
 
 #[test]
-fn query_predexp(){
+fn query_predexp() {
     let _ = env_logger::try_init();
 
     let client = common::client();

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -109,9 +109,9 @@ fn query_predexp(){
 
     // Filter Query
     let mut statement = Statement::new(namespace, &set_name, Bins::All);
-    statement.add_predicate(as_pred_int_bin!("bin".to_string()));
-    statement.add_predicate(as_pred_int_val!(19));
-    statement.add_predicate(as_pred_int_lteq!());
+    statement.add_predicate(as_predexp_integer_bin!("bin".to_string()));
+    statement.add_predicate(as_predexp_integer_value!(19));
+    statement.add_predicate(as_predexp_integer_lesseq!());
     let rs = client.query(&qpolicy, statement).unwrap();
     let mut count = 0;
     for res in &*rs {

--- a/tests/src/scan.rs
+++ b/tests/src/scan.rs
@@ -20,7 +20,7 @@ use std::thread;
 use crate::common;
 use env_logger;
 
-use aerospike::{Bins, ScanPolicy, WritePolicy, as_key, as_bin};
+use aerospike::{as_bin, as_key, Bins, ScanPolicy, WritePolicy};
 
 const EXPECTED: usize = 1000;
 


### PR DESCRIPTION
This is an implementation for Predicate Filtering. Related to #70 

Changes:
Predicates added to query/predexp.rs
Predicate Handling added to query/statement.rs
Modified commands/buffer.rs to add Headers and Values for predicates
Added test/example to tests/query.rs
Fixed some compiler and clippy warnings in various files.

Please review and report to me if you have any ideas how to improve it. 
Docs still need some work.