### PR TITLE
Clear connection buffer on server error

### DIFF
--- a/src/commands/stream_command.rs
+++ b/src/commands/stream_command.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Aerospike, Inc.
+// Copyright 2015-2020 Aerospike, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,19 +45,17 @@ impl StreamCommand {
     }
 
     fn parse_record(conn: &mut Connection, size: usize) -> Result<Option<Record>> {
-        // A number of these are commented out because we just don't care enough to read
-        // that section of the header. If we do care, uncomment and check!
         let result_code = ResultCode::from(conn.buffer.read_u8(Some(5))?);
         if result_code != ResultCode::Ok {
-            if result_code == ResultCode::KeyNotFoundError {
-                if conn.bytes_read() < size {
-                    let remaining = size - conn.bytes_read();
-                    conn.read_buffer(remaining)?;
-                }
-                return Ok(None);
+            if conn.bytes_read() < size {
+                let remaining = size - conn.bytes_read();
+                conn.read_buffer(remaining)?;
             }
 
-            bail!(ErrorKind::ServerError(result_code));
+            match result_code {
+                ResultCode::KeyNotFoundError => return Ok(None),
+                _ => bail!(ErrorKind::ServerError(result_code)),
+            }
         }
 
         // if cmd is the end marker of the response, do not proceed further


### PR DESCRIPTION
When a scan/query command returns a server error, we need to always clear the connection buffer.

Also adds protection for excessive memory allocation due to parse errors to the info command buffer, similar to the regular connection buffer.

Resolves #75.