### PR TITLE
Fix for ctx_map_key_create

### DIFF
--- a/src/operations/cdt_context.rs
+++ b/src/operations/cdt_context.rs
@@ -16,6 +16,7 @@
 use crate::operations::lists::{list_order_flag, ListOrderType};
 use crate::operations::MapOrder;
 use crate::Value;
+use crate::operations::maps::map_order_flag;
 
 #[doc(hidden)]
 // Empty Context for scalar operations
@@ -133,7 +134,7 @@ pub const fn ctx_map_key(key: Value) -> CdtContext {
 pub const fn ctx_map_key_create(key: Value, order: MapOrder) -> CdtContext {
     CdtContext {
         id: CtxType::MapKey as u8,
-        flags: order as u8,
+        flags: map_order_flag(order),
         value: key,
     }
 }

--- a/src/operations/maps.rs
+++ b/src/operations/maps.rs
@@ -226,6 +226,15 @@ const fn map_order_arg(policy: &MapPolicy) -> Option<CdtArgument> {
     }
 }
 
+#[doc(hidden)]
+pub const fn map_order_flag(order: MapOrder) -> u8 {
+    match order {
+        MapOrder::KeyOrdered => 0x80,
+        MapOrder::Unordered => 0x40,
+        MapOrder::KeyValueOrdered => 0xc0
+    }
+}
+
 /// Create set map policy operation. Server set the map policy attributes. Server does not
 /// return a result.
 ///


### PR DESCRIPTION
This PR fixes a bug with the ctx_map_key_create context, where the flags are not encoded correctly.