### PR TITLE
Authentication change - user management 

### DIFF
--- a/aerospike-core/src/commands/admin_command.rs
+++ b/aerospike-core/src/commands/admin_command.rs
@@ -185,8 +185,8 @@ impl AdminCommand {
         conn.buffer.reset_offset();
         AdminCommand::write_header(&mut conn, CHANGE_PASSWORD, 3);
         AdminCommand::write_field_str(&mut conn, USER, user);
-        match cluster.client_policy().user_password {
-            Some((_, ref password)) => {
+        match &cluster.client_policy().password {
+            Some(password) => {
                 AdminCommand::write_field_str(
                     &mut conn,
                     OLD_PASSWORD,

--- a/aerospike-core/src/lib.rs
+++ b/aerospike-core/src/lib.rs
@@ -182,7 +182,7 @@ mod key;
 mod batch;
 mod client;
 mod cluster;
-mod commands;
+pub mod commands;
 pub mod expressions;
 mod msgpack;
 mod net;

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -42,7 +42,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub async fn new(addr: &str, policy: &mut ClientPolicy) -> Result<Self> {
+    pub async fn new(addr: &str, policy: &ClientPolicy) -> Result<Self> {
         let stream = aerospike_rt::timeout(Duration::from_secs(10), TcpStream::connect(addr)).await;
         if stream.is_err() {
             bail!(ErrorKind::Connection(
@@ -56,7 +56,7 @@ impl Connection {
             idle_timeout: policy.idle_timeout,
             idle_deadline: policy.idle_timeout.map(|timeout| Instant::now() + timeout),
         };
-        if policy.requires_auth(){
+        if ClientPolicy::requires_auth(policy.username.clone(), policy.password.clone()){
             if let Some(password) = &policy.password {
                 let hashed_password = AdminCommand::hash_password(password)?;
                 conn.authenticate(policy.username.clone(), Some(hashed_password)).await?;

--- a/aerospike-core/src/policy/client_policy.rs
+++ b/aerospike-core/src/policy/client_policy.rs
@@ -112,8 +112,8 @@ impl Default for ClientPolicy {
 
 impl ClientPolicy {
     /// Set username and password to use when authenticating to the cluster.
-    pub fn requires_auth(&mut self) -> bool {
-        if self.username == None || self.password == None {
+    pub fn requires_auth(username: Option<String>, password: Option<String>) -> bool {
+        if username == None || password == None {
             return false;
         }
         return true;

--- a/aerospike-core/src/policy/client_policy.rs
+++ b/aerospike-core/src/policy/client_policy.rs
@@ -17,12 +17,17 @@ use std::time::Duration;
 
 use crate::commands::admin_command::AdminCommand;
 use crate::errors::Result;
+use crate::user;
 
 /// `ClientPolicy` encapsulates parameters for client policy command.
 #[derive(Debug, Clone)]
 pub struct ClientPolicy {
     /// User authentication to cluster. Leave empty for clusters running without restricted access.
-    pub user_password: Option<(String, String)>,
+    pub username: Option<String>,
+
+    // Password authentication to cluster. The password will be stored by the client and sent to server
+	// in hashed format. Leave empty for clusters running without restricted access.
+    pub password: Option<String>,
 
     /// Initial host connection timeout in milliseconds.  The timeout when opening a connection
     /// to the server host for the first time.
@@ -88,7 +93,8 @@ pub struct ClientPolicy {
 impl Default for ClientPolicy {
     fn default() -> ClientPolicy {
         ClientPolicy {
-            user_password: None,
+            username: None,
+            password: None,
             timeout: Some(Duration::new(30, 0)),
             idle_timeout: Some(Duration::new(5, 0)),
             max_conns_per_node: 256,
@@ -106,9 +112,10 @@ impl Default for ClientPolicy {
 
 impl ClientPolicy {
     /// Set username and password to use when authenticating to the cluster.
-    pub fn set_user_password(&mut self, username: String, password: String) -> Result<()> {
-        let password = AdminCommand::hash_password(&password)?;
-        self.user_password = Some((username, password));
-        Ok(())
+    pub fn requires_auth(&mut self) -> bool {
+        if self.username == None || self.password == None {
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
1. Removed username_password field
2. Made it two separate fields
3. Added requires_auth() fn to client policy 
4. Do the entire auth routine only if requires_auth is true.
