### PR TITLE
Implement `RecordStream` for iterating over scanned records

### DIFF
--- a/aerospike-core/src/query/recordset.rs
+++ b/aerospike-core/src/query/recordset.rs
@@ -197,6 +197,12 @@ impl futures::Stream for RecordStream {
     }
 }
 
+impl AsRef<Recordset> for RecordStream {
+    fn as_ref(&self) -> &Recordset {
+        &self.0
+    }
+}
+
 impl Drop for RecordStream {
     fn drop(&mut self) {
         self.0.close_stream();


### PR DESCRIPTION
This PR solves two problems with `Recordset`:
1. Iteration/collection of scanned records is currently not workable in an async context because the `Recordset` iterator calls `std::thread::yield_now()` internally.
2. An `Arc<Recordset>` can be sent between threads, and iterated over in multiple places at once, which would leave each thread with a partial iteration over the scanned records. Ideally, it should be impossible to iterate over the scanned records in more than one thread at once.

To solve these, I've implemented a new struct, `RecordStream`, that acts as an iterable wrapper over an `Arc<Recordset>`. It can be created by a new `into_stream()` method on `Arc<Recordset>`, and crucially, this will make at most one `RecordStream` available at any one time—trying to instantiate a second `RecordStream` will return `None`.

`RecordStream` implements both the synchronous `Iterator` trait that was previously implemented for `&Recordset`, but it also supports asynchronous iteration via `futures::Stream`.

It might be worth considering whether `Client::scan` should just return a `RecordStream` directly, though this can be done in a follow-up PR.