### PR TITLE
Serde Serializers for Record and Value objects

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -120,3 +120,4 @@ build: false
 # environment variable.
 test_script:
   - cargo test --lib --verbose %cargoflags%
+  - cargo test --lib --features "serialization" --verbose %cargoflags%

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
   - rm -rf target/debug/deps/*aerospike*
   - cargo build
   - cargo test --verbose
+  - cargo build --features "serialization"
+  - cargo test --features "serialization" --verbose
   - rustdoc -L target/debug/deps/ --test README.md
 after_script:
 - tail -n +1 aerospike-server/instance?/var/log/aerospike.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
   - rm -rf target/debug/deps/*aerospike*
   - cargo build
   - cargo test --verbose
+  - rustdoc -L target/debug/deps/ --test README.md
+  - rm -rf target/debug/deps/*aerospike*
   - cargo build --features "serialization"
   - cargo test --features "serialization" --verbose
   - rustdoc -L target/debug/deps/ --test README.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,10 @@ lazy_static = "1.4"
 error-chain = "0.12"
 parking_lot = "0.9"
 pwhash = "0.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
+
+[features]
+serialization = ["serde"]
 
 [dev-dependencies]
 env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,13 @@ lazy_static = "1.4"
 error-chain = "0.12"
 parking_lot = "0.9"
 pwhash = "0.3"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 env_logger = "0.7"
 hex = "0.4"
 bencher = "0.1"
+serde_json = "1.0"
 
 [[bench]]
 name = "client_server"

--- a/src/batch/batch_read.rs
+++ b/src/batch/batch_read.rs
@@ -16,7 +16,7 @@
 use crate::Bins;
 use crate::Key;
 use crate::Record;
-#[cfg(feature="serialization")]
+#[cfg(feature = "serialization")]
 use serde::Serialize;
 
 /// Key and bin names used in batch read commands where variable bins are needed for each key.

--- a/src/batch/batch_read.rs
+++ b/src/batch/batch_read.rs
@@ -16,8 +16,10 @@
 use crate::Bins;
 use crate::Key;
 use crate::Record;
+use serde::{Serialize};
 
 /// Key and bin names used in batch read commands where variable bins are needed for each key.
+#[derive(Serialize)]
 pub struct BatchRead<'a> {
     /// Key.
     pub key: Key,

--- a/src/batch/batch_read.rs
+++ b/src/batch/batch_read.rs
@@ -16,7 +16,7 @@
 use crate::Bins;
 use crate::Key;
 use crate::Record;
-use serde::{Serialize};
+use serde::Serialize;
 
 /// Key and bin names used in batch read commands where variable bins are needed for each key.
 #[derive(Serialize)]

--- a/src/batch/batch_read.rs
+++ b/src/batch/batch_read.rs
@@ -16,10 +16,11 @@
 use crate::Bins;
 use crate::Key;
 use crate::Record;
+#[cfg(feature="serialization")]
 use serde::Serialize;
 
 /// Key and bin names used in batch read commands where variable bins are needed for each key.
-#[derive(Serialize)]
+#[cfg_attr(feature = "serialization", derive(Serialize))]
 pub struct BatchRead<'a> {
     /// Key.
     pub key: Key,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -14,7 +14,7 @@
 // the License.
 
 use std::convert::From;
-
+use serde::{Serialize};
 use crate::value::Value;
 
 /// Container object for a record bin, comprising a name and a value.
@@ -51,7 +51,7 @@ macro_rules! as_bin {
 }
 
 /// Specify which, if any, bins to return in read operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub enum Bins {
     /// Read all bins.
     All,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -13,9 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::convert::From;
-use serde::{Serialize};
 use crate::value::Value;
+use serde::Serialize;
+use std::convert::From;
 
 /// Container object for a record bin, comprising a name and a value.
 pub struct Bin<'a> {

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -14,6 +14,7 @@
 // the License.
 
 use crate::value::Value;
+#[cfg(feature="serialization")]
 use serde::Serialize;
 use std::convert::From;
 
@@ -51,7 +52,8 @@ macro_rules! as_bin {
 }
 
 /// Specify which, if any, bins to return in read operations.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serialization", derive(Serialize))]
 pub enum Bins {
     /// Read all bins.
     All,

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -14,7 +14,7 @@
 // the License.
 
 use crate::value::Value;
-#[cfg(feature="serialization")]
+#[cfg(feature = "serialization")]
 use serde::Serialize;
 use std::convert::From;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -21,11 +21,11 @@ use crate::Value;
 
 use ripemd160::digest::Digest;
 use ripemd160::Ripemd160;
-
+use serde::{Serialize};
 /// Unique record identifier. Records can be identified using a specified namespace, an optional
 /// set name and a user defined key which must be uique within a set. Records can also be
 /// identified by namespace/digest, which is the combination used on the server.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Key {
     /// Namespace.
     pub namespace: String,

--- a/src/key.rs
+++ b/src/key.rs
@@ -21,7 +21,7 @@ use crate::Value;
 
 use ripemd160::digest::Digest;
 use ripemd160::Ripemd160;
-#[cfg(feature="serialization")]
+#[cfg(feature = "serialization")]
 use serde::Serialize;
 /// Unique record identifier. Records can be identified using a specified namespace, an optional
 /// set name and a user defined key which must be uique within a set. Records can also be

--- a/src/key.rs
+++ b/src/key.rs
@@ -21,7 +21,7 @@ use crate::Value;
 
 use ripemd160::digest::Digest;
 use ripemd160::Ripemd160;
-use serde::{Serialize};
+use serde::Serialize;
 /// Unique record identifier. Records can be identified using a specified namespace, an optional
 /// set name and a user defined key which must be uique within a set. Records can also be
 /// identified by namespace/digest, which is the combination used on the server.

--- a/src/key.rs
+++ b/src/key.rs
@@ -21,11 +21,13 @@ use crate::Value;
 
 use ripemd160::digest::Digest;
 use ripemd160::Ripemd160;
+#[cfg(feature="serialization")]
 use serde::Serialize;
 /// Unique record identifier. Records can be identified using a specified namespace, an optional
 /// set name and a user defined key which must be uique within a set. Records can also be
 /// identified by namespace/digest, which is the combination used on the server.
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serialization", derive(Serialize))]
 pub struct Key {
     /// Namespace.
     pub namespace: String,

--- a/src/msgpack/encoder.rs
+++ b/src/msgpack/encoder.rs
@@ -69,7 +69,7 @@ pub fn pack_cdt_op(
         for c in ctx {
             if c.id != 0 {
                 size += pack_integer(buf, i64::from(c.id | c.flags))?;
-            }else {
+            } else {
                 size += pack_integer(buf, i64::from(c.id))?;
             }
             size += pack_value(buf, &c.value)?;
@@ -109,7 +109,7 @@ pub fn pack_cdt_bit_op(
         for c in ctx {
             if c.id != 0 {
                 size += pack_integer(buf, i64::from(c.id | c.flags))?;
-            }else {
+            } else {
                 size += pack_integer(buf, i64::from(c.id))?;
             }
             size += pack_value(buf, &c.value)?;

--- a/src/record.rs
+++ b/src/record.rs
@@ -13,7 +13,9 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+#[cfg(feature="serialization")]
 use serde::Serialize;
+
 use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -27,7 +29,8 @@ lazy_static! {
 }
 
 /// Container object for a database record.
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serialization", derive(Serialize))]
 pub struct Record {
     /// Record key. When reading a record from the database, the key is not set in the returned
     /// Record struct.

--- a/src/record.rs
+++ b/src/record.rs
@@ -13,7 +13,7 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-#[cfg(feature="serialization")]
+#[cfg(feature = "serialization")]
 use serde::Serialize;
 
 use std::collections::HashMap;

--- a/src/record.rs
+++ b/src/record.rs
@@ -16,9 +16,12 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use serde::{Serialize};
 
 use crate::Key;
 use crate::Value;
+
+
 
 lazy_static! {
   // Fri Jan  1 00:00:00 UTC 2010
@@ -26,7 +29,7 @@ lazy_static! {
 }
 
 /// Container object for a database record.
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub struct Record {
     /// Record key. When reading a record from the database, the key is not set in the returned
     /// Record struct.

--- a/src/record.rs
+++ b/src/record.rs
@@ -13,15 +13,13 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
+use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use serde::{Serialize};
 
 use crate::Key;
 use crate::Value;
-
-
 
 lazy_static! {
   // Fri Jan  1 00:00:00 UTC 2010

--- a/src/value.rs
+++ b/src/value.rs
@@ -738,11 +738,13 @@ mod tests {
 }
 
 impl Serialize for Value {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-        where
-            S: Serializer,
+    fn serialize<S>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
+    where
+        S: Serializer,
     {
-
         match &self {
             Value::Nil => serializer.serialize_none(),
             Value::Bool(b) => serializer.serialize_bool(*b),
@@ -752,7 +754,7 @@ impl Serialize for Value {
                 FloatValue::F32(u) => serializer.serialize_u32(*u),
                 FloatValue::F64(u) => serializer.serialize_u64(*u),
             },
-            Value::String(s) => serializer.serialize_str(s),
+            Value::String(s) |  Value::GeoJSON(s) => serializer.serialize_str(s),
             Value::Blob(b) => serializer.serialize_bytes(&b[..]),
             Value::List(l) => {
                 let mut seq = serializer.serialize_seq(Some(l.len()))?;
@@ -775,7 +777,6 @@ impl Serialize for Value {
                 }
                 map.end()
             }
-            Value::GeoJSON(s) => serializer.serialize_str(&s),
         }
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -31,9 +31,9 @@ use crate::commands::ParticleType;
 use crate::errors::Result;
 use crate::msgpack::{decoder, encoder};
 
-#[cfg(feature="serialization")]
+#[cfg(feature = "serialization")]
 use serde::ser::{SerializeMap, SerializeSeq};
-#[cfg(feature="serialization")]
+#[cfg(feature = "serialization")]
 use serde::{Serialize, Serializer};
 
 /// Container for floating point bin values stored in the Aerospike database.
@@ -717,8 +717,8 @@ impl Serialize for Value {
         &self,
         serializer: S,
     ) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         match &self {
             Value::Nil => serializer.serialize_none(),
@@ -729,7 +729,7 @@ impl Serialize for Value {
                 FloatValue::F32(u) => serializer.serialize_u32(*u),
                 FloatValue::F64(u) => serializer.serialize_u64(*u),
             },
-            Value::String(s) |  Value::GeoJSON(s) => serializer.serialize_str(s),
+            Value::String(s) | Value::GeoJSON(s) => serializer.serialize_str(s),
             Value::Blob(b) => serializer.serialize_bytes(&b[..]),
             Value::List(l) => {
                 let mut seq = serializer.serialize_seq(Some(l.len()))?;
@@ -755,7 +755,6 @@ impl Serialize for Value {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -786,15 +785,19 @@ mod tests {
 
     #[test]
     #[cfg(feature = "serialization")]
-    fn serializer(){
-        let val: Value = as_list!("0", 9, 8, 7, 1, 2.1f64, -1, as_list!(5,6,7,8,"asd"));
+    fn serializer() {
+        let val: Value = as_list!("0", 9, 8, 7, 1, 2.1f64, -1, as_list!(5, 6, 7, 8, "asd"));
         let json = serde_json::to_string(&val);
-        assert_eq!(json.unwrap(), "[\"0\",9,8,7,1,4611911198408756429,-1,[5,6,7,8,\"asd\"]]", "List Serialization failed");
+        assert_eq!(
+            json.unwrap(),
+            "[\"0\",9,8,7,1,4611911198408756429,-1,[5,6,7,8,\"asd\"]]",
+            "List Serialization failed"
+        );
 
-        let val: Value = as_map!("a" => 1, "b" => 2, "c" => 3, "d" => 4, "e" => 5, "f" => as_map!("test"=>123));
+        let val: Value =
+            as_map!("a" => 1, "b" => 2, "c" => 3, "d" => 4, "e" => 5, "f" => as_map!("test"=>123));
         let json = serde_json::to_string(&val);
         // We only check for the len of the String because HashMap serialization does not keep the key order. Comparing like the list above is not possible.
         assert_eq!(json.unwrap().len(), 48, "Map Serialization failed");
     }
 }
-

--- a/src/value.rs
+++ b/src/value.rs
@@ -688,7 +688,6 @@ macro_rules! as_values {
 ///
 /// ```rust
 /// # use aerospike::*;
-/// # use std::collections::HashMap;
 /// # fn main() {
 /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
 /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();

--- a/tests/src/cdt_list.rs
+++ b/tests/src/cdt_list.rs
@@ -50,7 +50,7 @@ fn cdt_list() {
 
     let values = vec![as_val!(9), as_val!(8), as_val!(7)];
     let ops = &vec![
-        lists::insert_items(&lpolicy,"bin", 1, &values),
+        lists::insert_items(&lpolicy, "bin", 1, &values),
         operations::get_bin("bin"),
     ];
     let rec = client.operate(&wpolicy, &key, ops).unwrap();

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -16,9 +16,9 @@ use aerospike::operations;
 use aerospike::{
     as_bin, as_blob, as_geo, as_key, as_list, as_map, as_val, Bins, ReadPolicy, Value, WritePolicy,
 };
-use std::collections::HashMap;
-use serde_json::json;
 use env_logger;
+use serde_json::json;
+use std::collections::HashMap;
 
 use crate::common;
 

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -17,7 +17,7 @@ use aerospike::{
     as_bin, as_blob, as_geo, as_key, as_list, as_map, as_val, Bins, ReadPolicy, Value, WritePolicy,
 };
 use std::collections::HashMap;
-
+use serde_json::json;
 use env_logger;
 
 use crate::common;
@@ -83,6 +83,13 @@ fn connect() {
     let bins = Bins::from(["bin999", "bin f64"]);
     let record = client.get(&policy, &key, bins).unwrap();
     assert_eq!(record.bins.len(), 2);
+
+    let json = serde_json::to_string(&record);
+    if json.is_err() {
+        assert!(false)
+    }
+    let json = serde_json::to_string(&record.bins.get("bin999"));
+    assert_eq!(json.unwrap(), "\"test string\"");
 
     let record = client.get(&policy, &key, Bins::None).unwrap();
     assert_eq!(record.bins.len(), 0);

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -24,3 +24,5 @@ mod scan;
 mod task;
 mod truncate;
 mod udf;
+#[cfg(feature="serialization")]
+mod serialization;

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -21,8 +21,8 @@ mod index;
 mod kv;
 mod query;
 mod scan;
+#[cfg(feature = "serialization")]
+mod serialization;
 mod task;
 mod truncate;
 mod udf;
-#[cfg(feature="serialization")]
-mod serialization;

--- a/tests/src/serialization.rs
+++ b/tests/src/serialization.rs
@@ -12,16 +12,15 @@
 // WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 // License for the specific language governing permissions and limitations under
 // the License.
-use aerospike::operations;
 use aerospike::{
-    as_bin, as_blob, as_geo, as_key, as_list, as_map, as_val, Bins, ReadPolicy, Value, WritePolicy,
+    as_bin, as_blob, as_geo, as_key, as_list, as_map, as_val, Bins, ReadPolicy, WritePolicy,
 };
 use env_logger;
 
 use crate::common;
 
 #[test]
-fn connect() {
+fn serialize() {
     let _ = env_logger::try_init();
 
     let client = common::client();
@@ -52,49 +51,11 @@ fn connect() {
     client.put(&wpolicy, &key, &bins).unwrap();
 
     let record = client.get(&policy, &key, Bins::All).unwrap();
-    let bins = record.bins;
-    assert_eq!(bins.len(), 7);
-    assert_eq!(bins.get("bin999"), Some(&Value::from("test string")));
-    assert_eq!(bins.get("bin vec![int]"), Some(&as_list![1u32, 2u32, 3u32]));
-    assert_eq!(
-        bins.get("bin vec![u8]"),
-        Some(&as_blob!(vec![1u8, 2u8, 3u8]))
-    );
-    assert_eq!(
-        bins.get("bin map"),
-        Some(&as_map!(1 => 1, 2 => 2, 3 => "hi!"))
-    );
-    assert_eq!(bins.get("bin f64"), Some(&Value::from(1.64f64)));
-    assert_eq!(
-        bins.get("bin Geo"),
-        Some(&as_geo!(
-            r#"{ "type": "Point", "coordinates": [17.119381, 19.45612] }"#
-        ))
-    );
-    assert_eq!(
-        bins.get("bin-name-len-15"),
-        Some(&Value::from("max. bin name length is 15 chars"))
-    );
 
-    client.touch(&wpolicy, &key).unwrap();
-
-    let bins = Bins::from(["bin999", "bin f64"]);
-    let record = client.get(&policy, &key, bins).unwrap();
-    assert_eq!(record.bins.len(), 2);
-
-    let record = client.get(&policy, &key, Bins::None).unwrap();
-    assert_eq!(record.bins.len(), 0);
-
-    let exists = client.exists(&wpolicy, &key).unwrap();
-    assert!(exists);
-
-    let bin = as_bin!("bin999", "test string");
-    let ops = &vec![operations::put(&bin), operations::get()];
-    client.operate(&wpolicy, &key, ops).unwrap();
-
-    let existed = client.delete(&wpolicy, &key).unwrap();
-    assert!(existed);
-
-    let existed = client.delete(&wpolicy, &key).unwrap();
-    assert!(!existed);
+    let json = serde_json::to_string(&record);
+    if json.is_err() {
+        assert!(false, "JSON Parsing of the Record was not successful")
+    }
+    let json = serde_json::to_string(&record.bins.get("bin999"));
+    assert_eq!(json.unwrap(), "\"test string\"", "The Parsed JSON value for bin999 did not match");
 }

--- a/tests/src/serialization.rs
+++ b/tests/src/serialization.rs
@@ -57,5 +57,9 @@ fn serialize() {
         assert!(false, "JSON Parsing of the Record was not successful")
     }
     let json = serde_json::to_string(&record.bins.get("bin999"));
-    assert_eq!(json.unwrap(), "\"test string\"", "The Parsed JSON value for bin999 did not match");
+    assert_eq!(
+        json.unwrap(),
+        "\"test string\"",
+        "The Parsed JSON value for bin999 did not match"
+    );
 }


### PR DESCRIPTION
This PR adds the widely used Serializer for [Serde](https://github.com/serde-rs/serde) to the Value, Record, Bins, Key and BatchRead structs. (Serializer in value.rs made by @j-brn)
Its useful when using the Aerospike Client for REST APIs returning JSON with for example actix and does not affect the performance in any way if not used.
Without, you have to build own structs around the Value object and fill them with big match blocks.
Many Database drivers include it for that reason (for example Postgres and MongoDB).