### PR TITLE
Client 4102 update readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ aerospike-rust-client.sublime-project
 aerospike-rust-client.sublime-workspace
 aerospike-client-rust.code-workspace
 Makefile
+.idea/
 proptest-regressions/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 exclude = [
     ".travis.yml",
@@ -21,6 +22,7 @@ exclude = [
 [workspace.package]
 version = "2.0.0-alpha.10"
 edition = "2018"
+rust-version = "1.87"
 authors = ["Khosrow Afroozeh <khosrow@aerospike.com>", "Jan Hecking <jhecking@aerospike.com>"]
 license = "Apache-2.0"
 description = "Aerospike Client for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,3 +76,7 @@ tokio-rustls = {version = "0.26.0"}
 rustls = {version = "0.23.31"}
 webpki-roots = "1"
 #console-subscriber = "0.1.5"
+
+[[example]]
+name = "crud_sync"
+required-features = ["sync", "rt-tokio"]

--- a/README.md
+++ b/README.md
@@ -60,33 +60,43 @@ other officially supported clients. Features on the roadmap include:
 Prerequisites:
 
 - [Aerospike Database](https://aerospike.com/download/server/community/) 6.4 or later.
-- [Rust](https://www.rust-lang.org/) version 1.75 or later 
+- [Rust](https://www.rust-lang.org/) version 1.87 or later 
 - [Tokio runtime](https://tokio.rs/) or [async-std](https://async.rs/)
 
 ## Installation
 
-1. Build from source code:
+### Build from source
+
+1. Clone the repository and change into the project directory:
 
    ```
    git clone --single-branch --branch v2 https://github.com/aerospike/aerospike-client-rust.git
    cd aerospike-client-rust
    ```
 
-1. Add the following to your `cargo.toml` file:
+2. Build the project:
 
    ```
-   [dependencies]  
+   cargo build
+   ```
+
+### Use as a dependency
+
+To use the client in your own project, add one of the following to your `Cargo.toml`:
+
+   ```
+   [dependencies]
    # Async API with tokio Runtime
    aerospike = { version = "<version>", features = ["rt-tokio"]}
-   
+
    # OR
 
    # Async API with async-std runtime
    aerospike = { version = "<version>", features = ["rt-async-std"]}
-   
+
    # The library still supports the old sync interface, but it will be deprecated in the future.
    # This is only for compatibility reasons and will be removed in a later stage.
-   
+
    # Sync API with tokio
    aerospike = { version = "<version>", default-features = false, features = ["rt-tokio", "sync"]}
 
@@ -96,11 +106,7 @@ Prerequisites:
    aerospike = { version = "<version>", default-features = false, features = ["rt-async-std", "sync"]}
    ```
 
-1. Run the following command:
-
-   ```
-   cargo build
-   ```
+   Then run `cargo build` in your project.
 
 ## Core feature examples
 

--- a/README.md
+++ b/README.md
@@ -115,18 +115,62 @@ features.
 
 ### Client connection
 
+The examples below use the **async** client (default). For a blocking API with no `.await`, see [Sync client](#sync-client) below.
+
 #### Standard connection
 
 Connect to an Aerospike cluster without TLS:
 
 ```rust
+use std::env;
 use aerospike::{Client, ClientPolicy};
 
 let policy = ClientPolicy::default();
 let hosts = env::var("AEROSPIKE_HOSTS")
-    .unwrap_or(String::from("127.0.0.1:3000"));
-let client = Client::new(&policy, &hosts).await
+    .unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+let client = Client::new(&policy, &hosts)
+    .await
     .expect("Failed to connect to cluster");
+```
+
+#### Sync client
+
+With the `sync` feature, the client exposes blocking APIs (no `async`/`.await`). Use the same types and methods; calls block until the operation completes.
+
+**Cargo.toml** (sync with tokio; or use `rt-async-std` instead of `rt-tokio`):
+
+```toml
+[dependencies]
+aerospike = { version = "<version>", default-features = false, features = ["rt-tokio", "sync"]}
+```
+
+**Example:**
+
+```rust
+#[macro_use]
+extern crate aerospike;
+
+use std::env;
+use aerospike::{as_key, as_bin, Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let policy = ClientPolicy::default();
+    let hosts = env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+
+    let client = Client::new(&policy, &hosts)?;
+
+    let key = as_key!("test", "myset", "sync-key");
+    let wpolicy = WritePolicy::default();
+    let bins = vec![as_bin!("name", "Alice"), as_bin!("count", 42)];
+    client.put(&wpolicy, &key, &bins)?;
+
+    let rpolicy = ReadPolicy::default();
+    let record = client.get(&rpolicy, &key, Bins::All)?;
+    println!("Record: {:?}", record.bins);
+
+    client.close()?;
+    Ok(())
+}
 ```
 
 #### TLS connection without client authentication

--- a/README.md
+++ b/README.md
@@ -135,43 +135,52 @@ let client = Client::new(&policy, &hosts)
 
 #### Sync client
 
-With the `sync` feature, the client exposes blocking APIs (no `async`/`.await`). Use the same types and methods; calls block until the operation completes.
+The `sync` feature exposes blocking APIs — no `async`/`.await` at call sites. However, the client still uses Tokio 
+internally for cluster management, so **a Tokio runtime must be running** for the duration of your program.
 
-**Cargo.toml** (sync with tokio; or use `rt-async-std` instead of `rt-tokio`):
-
+**Cargo.toml**
 ```toml
 [dependencies]
-aerospike = { version = "<version>", default-features = false, features = ["rt-tokio", "sync"]}
+aerospike = { version = "<version>", default-features = false, features = ["rt-tokio", "sync"] }
+tokio = { version = "1", features = ["full"] }  # required even for sync usage
 ```
 
-**Example:**
+> Swap `rt-tokio` for `rt-async-std` if your project uses async-std instead.
 
+**Example:**
 ```rust
 #[macro_use]
 extern crate aerospike;
 
 use std::env;
-use aerospike::{as_key, as_bin, Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
+use aerospike::{Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+// #[tokio::main] is required — the sync client uses Tokio internally
+// for cluster tending, even though your code has no .await calls.
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let policy = ClientPolicy::default();
-    let hosts = env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+    let hosts = env::var("AEROSPIKE_HOSTS")
+        .unwrap_or_else(|_| "127.0.0.1:3000".to_string());
 
     let client = Client::new(&policy, &hosts)?;
 
     let key = as_key!("test", "myset", "sync-key");
-    let wpolicy = WritePolicy::default();
-    let bins = vec![as_bin!("name", "Alice"), as_bin!("count", 42)];
-    client.put(&wpolicy, &key, &bins)?;
+    let bins = [as_bin!("name", "Alice"), as_bin!("count", 42)];
+    client.put(&WritePolicy::default(), &key, &bins)?;
 
-    let rpolicy = ReadPolicy::default();
-    let record = client.get(&rpolicy, &key, Bins::All)?;
+    let record = client.get(&ReadPolicy::default(), &key, Bins::All)?;
     println!("Record: {:?}", record.bins);
 
     client.close()?;
     Ok(())
 }
 ```
+
+> **Why does sync need a Tokio runtime?** The `sync` feature wraps the async client and provides blocking call 
+> sites — it does not replace the underlying async runtime. Cluster tending (node discovery, connection pooling) runs 
+> as a background Tokio task regardless of which API surface you use. Calling `Client::new` outside of a runtime context
+> will panic with `there is no reactor running`.
 
 #### TLS connection without client authentication
 

--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/aerospike-macro/Cargo.toml
+++ b/aerospike-macro/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/aerospike-rt/Cargo.toml
+++ b/aerospike-rt/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/aerospike-sync/Cargo.toml
+++ b/aerospike-sync/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 documentation.workspace = true
 readme.workspace = true
+rust-version.workspace = true
 publish = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,8 @@ This directory includes several Rust examples that demonstrate how to use the Ae
 ## Available Examples
 
 * `batch_operations`
-* `crud`
+* `crud` — async client
+* `crud_sync` — sync (blocking) client; see [How to run sync example](#sync-example-crud_sync) below
 * `query`
 * `timeout_configuration`
 
@@ -40,6 +41,14 @@ cargo run --example batch_operations
 cargo run --example crud
 cargo run --example query
 cargo run --example timeout_configuration
+```
+
+### Sync example (`crud_sync`)
+
+The `crud_sync` example uses the blocking client and requires the `sync` feature:
+
+```bash
+cargo run --example crud_sync --no-default-features --features "rt-tokio,sync"
 ```
 
 Cargo will compile and run the selected example binary.

--- a/examples/crud.rs
+++ b/examples/crud.rs
@@ -11,7 +11,7 @@ use aerospike::{Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
 #[tokio::main]
 async fn main() {
     let cpolicy = ClientPolicy::default();
-    let hosts = env::var("AEROSPIKE_HOSTS").unwrap_or(String::from("127.0.0.1:3100"));
+    let hosts = env::var("AEROSPIKE_HOSTS").unwrap_or(String::from("127.0.0.1:3000"));
     let client = Client::new(&cpolicy, &hosts)
         .await
         .expect("Failed to connect to cluster");

--- a/examples/crud_sync.rs
+++ b/examples/crud_sync.rs
@@ -19,11 +19,9 @@ use std::time::Instant;
 use aerospike::operations;
 use aerospike::{Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
 
-fn main() {
-    let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
-    rt.block_on(async {
-        run();
-    });
+#[tokio::main]
+async fn main() {
+    run();
 }
 
 fn run() {

--- a/examples/crud_sync.rs
+++ b/examples/crud_sync.rs
@@ -1,0 +1,66 @@
+//! CRUD operations using the **sync** (blocking) client.
+//!
+//! The sync client wraps the async client and must run on a thread where a Tokio runtime
+//! is current (the core client uses the runtime for cluster tending). So we run the
+//! example inside `runtime.block_on(...)`.
+//!
+//! Run with the sync feature enabled:
+//!
+//! ```bash
+//! cargo run --example crud_sync --no-default-features --features "rt-tokio,sync"
+//! ```
+
+#[macro_use]
+extern crate aerospike;
+
+use std::env;
+use std::time::Instant;
+
+use aerospike::operations;
+use aerospike::{Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
+
+fn main() {
+    let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
+    rt.block_on(async {
+        run();
+    });
+}
+
+fn run() {
+    let cpolicy = ClientPolicy::default();
+    let hosts = env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
+    let client = Client::new(&cpolicy, &hosts).expect("Failed to connect to cluster");
+
+    let now = Instant::now();
+    let rpolicy = ReadPolicy::default();
+    let wpolicy = WritePolicy::default();
+    let key = as_key!("test", "test", "test");
+
+    let bins = [as_bin!("int", 999), as_bin!("str", "Hello, World!")];
+    client.put(&wpolicy, &key, &bins).unwrap();
+    let rec = client.get(&rpolicy, &key, Bins::All).unwrap();
+    println!("Record: {}", rec);
+
+    client.touch(&wpolicy, &key).unwrap();
+    let rec = client.get(&rpolicy, &key, Bins::All).unwrap();
+    println!("Record: {}", rec);
+
+    let rec = client.get(&rpolicy, &key, Bins::None).unwrap();
+    println!("Record Header: {}", rec);
+
+    let exists = client.exists(&rpolicy, &key).unwrap();
+    println!("exists: {}", exists);
+
+    let bin = as_bin!("int", "123");
+    let ops = &[operations::put(&bin), operations::get()];
+    let op_rec = client.operate(&wpolicy, &key, ops).unwrap();
+    println!("operate: {}", op_rec);
+
+    let existed = client.delete(&wpolicy, &key).unwrap();
+    println!("existed (should be true): {}", existed);
+
+    let existed = client.delete(&wpolicy, &key).unwrap();
+    println!("existed (should be false): {}", existed);
+
+    println!("total time: {:?}", now.elapsed());
+}

--- a/tools/benchmark/Cargo.toml
+++ b/tools/benchmark/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://www.aerospike.com/"
 repository = "https://github.com/aerospike/aerospike-client-rust/"
 license = "Apache-2.0"
 edition = "2018"
+rust-version = "1.87"
 
 [dependencies]
 clap = "2.33"


### PR DESCRIPTION
1. Update the supported rust version
2. Separate the installation sections to 2 parts: `build from source` and `use as dependency`
3. Add `rust-version` to `Cargo.toml`
