### PR TITLE
Fix issue: Memory leaks #82

### DIFF
--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -126,9 +126,9 @@ impl Buffer {
             bail!("Invalid size for buffer: {}", size);
         }
 
-        let len = self.data_buffer.len();
+        let mem_size = self.data_buffer.capacity();
         self.data_buffer.resize(size, 0);
-        if len > 8192 && size < len {
+        if mem_size > 8192 && size < mem_size {
             self.data_buffer.shrink_to_fit();
         }
 

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -99,13 +99,15 @@ const MAX_BUFFER_SIZE: usize = 1024 * 1024 + 8; // 1 MB + header
 pub struct Buffer {
     pub data_buffer: Vec<u8>,
     pub data_offset: usize,
+    pub reclaim_threshold: usize,
 }
 
 impl Buffer {
-    pub fn new() -> Self {
+    pub fn new(reclaim_threshold: usize) -> Self {
         Buffer {
             data_buffer: Vec::with_capacity(1024),
             data_offset: 0,
+            reclaim_threshold,
         }
     }
 
@@ -128,7 +130,7 @@ impl Buffer {
 
         let mem_size = self.data_buffer.capacity();
         self.data_buffer.resize(size, 0);
-        if mem_size > 8192 && size < mem_size {
+        if mem_size > self.reclaim_threshold && size < mem_size {
             self.data_buffer.shrink_to_fit();
         }
 

--- a/src/commands/buffer.rs
+++ b/src/commands/buffer.rs
@@ -126,7 +126,11 @@ impl Buffer {
             bail!("Invalid size for buffer: {}", size);
         }
 
+        let len = self.data_buffer.len();
         self.data_buffer.resize(size, 0);
+        if len > 8192 && size < len {
+            self.data_buffer.shrink_to_fit();
+        }
 
         Ok(())
     }

--- a/src/net/connection.rs
+++ b/src/net/connection.rs
@@ -43,7 +43,7 @@ impl Connection {
     pub fn new<T: ToSocketAddrs>(addr: T, policy: &ClientPolicy) -> Result<Self> {
         let stream = TcpStream::connect(addr)?;
         let mut conn = Connection {
-            buffer: Buffer::new(),
+            buffer: Buffer::new(policy.buffer_reclaim_threshold),
             bytes_read: 0,
             timeout: policy.timeout,
             conn: stream,

--- a/src/policy/client_policy.rs
+++ b/src/policy/client_policy.rs
@@ -99,7 +99,7 @@ impl Default for ClientPolicy {
             use_services_alternate: false,
             thread_pool_size: 128,
             cluster_name: None,
-            buffer_reclaim_threshold: 8192,
+            buffer_reclaim_threshold: 65536,
         }
     }
 }

--- a/src/policy/client_policy.rs
+++ b/src/policy/client_policy.rs
@@ -45,6 +45,13 @@ pub struct ClientPolicy {
     /// Throw exception if host connection fails during addHost().
     pub fail_if_not_connected: bool,
 
+    /// Threshold at which the buffer attached to the connection will be shrunk by deallocating
+    /// memory instead of just resetting the size of the underlying vec.
+    /// Should be set to a value that covers as large a percentile of payload sizes as possible,
+    /// while also being small enough not to occupy a significant amount of memory for the life
+    /// of the connection pool.
+    pub buffer_reclaim_threshold: usize,
+
     /// TendInterval determines interval for checking for cluster state changes.
     /// Minimum possible interval is 10 Milliseconds.
     pub tend_interval: Duration,
@@ -92,6 +99,7 @@ impl Default for ClientPolicy {
             use_services_alternate: false,
             thread_pool_size: 128,
             cluster_name: None,
+            buffer_reclaim_threshold: 8192,
         }
     }
 }


### PR DESCRIPTION
Make sure to shrink the allocation of the buffers once they have grown past a certain size and we are trying to truncate them. The value is probably something one might want to tune.