### PR TITLE
fix: v2 Record.bins must not lose bin order

### DIFF
--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -29,6 +29,7 @@ aerospike-rt = {path = "../aerospike-rt", version = "2.0.0-alpha.9"}
 futures = {version = "0.3.16" }
 async-trait = "0.1.51"
 rhexdump = "0.2.0"
+indexmap = "2"
 regex = "1"
 tokio-rustls = {version = "0.26.0", optional = true}
 rustls = {version = "0.23.31", optional = true}
@@ -36,7 +37,7 @@ async-lock = "3.4.1"
 async-channel = "2.5.0"
 
 [features]
-serialization = ["serde"]
+serialization = ["serde", "indexmap/serde"]
 rt-tokio = ["aerospike-rt/rt-tokio"]
 rt-async-std = ["aerospike-rt/rt-async-std"]
 tls = ["rustls", "tokio-rustls"]

--- a/aerospike-core/src/commands/batch_operate_command.rs
+++ b/aerospike-core/src/commands/batch_operate_command.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use aerospike_rt::time::Instant;
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::HashMap;
+use indexmap::map::Entry::{Occupied, Vacant};
+use indexmap::IndexMap;
 use std::sync::Arc;
 
 use crate::batch::BatchOperation;
@@ -273,7 +273,7 @@ impl BatchOperateCommand {
         let (key, _) = StreamCommand::parse_key(conn, field_count).await?;
 
         let record = if found_key {
-            let mut bins: HashMap<String, Value> = HashMap::with_capacity(op_count);
+            let mut bins: IndexMap<String, Value> = IndexMap::with_capacity(op_count);
 
             for _ in 0..op_count {
                 conn.read_buffer(8).await?;

--- a/aerospike-core/src/commands/read_command.rs
+++ b/aerospike-core/src/commands/read_command.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::HashMap;
+use indexmap::map::Entry::{Occupied, Vacant};
+use indexmap::IndexMap;
 use std::sync::Arc;
 
 use crate::cluster::{Cluster, Node};
@@ -59,7 +59,7 @@ impl<'a> ReadCommand<'a> {
         generation: u32,
         expiration: u32,
     ) -> Result<Record> {
-        let mut bins: HashMap<String, Value> = HashMap::with_capacity(op_count);
+        let mut bins: IndexMap<String, Value> = IndexMap::with_capacity(op_count);
 
         // There can be fields in the response (setname etc). For now, ignore them. Expose them to
         // the API if needed in the future.
@@ -154,7 +154,7 @@ impl<'a> Command for ReadCommand<'a> {
         match ResultCode::from(result_code) {
             ResultCode::Ok => {
                 let record = if self.bins.is_none() {
-                    Record::new(None, HashMap::new(), generation, expiration)
+                    Record::new(None, IndexMap::new(), generation, expiration)
                 } else {
                     self.parse_record(conn, op_count, field_count, generation, expiration)?
                 };

--- a/aerospike-core/src/commands/stream_command.rs
+++ b/aerospike-core/src/commands/stream_command.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::hash_map::Entry::{Occupied, Vacant};
-use std::collections::HashMap;
+use indexmap::map::Entry::{Occupied, Vacant};
+use indexmap::IndexMap;
 use std::sync::Arc;
 
 use aerospike_rt::Mutex;
@@ -107,7 +107,7 @@ impl StreamCommand {
             return Ok((None, None, true));
         }
 
-        let mut bins: HashMap<String, Value> = HashMap::with_capacity(op_count);
+        let mut bins: IndexMap<String, Value> = IndexMap::with_capacity(op_count);
 
         for _ in 0..op_count {
             conn.read_buffer(8).await?;

--- a/aerospike-core/src/record.rs
+++ b/aerospike-core/src/record.rs
@@ -16,7 +16,7 @@
 #[cfg(feature = "serialization")]
 use serde::Serialize;
 
-use std::collections::HashMap;
+use indexmap::IndexMap;
 use std::fmt;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -37,7 +37,7 @@ pub struct Record {
     pub key: Option<Key>,
 
     /// Map of named record bins.
-    pub bins: HashMap<String, Value>,
+    pub bins: IndexMap<String, Value>,
 
     /// Record modification count.
     pub generation: u32,
@@ -48,9 +48,9 @@ pub struct Record {
 
 impl Record {
     /// Construct a new Record. For internal use only.
-    pub(crate) const fn new(
+    pub(crate) fn new(
         key: Option<Key>,
-        bins: HashMap<String, Value>,
+        bins: IndexMap<String, Value>,
         generation: u32,
         expiration: u32,
     ) -> Self {
@@ -102,7 +102,7 @@ impl fmt::Display for Record {
 #[cfg(test)]
 mod tests {
     use super::{Record, CITRUSLEAF_EPOCH};
-    use std::collections::HashMap;
+    use indexmap::IndexMap;
     use std::time::{Duration, SystemTime};
 
     #[test]
@@ -112,7 +112,7 @@ mod tests {
             .duration_since(*CITRUSLEAF_EPOCH)
             .unwrap()
             .as_secs();
-        let record = Record::new(None, HashMap::new(), 0, secs_since_epoch as u32);
+        let record = Record::new(None, IndexMap::new(), 0, secs_since_epoch as u32);
         let ttl = record.time_to_live();
         assert!(ttl.is_some());
         assert!(1000 - ttl.unwrap().as_secs() <= 1);
@@ -120,13 +120,13 @@ mod tests {
 
     #[test]
     fn ttl_expiration_past() {
-        let record = Record::new(None, HashMap::new(), 0, 0x0d00_d21c);
+        let record = Record::new(None, IndexMap::new(), 0, 0x0d00_d21c);
         assert_eq!(record.time_to_live(), Some(Duration::new(1u64, 0)));
     }
 
     #[test]
     fn ttl_never_expires() {
-        let record = Record::new(None, HashMap::new(), 0, 0);
+        let record = Record::new(None, IndexMap::new(), 0, 0);
         assert_eq!(record.time_to_live(), None);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/aerospike/aerospike-client-rust/issues/183

- Replace `HashMap<String, Value>` with `IndexMap<String, Value>` for `Record.bins` to preserve server-returned bin order
