### PR TITLE
IndexTask: Return Status::Complete only once all nodes complete the task

### DIFF
--- a/src/task/index_task.rs
+++ b/src/task/index_task.rs
@@ -101,7 +101,10 @@ impl Task for IndexTask {
                 return Ok(Status::NotFound);
             }
 
-            return IndexTask::parse_response(&response[command]);
+            match IndexTask::parse_response(&response[command]) {
+                Ok(Status::Complete) => {}
+                in_progress_or_error => return in_progress_or_error,
+            }
         }
         return Ok(Status::Complete);
     }


### PR DESCRIPTION
Follow-up to #69: Index task should return `Status::Complete` only once _all_ nodes complete the task.