### PR TITLE
Fix for Expression Test

### DIFF
--- a/tests/src/exp.rs
+++ b/tests/src/exp.rs
@@ -240,7 +240,16 @@ fn expression_rec_ops() {
         le(device_size(), int_val(0)),
         &set_name,
     );
-    let count = count_results(rs);
+    let mut count = count_results(rs);
+
+    if count == 0 {
+        // Not in-memory
+        let rs = test_filter(
+            le(device_size(), int_val(2000)),
+            &set_name,
+        );
+        count = count_results(rs);
+    }
     assert_eq!(count, 100, "DEVICE SIZE Test Failed");
 
     let rs = test_filter(

--- a/tests/src/exp.rs
+++ b/tests/src/exp.rs
@@ -260,7 +260,7 @@ fn expression_rec_ops() {
     assert_eq!(count, 100, "LAST UPDATE Test Failed");
 
     let rs = test_filter(
-        gt(since_update(), int_val(150)),
+        gt(since_update(), int_val(10)),
         &set_name,
     );
     let count = count_results(rs);

--- a/tests/src/exp_hll.rs
+++ b/tests/src/exp_hll.rs
@@ -83,7 +83,7 @@ fn expression_hll() {
         &set_name,
     );
     let count = count_results(rs);
-    assert_eq!(count, 98, "HLL INIT Test Failed");
+    assert_eq!(count, 99, "HLL INIT Test Failed");
 
     let rs = test_filter(
         eq(
@@ -125,7 +125,7 @@ fn expression_hll() {
         &set_name,
     );
     let count = count_results(rs);
-    assert_eq!(count, 97, "HLL GET UNION Test Failed");
+    assert_eq!(count, 98, "HLL GET UNION Test Failed");
 
     let rs = test_filter(
         eq(
@@ -138,7 +138,7 @@ fn expression_hll() {
         &set_name,
     );
     let count = count_results(rs);
-    assert_eq!(count, 97, "HLL GET UNION COUNT Test Failed");
+    assert_eq!(count, 98, "HLL GET UNION COUNT Test Failed");
 
     let rs = test_filter(
         eq(


### PR DESCRIPTION
- Adjusted the Device Size test to also support not in-memory DBs. ( #91 )
- Fixed returns for HLL from the new Server version (5.4)