### PR TITLE
Restrict Travis CI tests to stable/beta/nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ rust:
   - nightly
   - beta
   - stable
-  - 1.38.0
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
Testing against a specific, older Rust version to assure a minimum supported Rust version for the client is proving futile. Every so often, Travis CI will pick up an updated dependency (often an indirect dependency) that requires a newer Rust version, breaking the build. And because we're following the [Cargo team's recommendation](https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html) to not check in the Cargo.lock file for library crates there is nothing we can do about that. So even though the client still compiles fine on older Rust versions, there is no good way to test that.