### PR TITLE
docs: Add query and timeout examples and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,112 @@ Prerequisites:
 The following code examples demonstrate some of the Rust client's new
 features.
 
+### Client connection
+
+#### Standard connection
+
+Connect to an Aerospike cluster without TLS:
+
+```rust
+use aerospike::{Client, ClientPolicy};
+
+let policy = ClientPolicy::default();
+let hosts = env::var("AEROSPIKE_HOSTS")
+    .unwrap_or(String::from("127.0.0.1:3000"));
+let client = Client::new(&policy, &hosts).await
+    .expect("Failed to connect to cluster");
+```
+
+#### TLS connection without client authentication
+
+Connect to an Aerospike cluster with TLS but without client certificate authentication:
+
+```rust
+use aerospike::{Client, ClientPolicy};
+use rustls::RootCertStore;
+use rustls::pki_types::CertificateDer;
+
+fn tls_config_no_client_auth(ca_cert_path: &str) -> rustls::ClientConfig {
+    let mut root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
+
+    // Add custom CA certificate
+    root_store.add_parsable_certificates(
+        CertificateDer::pem_file_iter(ca_cert_path)
+            .expect("Cannot open CA file")
+            .map(|result| result.unwrap()),
+    );
+
+    rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth()
+}
+
+let mut policy = ClientPolicy::default();
+policy.tls_config = Some(tls_config_no_client_auth("/path/to/ca-cert.pem"));
+
+let hosts = "tls-cluster.example.com:4333";
+let client = Client::new(&policy, hosts).await
+    .expect("Failed to connect to cluster");
+```
+
+#### TLS connection with client authentication
+
+Connect to an Aerospike cluster with TLS and mutual authentication using client certificates:
+
+```rust
+use aerospike::{Client, ClientPolicy};
+use rustls::RootCertStore;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+
+fn tls_config_with_client_auth(
+    ca_cert_path: &str,
+    client_cert_path: &str,
+    client_key_path: &str,
+) -> rustls::ClientConfig {
+    let mut root_store = RootCertStore {
+        roots: webpki_roots::TLS_SERVER_ROOTS.into(),
+    };
+
+    // Add custom CA certificate
+    root_store.add_parsable_certificates(
+        CertificateDer::pem_file_iter(ca_cert_path)
+            .expect("Cannot open CA file")
+            .map(|result| result.unwrap()),
+    );
+
+    // Load client certificate and private key
+    let client_cert = CertificateDer::from_pem_file(client_cert_path)
+        .expect("Cannot open client certificate file");
+    let client_key = PrivateKeyDer::from_pem_file(client_key_path)
+        .expect("Cannot open client key file");
+
+    rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_client_auth_cert(vec![client_cert], client_key)
+        .expect("Failed to configure client authentication")
+}
+
+let mut policy = ClientPolicy::default();
+policy.tls_config = Some(tls_config_with_client_auth(
+    "/path/to/ca-cert.pem",
+    "/path/to/client-cert.pem",
+    "/path/to/client-key.pem",
+));
+
+let hosts = "tls-cluster.example.com:4333";
+let client = Client::new(&policy, hosts).await
+    .expect("Failed to connect to cluster");
+```
+
+**Note**: To use TLS features, enable the `tls` feature in your `Cargo.toml`:
+
+```toml
+[dependencies]
+aerospike = { version = "...", features = ["tls"] }
+```
+
 ### CRUD operations
 
 ```rust
@@ -148,7 +254,7 @@ async fn main() {
     let rec = client.get(&rpolicy, &key, Bins::None).await;
     println!("Record Header: {}", rec.unwrap());
 
-    let exists = client.exists(&wpolicy, &key).await.unwrap();
+    let exists = client.exists(&rpolicy, &key).await.unwrap();
     println!("exists: {}", exists);
 
     let bin = as_bin!("int", "123");
@@ -170,6 +276,7 @@ async fn main() {
 
 ```rust
     let mut bpolicy = BatchPolicy::default();
+    let apolicy = AdminPolicy::default();
 
     let udf_body = r#"
 	function echo(rec, val)
@@ -178,7 +285,7 @@ async fn main() {
 	"#;
 
     let task = client
-        .register_udf(udf_body.as_bytes(), "test_udf.lua", UDFLang::Lua)
+        .register_udf(&apolicy, udf_body.as_bytes(), "test_udf.lua", UDFLang::Lua)
         .await
         .unwrap();
     task.wait_till_complete(None).await.unwrap();
@@ -263,6 +370,260 @@ async fn main() {
     dbg!(&results);
 ```
 
+A complete working example can be found in [examples/batch_operations.rs](./examples/batch_operations.rs).
+
+### Query operations
+
+The Rust client supports various query patterns for retrieving data from Aerospike. Below are examples demonstrating different query capabilities.
+
+#### Simple equality query
+
+Query records where a bin equals a specific value:
+
+```rust
+use aerospike::{QueryPolicy, Statement, Bins};
+use aerospike::query::PartitionFilter;
+
+let policy = QueryPolicy::default();
+let mut stmt = Statement::new(namespace, set_name, Bins::All);
+stmt.add_filter(as_eq!("bin_name", 5));
+
+let rs = client.query(&policy, PartitionFilter::all(), stmt).await.unwrap();
+let mut rs = rs.into_stream();
+
+while let Some(r) = rs.next().await {
+    println!("Record: {:?}", r.unwrap());
+}
+```
+
+#### Range query
+
+Query records where a bin value falls within a range:
+
+```rust
+let policy = QueryPolicy::default();
+let mut stmt = Statement::new(namespace, set_name, Bins::All);
+stmt.add_filter(as_range!("bin_name", 0, 100));
+
+let rs = client.query(&policy, PartitionFilter::all(), stmt).await.unwrap();
+let mut rs = rs.into_stream();
+
+while let Some(r) = rs.next().await {
+    println!("Record: {:?}", r.unwrap());
+}
+```
+
+#### Metadata-only query
+
+Query records but only retrieve metadata (no bin data):
+
+```rust
+let policy = QueryPolicy::default();
+let mut stmt = Statement::new(namespace, set_name, Bins::None);
+stmt.add_filter(as_range!("bin_name", 0, 100));
+
+let rs = client.query(&policy, PartitionFilter::all(), stmt).await.unwrap();
+let mut rs = rs.into_stream();
+
+while let Some(r) = rs.next().await {
+    let rec = r.unwrap();
+    println!("Generation: {}, TTL: {}", rec.generation, rec.expiration);
+}
+```
+
+#### Cursor-based pagination
+
+Query records in batches using partition cursors for pagination:
+
+```rust
+let policy = QueryPolicy::default();
+let mut pf = PartitionFilter::all();
+
+while !pf.done() {
+    let stmt = Statement::new(namespace, set_name, Bins::All);
+    let rs = client.query(&policy, pf, stmt).await.unwrap();
+    let mut rs = rs.into_stream();
+    
+    while let Some(r) = rs.next().await {
+        println!("Record: {:?}", r.unwrap());
+    }
+    
+    // Get the next partition filter to continue pagination
+    pf = rs.partition_filter().await.unwrap();
+}
+```
+
+#### Parallel query with multiple consumers
+
+Process query results in parallel using multiple async tasks:
+
+```rust
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+let policy = QueryPolicy::default();
+let mut stmt = Statement::new(namespace, set_name, Bins::All);
+stmt.add_filter(as_range!("bin_name", 0, 100));
+
+let rs = client.query(&policy, PartitionFilter::all(), stmt).await.unwrap();
+let count = Arc::new(AtomicUsize::new(0));
+let mut handles = vec![];
+
+// Spawn 4 worker tasks to process results in parallel
+for _ in 0..4 {
+    let rs_clone = rs.clone();
+    let count = count.clone();
+    
+    handles.push(tokio::spawn(async move {
+        let mut rs_stream = rs_clone.into_stream();
+        while let Some(record) = rs_stream.next().await {
+            if record.is_ok() {
+                count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }));
+}
+
+futures::future::join_all(handles).await;
+println!("Total processed: {}", count.load(Ordering::Relaxed));
+```
+
+#### Query with expression filter
+
+Use filter expressions for more complex filtering logic:
+
+```rust
+use aerospike_core::expressions::{eq, int_bin, int_val};
+
+let mut policy = QueryPolicy::default();
+policy.base_policy.filter_expression.replace(
+    eq(int_bin("bin_name".to_string()), int_val(42))
+);
+
+let stmt = Statement::new(namespace, set_name, Bins::All);
+let rs = client.query(&policy, PartitionFilter::all(), stmt).await.unwrap();
+let mut rs = rs.into_stream();
+
+while let Some(r) = rs.next().await {
+    println!("Record: {:?}", r.unwrap());
+}
+```
+
+#### Rate-limited query
+
+Control query throughput by limiting records per second:
+
+```rust
+let mut policy = QueryPolicy::default();
+policy.records_per_second = 100;  // Limit to 100 records/second
+
+let mut stmt = Statement::new(namespace, set_name, Bins::All);
+stmt.add_filter(as_range!("bin_name", 0, 1000));
+
+let rs = client.query(&policy, PartitionFilter::all(), stmt).await.unwrap();
+let mut rs = rs.into_stream();
+
+while let Some(r) = rs.next().await {
+    match r {
+        Ok(rec) => println!("Record: {:?}", rec),
+        Err(err) => eprintln!("Error: {:?}", err),
+    }
+}
+```
+
+#### Prerequisites for queries
+
+Before running queries, you need to create a secondary index on the bin you want to query:
+
+```rust
+use aerospike_core::{AdminPolicy, IndexType, CollectionIndexType};
+
+let policy = AdminPolicy::default();
+let task = client
+    .create_index_on_bin(
+        &policy,
+        namespace,
+        set_name,
+        "bin_name",
+        "idx_bin_name",
+        IndexType::Numeric,
+        CollectionIndexType::Default,
+        None,
+    )
+    .await
+    .expect("Failed to create index");
+
+// Wait for index creation to complete
+task.wait_till_complete(None).await.unwrap();
+```
+
+For a complete working example with all query patterns, see [`examples/query.rs`](./examples/query.rs).
+
+### Timeout configuration
+
+The Rust client provides flexible timeout configuration through `socket_timeout` and `total_timeout` parameters in policies. Understanding how these interact is crucial for handling network issues and controlling command execution time.
+
+#### Timeout parameters
+
+- **`socket_timeout`**: Socket idle timeout when processing a database command (in milliseconds). Default value 5000 (5 seconds).
+- **`total_timeout`**: Total command timeout, including retries (in milliseconds). Default value 0.
+
+#### Timeout behavior rules
+
+1. **Both zero (0, 0)**: No timeout limits - commands wait indefinitely
+2. **Socket zero, total non-zero (0, N)**: `socket_timeout` inherits `total_timeout` value
+3. **Socket non-zero, total zero (N, 0)**: Socket idle timeout of N ms, no total limit
+4. **Both non-zero, socket > total (N, M where N > M)**: `socket_timeout` capped at `total_timeout`
+5. **Both non-zero, socket ≤ total (N, M where N ≤ M)**: Both timeouts enforced independently
+
+When a socket timeout occurs, the client checks `max_retries` and `total_timeout`. If neither is exceeded, the command is automatically retried.
+
+Rust client exposes these parameters through the Read/Write policy, and can be tuned as below:
+
+```rust
+use aerospike::{ReadPolicy, Bins};
+
+let mut policy = ReadPolicy::default();
+policy.base_policy.socket_timeout = 0;
+policy.base_policy.total_timeout = 0;
+
+let rec = client.get(&policy, &key, Bins::All).await;
+```
+
+#### Socket recovery with timeout_delay
+
+The `timeout_delay` parameter controls how the client handles sockets after a read timeout. This is particularly important for cloud deployments.
+
+```rust
+let mut policy = ReadPolicy::default();
+policy.base_policy.socket_timeout = 2000;  // 2 second socket timeout
+policy.base_policy.total_timeout = 10000;  // 10 second total timeout
+policy.base_policy.timeout_delay = 3000;   // 3 second delay for socket recovery
+
+let rec = client.get(&policy, &key, Bins::All).await;
+```
+
+**How `timeout_delay` works:**
+
+1. **When `timeout_delay = 0` (default)**: Socket is immediately closed on timeout
+2. **When `timeout_delay > 0`**: After a socket read timeout, the client attempts to drain remaining data from the socket in the background for up to `timeout_delay` milliseconds
+    - If all data is drained within the delay: Socket returned to connection pool (reusable)
+    - If delay expires before draining completes: Socket is closed
+
+**Why use `timeout_delay`?**
+
+Many cloud providers experience performance issues when clients close sockets while the server still has data to write (results in TCP RST packets). Draining the socket before closing avoids this penalty.
+
+**Trade-offs:**
+
+- ✓ Avoids TCP RST performance penalties on cloud platforms
+- ✓ Allows socket reuse when recovery is successful
+- ✗ Requires extra processing to drain sockets
+- ✗ May need additional connections for command retries during recovery
+
+**Recommended value:** If enabling `timeout_delay`, 3000ms (3 seconds) is a reasonable starting point.
+
+For a complete working example demonstrating timeout scenarios, see [`examples/timeout_configuration.rs`](./examples/timeout_configuration.rs).
 ## Feedback wanted
 
 We need your help with:

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,22 @@ This directory includes several Rust examples that demonstrate how to use the Ae
 * `query`
 * `timeout_configuration`
 
+## Configuration
+
+The examples connect to Aerospike using the `AEROSPIKE_HOSTS` environment variable.
+
+If the variable is not set, the examples default to:
+
+```
+127.0.0.1:3100
+```
+
+You can override this by setting the environment variable before running an example:
+
+```bash
+export AEROSPIKE_HOSTS="127.0.0.1:3100"
+```
+
 ## How to Run
 
 From the root of the project, use Cargo to run an example by name:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,29 @@
+# Examples
+
+This directory includes several Rust examples that demonstrate how to use the Aerospike Rust Client to interact with the Aerospike Database Server. Each example is a standalone binary with its own `main` function.
+
+## Available Examples
+
+* `batch_operations`
+* `crud`
+* `query`
+* `timeout_configuration`
+
+## How to Run
+
+From the root of the project, use Cargo to run an example by name:
+
+```bash
+cargo run --example <example_name>
+```
+
+### Examples
+
+```bash
+cargo run --example batch_operations
+cargo run --example crud
+cargo run --example query
+cargo run --example timeout_configuration
+```
+
+Cargo will compile and run the selected example binary.

--- a/examples/batch_operations.rs
+++ b/examples/batch_operations.rs
@@ -1,0 +1,138 @@
+#[macro_use]
+extern crate aerospike;
+extern crate tokio;
+
+use std::env;
+use aerospike::{Bins, Client, ClientPolicy, BatchPolicy, UDFLang};
+use aerospike::operations;
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+use aerospike_core::{AdminPolicy, BatchDeletePolicy, BatchOperation, BatchReadPolicy, BatchUDFPolicy, BatchWritePolicy, Task};
+
+#[tokio::main]
+async fn main() {
+    let cpolicy = ClientPolicy::default();
+    let hosts = env::var("AEROSPIKE_HOSTS")
+        .unwrap_or(String::from("127.0.0.1:3100"));
+    let client = Client::new(&cpolicy, &hosts)
+        .await
+        .expect("Failed to connect to cluster");
+
+    println!("Connected to Aerospike!");
+
+    let namespace = "test";
+    let set_name = generate_random_set_name();
+
+    println!("Using set: {}", set_name);
+
+    // Register UDF
+    let udf_body = r#"
+function echo(rec, val)
+    return val
+end
+"#;
+
+    println!("Registering UDF...");
+    let apolicy = AdminPolicy::default();
+    let task = client
+        .register_udf(&apolicy, udf_body.as_bytes(), "test_udf.lua", UDFLang::Lua)
+        .await
+        .unwrap();
+    task.wait_till_complete(None).await.unwrap();
+    println!("UDF registered successfully!");
+
+    let bpolicy = BatchPolicy::default();
+
+    let bin1 = as_bin!("a", "a value");
+    let bin2 = as_bin!("b", "another value");
+    let bin3 = as_bin!("c", 42);
+
+    let key1 = as_key!(namespace, &set_name, 1);
+    let key2 = as_key!(namespace, &set_name, 2);
+    let key3 = as_key!(namespace, &set_name, 3);
+    let key4 = as_key!(namespace, &set_name, -1); // key does not exist
+
+    let selected = Bins::from(["a"]);
+    let all = Bins::All;
+    let none = Bins::None;
+
+    let wops = vec![
+        operations::put(&bin1),
+        operations::put(&bin2),
+        operations::put(&bin3),
+    ];
+
+    let rops = vec![
+        operations::get_bin(&bin1.name),
+        operations::get_bin(&bin2.name),
+        operations::get_header(),
+    ];
+
+    let bpr = BatchReadPolicy::default();
+    let bpw = BatchWritePolicy::default();
+    let bpd = BatchDeletePolicy::default();
+    let bpu = BatchUDFPolicy::default();
+
+    // WRITE Operations
+    println!("\n--- Batch WRITE operations ---");
+    let batch = vec![
+        BatchOperation::write(&bpw, key1.clone(), wops.clone()),
+        BatchOperation::write(&bpw, key2.clone(), wops.clone()),
+        BatchOperation::write(&bpw, key3.clone(), wops.clone()),
+    ];
+    let results = client.batch(&bpolicy, &batch).await.unwrap();
+    println!("Write results:");
+    dbg!(&results);
+
+    // READ Operations
+    println!("\n--- Batch READ operations ---");
+    let batch = vec![
+        BatchOperation::read(&bpr, key1.clone(), selected),
+        BatchOperation::read(&bpr, key2.clone(), all),
+        BatchOperation::read(&bpr, key3.clone(), none.clone()),
+        BatchOperation::read_ops(&bpr, key3.clone(), rops),
+        BatchOperation::read(&bpr, key4.clone(), none.clone()),
+    ];
+    let results = client.batch(&bpolicy, &batch).await.unwrap();
+    println!("Read results:");
+    dbg!(&results);
+
+    // UDF Operations
+    println!("\n--- Batch UDF operations ---");
+    let args1 = &[as_val!(1)];
+    let args2 = &[as_val!(2)];
+    let args3 = &[as_val!(3)];
+    let args4 = &[as_val!(4)];
+    let batch = vec![
+        BatchOperation::udf(&bpu, key1.clone(), "test_udf", "echo", Some(args1)),
+        BatchOperation::udf(&bpu, key2.clone(), "test_udf", "echo", Some(args2)),
+        BatchOperation::udf(&bpu, key3.clone(), "test_udf", "echo", Some(args3)),
+        BatchOperation::udf(&bpu, key4.clone(), "test_udf", "echo", Some(args4)),
+    ];
+    let results = client.batch(&bpolicy, &batch).await.unwrap();
+    println!("UDF results:");
+    dbg!(&results);
+
+    // DELETE Operations
+    println!("\n--- Batch DELETE operations ---");
+    let batch = vec![
+        BatchOperation::delete(&bpd, key1.clone()),
+        BatchOperation::delete(&bpd, key2.clone()),
+        BatchOperation::delete(&bpd, key3.clone()),
+        BatchOperation::delete(&bpd, key4.clone()),
+    ];
+    let results = client.batch(&bpolicy, &batch).await.unwrap();
+    println!("Delete results:");
+    dbg!(&results);
+
+    println!("\n✓ All batch operations completed!");
+    client.close().await.unwrap();
+}
+
+fn generate_random_set_name() -> String {
+    let rng = rand::thread_rng();
+    rng.sample_iter(&Alphanumeric)
+        .take(10)
+        .map(char::from)
+        .collect()
+}

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -1,0 +1,55 @@
+#[macro_use]
+extern crate aerospike;
+extern crate tokio;
+
+use std::env;
+use std::time::Instant;
+
+use aerospike::{Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
+use aerospike::operations;
+
+#[tokio::main]
+async fn main() {
+    let cpolicy = ClientPolicy::default();
+    let hosts = env::var("AEROSPIKE_HOSTS")
+        .unwrap_or(String::from("127.0.0.1:3100"));
+    let client = Client::new(&cpolicy, &hosts).await
+        .expect("Failed to connect to cluster");
+
+
+    let now = Instant::now();
+    let rpolicy = ReadPolicy::default();
+    let wpolicy = WritePolicy::default();
+    let key = as_key!("test", "test", "test");
+
+    let bins = [
+        as_bin!("int", 999),
+        as_bin!("str", "Hello, World!"),
+    ];
+    client.put(&wpolicy, &key, &bins).await.unwrap();
+    let rec = client.get(&rpolicy, &key, Bins::All).await;
+    println!("Record: {}", rec.unwrap());
+
+    client.touch(&wpolicy, &key).await.unwrap();
+    let rec = client.get(&rpolicy, &key, Bins::All).await;
+    println!("Record: {}", rec.unwrap());
+
+    let rec = client.get(&rpolicy, &key, Bins::None).await;
+    println!("Record Header: {}", rec.unwrap());
+
+    let exists = client.exists(&rpolicy, &key).await.unwrap();
+    println!("exists: {}", exists);
+
+    let bin = as_bin!("int", "123");
+    let ops = &vec![operations::put(&bin), operations::get()];
+    let op_rec = client.operate(&wpolicy, &key, ops).await;
+    println!("operate: {}", op_rec.unwrap());
+
+    let existed = client.delete(&wpolicy, &key).await.unwrap();
+    println!("existed (should be true): {}", existed);
+
+    let existed = client.delete(&wpolicy, &key).await.unwrap();
+    println!("existed (should be false): {}", existed);
+
+    println!("total time: {:?}", now.elapsed());
+}

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -1,0 +1,283 @@
+#[macro_use]
+extern crate aerospike;
+extern crate tokio;
+
+use std::env;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use aerospike::{Client, ClientPolicy, Bins, QueryPolicy, Statement};
+use aerospike::query::PartitionFilter;
+use aerospike_core::{AdminPolicy, CollectionIndexType, Host, IndexType, Task, WritePolicy};
+use futures::stream::StreamExt;
+use rand::distributions::Alphanumeric;
+use rand::Rng;
+use aerospike_core::expressions::{eq, int_bin, int_val};
+
+const DEFAULT_NAMESPACE: &str = "test";
+const DEFAULT_NUM_RECORDS: usize = 100;
+const BIN_NAME: &str = "bin";
+
+#[tokio::main]
+async fn main() {
+    let client = connect_to_aerospike().await;
+    println!("Connected to Aerospike!");
+
+    let set_name = create_test_set(&client, DEFAULT_NAMESPACE, DEFAULT_NUM_RECORDS).await;
+
+    simple_equality_query(&client, DEFAULT_NAMESPACE, &set_name).await;
+    range_query(&client, DEFAULT_NAMESPACE, &set_name).await;
+    metadata_only_query(&client, DEFAULT_NAMESPACE, &set_name).await;
+    cursor_pagination(&client, DEFAULT_NAMESPACE, &set_name).await;
+    parallel_query(&client, DEFAULT_NAMESPACE, &set_name).await;
+    expression_filter(&client, DEFAULT_NAMESPACE, &set_name).await;
+    rate_limited_query(&client, DEFAULT_NAMESPACE, &set_name).await;
+
+    client.close().await.unwrap();
+}
+
+async fn connect_to_aerospike() -> Client {
+    let hosts = env::var("AEROSPIKE_HOSTS")
+        .unwrap_or_else(|_| String::from("127.0.0.1:3100"));
+
+    let policy = ClientPolicy::default();
+
+    Client::new(&policy, &hosts)
+        .await
+        .expect("Failed to connect to cluster")
+}
+
+async fn simple_equality_query(client: &Client, namespace: &str, set_name: &str) {
+    println!("\n--- 1. Simple equality query ---");
+
+    let policy = QueryPolicy::default();
+    let mut stmt = Statement::new(namespace, set_name, Bins::All);
+    stmt.add_filter(as_eq!(BIN_NAME, 5));
+
+    let rs = client.query(&policy, PartitionFilter::all(), stmt)
+        .await
+        .expect("Query failed");
+
+    let mut rs = rs.into_stream();
+    while let Some(r) = rs.next().await {
+        println!("Equal query record: {:?}", r.unwrap());
+    }
+}
+
+async fn range_query(client: &Client, namespace: &str, set_name: &str) {
+    println!("\n--- 2. Range query ---");
+
+    let policy = QueryPolicy::default();
+    let mut stmt = Statement::new(namespace, set_name, Bins::All);
+    stmt.add_filter(as_range!(BIN_NAME, 0, 9));
+
+    let rs = client.query(&policy, PartitionFilter::all(), stmt)
+        .await
+        .expect("Query failed");
+
+    let mut rs = rs.into_stream();
+    while let Some(r) = rs.next().await {
+        println!("Range query record: {:?}", r.unwrap());
+    }
+}
+
+async fn metadata_only_query(client: &Client, namespace: &str, set_name: &str) {
+    println!("\n--- 3. Query without bins (metadata only) ---");
+
+    let policy = QueryPolicy::default();
+    let mut stmt = Statement::new(namespace, set_name, Bins::None);
+    stmt.add_filter(as_range!(BIN_NAME, 0, 4));
+
+    let rs = client.query(&policy, PartitionFilter::all(), stmt)
+        .await
+        .expect("Query failed");
+
+    let mut rs = rs.into_stream();
+    while let Some(r) = rs.next().await {
+        let rec = r.unwrap();
+        println!("Record header: gen={}, bins={}", rec.generation, rec.bins.len());
+    }
+}
+
+async fn cursor_pagination(client: &Client, namespace: &str, set_name: &str) {
+    println!("\n--- 4. Cursor-based query (pagination) ---");
+
+    let policy = QueryPolicy::default();
+    let mut pf = PartitionFilter::all();
+
+    while !pf.done() {
+        let stmt = Statement::new(namespace, set_name, Bins::All);
+        let rs = client.query(&policy, pf, stmt)
+            .await
+            .expect("Query failed");
+
+        let mut rs = rs.into_stream();
+        while let Some(r) = rs.next().await {
+            println!("Cursor record: {:?}", r.unwrap());
+        }
+        pf = rs.partition_filter().await.unwrap();
+    }
+}
+
+async fn parallel_query(client: &Client, namespace: &str, set_name: &str) {
+    println!("\n--- 5. Multi-consumer parallel query ---");
+
+    const NUM_WORKERS: usize = 4;
+    let policy = QueryPolicy::default();
+    let mut stmt = Statement::new(namespace, set_name, Bins::All);
+    stmt.add_filter(as_range!(BIN_NAME, 0, 9));
+
+    let rs = client.query(&policy, PartitionFilter::all(), stmt)
+        .await
+        .expect("Query failed");
+
+    let count = Arc::new(AtomicUsize::new(0));
+    let mut handles = Vec::with_capacity(NUM_WORKERS);
+
+    for _ in 0..NUM_WORKERS {
+        let rs_clone = rs.clone();
+        let count = count.clone();
+        handles.push(tokio::spawn(async move {
+            let mut rs_stream = rs_clone.into_stream();
+            while let Some(record) = rs_stream.next().await {
+                if record.is_ok() {
+                    count.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }));
+    }
+
+    futures::future::join_all(handles).await;
+    println!("Total records processed in parallel: {}", count.load(Ordering::Relaxed));
+}
+
+async fn expression_filter(client: &Client, namespace: &str, set_name: &str) {
+    println!("\n--- 6. Query with expression filter ---");
+
+    let mut policy = QueryPolicy::default();
+    policy.base_policy.filter_expression.replace(
+        eq(int_bin(BIN_NAME.to_string()), int_val(10))
+    );
+
+    let stmt = Statement::new(namespace, set_name, Bins::All);
+    let rs = client.query(&policy, PartitionFilter::all(), stmt)
+        .await
+        .expect("Query failed");
+
+    let mut rs = rs.into_stream();
+    while let Some(r) = rs.next().await {
+        println!("Expression query record: {:?}", r.unwrap());
+    }
+}
+
+async fn rate_limited_query(client: &Client, namespace: &str, set_name: &str) {
+    println!("\n--- 7. Rate-limited query ---");
+
+    // Use 1000 records for more observable rate limiting effect
+    let test_set_name = create_test_set(client, namespace, 1000).await;
+
+    const RATE_LIMIT: u32 = 3;
+    const TOTAL_RECORDS: i64 = 1000;
+    let range_end = TOTAL_RECORDS / RATE_LIMIT as i64;
+
+    let mut policy = QueryPolicy::default();
+    policy.records_per_second = RATE_LIMIT;
+
+    // Query only a subset of records, matching the test pattern
+    let mut stmt = Statement::new(namespace, &test_set_name, Bins::All);
+    stmt.add_filter(as_range!(BIN_NAME, 0, range_end));
+
+    let expected_count = range_end + 1;
+    println!("Rate limit set to {} records/second", RATE_LIMIT);
+    println!("Querying records with bin value 0-{} (expected: ~{} records)",
+             range_end, expected_count);
+
+    let start_time = tokio::time::Instant::now();
+    let rs = client.query(&policy, PartitionFilter::all(), stmt)
+        .await
+        .expect("Query failed");
+
+    let mut count = 0;
+    let mut rs = rs.into_stream();
+    let mut last_log = tokio::time::Instant::now();
+    let mut batch_count = 0;
+
+    while let Some(res) = rs.next().await {
+        match res {
+            Ok(rec) => {
+                count += 1;
+                let v: i64 = rec.bins[BIN_NAME].clone().into();
+                assert!(v >= 0 && v <= range_end, "Unexpected bin value: {}", v);
+
+                // Log progress more frequently to see the throttling
+                if last_log.elapsed().as_millis() >= 500 {
+                    batch_count += 1;
+                    println!("Batch {}: {} records in {:?}", batch_count, count, start_time.elapsed());
+                    last_log = tokio::time::Instant::now();
+                }
+            }
+            Err(err) => panic!("Query error: {:?}", err),
+        }
+    }
+
+    let duration = tokio::time::Instant::now() - start_time;
+    println!("\nResults:");
+    println!("  Records returned: {}", count);
+    println!("  Duration: {:?} ({}ms)", duration, duration.as_millis());
+}
+
+async fn create_test_set(client: &Client, namespace: &str, num_records: usize) -> String {
+    let set_name = generate_random_set_name();
+    println!("Creating test set '{}' with {} records...", set_name, num_records);
+
+    populate_test_data(client, namespace, &set_name, num_records).await;
+    create_secondary_index(client, namespace, &set_name).await;
+
+    println!("Test set created successfully!");
+    set_name
+}
+
+fn generate_random_set_name() -> String {
+    let rng = rand::thread_rng();
+    rng.sample_iter(&Alphanumeric)
+        .take(10)
+        .map(char::from)
+        .collect()
+}
+
+async fn populate_test_data(client: &Client, namespace: &str, set_name: &str, num_records: usize) {
+    let wpolicy = WritePolicy::default();
+
+    for i in 0..num_records as i64 {
+        let key = as_key!(namespace, set_name, i);
+        let wbin = as_bin!(BIN_NAME, i);
+        let bins = vec![wbin];
+
+        client.delete(&wpolicy, &key).await.ok(); // Ignore if doesn't exist
+        client.put(&wpolicy, &key, &bins)
+            .await
+            .expect("Failed to write record");
+    }
+}
+
+async fn create_secondary_index(client: &Client, namespace: &str, set_name: &str) {
+    let apolicy = AdminPolicy::default();
+    let index_name = format!("{}_{}_idx", set_name, BIN_NAME);
+
+    let task = client
+        .create_index_on_bin(
+            &apolicy,
+            namespace,
+            set_name,
+            BIN_NAME,
+            &index_name,
+            IndexType::Numeric,
+            CollectionIndexType::Default,
+            None,
+        )
+        .await
+        .expect("Failed to create index");
+
+    task.wait_till_complete(None)
+        .await
+        .expect("Index creation timed out");
+}

--- a/examples/timeout_configuration.rs
+++ b/examples/timeout_configuration.rs
@@ -1,0 +1,70 @@
+#[macro_use]
+extern crate aerospike;
+extern crate tokio;
+
+use std::env;
+use std::time::Instant;
+use aerospike::{Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
+
+#[tokio::main]
+async fn main() {
+    let cpolicy = ClientPolicy::default();
+    let hosts = env::var("AEROSPIKE_HOSTS")
+        .unwrap_or(String::from("127.0.0.1:3100"));
+    let client = Client::new(&cpolicy, &hosts)
+        .await
+        .expect("Failed to connect to cluster");
+
+    println!("Connected to Aerospike!");
+
+    let namespace = "test";
+    let set_name = "timeout_demo";
+    let key = as_key!(namespace, set_name, "timeout_test");
+
+    // Setup: Write a test record
+    let wpolicy = WritePolicy::default();
+    let bins = [as_bin!("data", "test value")];
+    client.put(&wpolicy, &key, &bins).await.unwrap();
+    println!("Test record created\n");
+
+    default_timeout(&client, &key).await;
+    socket_and_total_timeouts(&client, &key).await;
+
+    client.delete(&wpolicy, &key).await.ok();
+    client.close().await.unwrap();
+}
+
+async fn default_timeout(client: &Client, key: &aerospike::Key) {
+    println!("socket_timeout: 5000 (default), total_timeout: 0");
+
+    let mut policy = ReadPolicy::default();
+    policy.base_policy.socket_timeout = 0;
+    policy.base_policy.total_timeout = 0;
+
+    let start = Instant::now();
+    match client.get(&policy, key, Bins::All).await {
+        Ok(rec) => {
+            println!("✓ Read successful in {:?}", start.elapsed());
+            println!("  Record: {}\n", rec);
+        }
+        Err(e) => println!("✗ Error: {:?}\n", e),
+    }
+}
+
+async fn socket_and_total_timeouts(client: &Client, key: &aerospike::Key) {
+    println!("socket_timeout: 2000ms, total_timeout: 5000ms");
+    println!("Result: Socket idle timeout of 2s, total command timeout of 5s");
+
+    let mut policy = ReadPolicy::default();
+    policy.base_policy.socket_timeout = 2000; // 2 seconds
+    policy.base_policy.total_timeout = 5000;  // 5 seconds
+
+    let start = Instant::now();
+    match client.get(&policy, key, Bins::All).await {
+        Ok(rec) => {
+            println!("✓ Read successful in {:?}", start.elapsed());
+            println!("  Record: {}\n", rec);
+        }
+        Err(e) => println!("✗ Error: {:?}\n", e),
+    }
+}


### PR DESCRIPTION
docs: Add query and timeout examples with comprehensive README documentation

    Add new example files:
    - examples/query.rs: Demonstrates various query patterns including
      equality queries, range queries, metadata-only queries, cursor-based
      pagination, parallel query processing, expression filters, and
      rate-limited queries
    - examples/batch_operations.rs: Complete runnable example for batch operations
      including write, read, UDF, and delete operations
    - examples/timeout_configuration.rs: Demonstrates timeout configuration scenarios
      including socket_timeout, total_timeout, and their interactions
    - examples/crud.rs: Basic CRUD operations

    Update README.md:
    - Add "Client connection" section with TLS configuration examples.
    - Add "Timeout configuration" section.
    - Add "Query" section.