### PR TITLE
CLIENT-4156 fix rust-doc examples at remaining places in client, errors, and expressions

### DIFF
--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -50,3 +50,4 @@ aerospike = { path = "../" }
 aerospike-macro = {path = "../aerospike-macro"}
 lazy_static = "1.4"
 tokio = { version = "1.48.0", features = ["full"] }
+webpki-roots = "1"

--- a/aerospike-core/src/errors.rs
+++ b/aerospike-core/src/errors.rs
@@ -22,8 +22,8 @@
 //! ```rust,edition2021
 //! use aerospike::*;
 //!
-//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+//! # async fn example() -> Result<()> {
+//! let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
 //! let policy = ClientPolicy::default();
 //! let client = Client::new(&policy, &hosts).await?;
 //! let key = as_key!("test", "test", "someKey");
@@ -39,13 +39,10 @@
 //!     },
 //!     Err(err) => {
 //!         println!("Error fetching record: {}", err);
-//!         for err in err.iter().skip(1) {
-//!             println!("Caused by: {}", err);
-//!         }
-//!         // The backtrace is not always generated. Try to run this example
-//!         // with `RUST_BACKTRACE=1`.
-//!         if let Some(backtrace) = err.backtrace() {
-//!             println!("Backtrace: {:?}", backtrace);
+//!         let mut source = std::error::Error::source(&err);
+//!         while let Some(e) = source {
+//!             println!("Caused by: {}", e);
+//!             source = e.source();
 //!         }
 //!     }
 //! }

--- a/aerospike-core/src/expressions/mod.rs
+++ b/aerospike-core/src/expressions/mod.rs
@@ -580,6 +580,8 @@ pub fn record_size() -> Expression {
 ///
 /// Deprecated: `memory_size` has been deprecated since server version 8.1. Use [`record_size()`].
 /// ```
+/// #  #![deny(warnings)]
+/// # #![allow(deprecated)]
 /// use aerospike::expressions::{ge, device_size, int_val};
 /// // Record device size >= 100 KB
 /// ge(device_size(), int_val(100*1024));
@@ -598,6 +600,8 @@ pub fn device_size() -> Expression {
 ///
 /// Deprecated: `memory_size` has been deprecated since server version 8.1. Use [`record_size()`].
 /// ```
+/// # #![deny(warnings)]
+/// # #![allow(deprecated)]
 /// use aerospike::expressions::{ge, memory_size, int_val};
 /// // Record device size >= 100 KB
 /// ge(memory_size(), int_val(100*1024));

--- a/aerospike-core/src/lib.rs
+++ b/aerospike-core/src/lib.rs
@@ -69,24 +69,24 @@
 //! use std::env;
 //! use std::sync::Arc;
 //! use std::time::Instant;
-//! use std::thread;
 //!
 //! use aerospike::{Bins, Client, ClientPolicy, ReadPolicy, WritePolicy};
 //! use aerospike::operations;
 //!
 //! fn main() {
-//!     let cpolicy = ClientPolicy::default();
-//!     let hosts = env::var("AEROSPIKE_HOSTS")
-//!         .unwrap_or(String::from("127.0.0.1:3000"));
-//!     let client = Client::new(&cpolicy, &hosts)
-//!         .expect("Failed to connect to cluster");
-//!     let client = Arc::new(client);
+//!     let rt = tokio::runtime::Runtime::new().unwrap();
+//!     rt.block_on(async {
+//!         let cpolicy = ClientPolicy::default();
+//!         let hosts = env::var("AEROSPIKE_HOSTS")
+//!             .unwrap_or_else(|_| String::from("127.0.0.1:3000"));
+//!         let client = Client::new(&cpolicy, &hosts)
+//!             .await
+//!             .expect("Failed to connect to cluster");
+//!         let client = Arc::new(client);
 //!
-//!     let mut threads = vec![];
-//!     let now = Instant::now();
-//!     for i in 0..2 {
-//!         let client = client.clone();
-//!         let t = thread::spawn(move || {
+//!         let now = Instant::now();
+//!         for i in 0..2 {
+//!             let client = Arc::clone(&client);
 //!             let rpolicy = ReadPolicy::default();
 //!             let wpolicy = WritePolicy::default();
 //!             let key = as_key!("test", "test", i);
@@ -95,40 +95,34 @@
 //!                 as_bin!("str", "Hello, World!"),
 //!             ];
 //!
-//!             client.put(&wpolicy, &key, &bins).unwrap();
-//!             let rec = client.get(&rpolicy, &key, Bins::All);
+//!             client.put(&wpolicy, &key, &bins).await.unwrap();
+//!             let rec = client.get(&rpolicy, &key, Bins::All).await;
 //!             println!("Record: {}", rec.unwrap());
 //!
-//!             client.touch(&wpolicy, &key).unwrap();
-//!             let rec = client.get(&rpolicy, &key, Bins::All);
+//!             client.touch(&wpolicy, &key).await.unwrap();
+//!             let rec = client.get(&rpolicy, &key, Bins::All).await;
 //!             println!("Record: {}", rec.unwrap());
 //!
-//!             let rec = client.get(&rpolicy, &key, Bins::None);
+//!             let rec = client.get(&rpolicy, &key, Bins::None).await;
 //!             println!("Record Header: {}", rec.unwrap());
 //!
-//!             let exists = client.exists(&wpolicy, &key).unwrap();
+//!             let exists = client.exists(&rpolicy, &key).await.unwrap();
 //!             println!("exists: {}", exists);
 //!
 //!             let bin = as_bin!("int", 999);
 //!             let ops = &vec![operations::put(&bin), operations::get()];
-//!             let op_rec = client.operate(&wpolicy, &key, ops);
+//!             let op_rec = client.operate(&wpolicy, &key, ops).await;
 //!             println!("operate: {}", op_rec.unwrap());
 //!
-//!             let existed = client.delete(&wpolicy, &key).unwrap();
-//!             println!("existed (sould be true): {}", existed);
+//!             let existed = client.delete(&wpolicy, &key).await.unwrap();
+//!             println!("existed (should be true): {}", existed);
 //!
-//!             let existed = client.delete(&wpolicy, &key).unwrap();
+//!             let existed = client.delete(&wpolicy, &key).await.unwrap();
 //!             println!("existed (should be false): {}", existed);
-//!         });
+//!         }
 //!
-//!         threads.push(t);
-//!     }
-//!
-//!     for t in threads {
-//!         t.join().unwrap();
-//!     }
-//!
-//!     println!("total time: {:?}", now.elapsed());
+//!         println!("total time: {:?}", now.elapsed());
+//!     });
 //! }
 //! ```
 

--- a/aerospike-core/src/policy/client_policy.rs
+++ b/aerospike-core/src/policy/client_policy.rs
@@ -53,7 +53,11 @@ pub struct ClientPolicy {
     ///
     /// Using cert files to allow for client authentication.
     ///
-    /// ```rust,edition2021
+    /// ```rust,edition2021,no_run
+    /// # use rustls::RootCertStore;
+    /// # use rustls::pki_types::CertificateDer;
+    /// # use rustls::pki_types::PrivateKeyDer;
+    /// # use rustls::pki_types::pem::PemObject;
     /// let mut root_store = RootCertStore {
     ///     roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     /// };
@@ -70,12 +74,15 @@ pub struct ClientPolicy {
     /// let tls_config = rustls::ClientConfig::builder()
     ///     .with_root_certificates(root_store)
     ///     .with_client_auth_cert(vec![client_ca], client_key)
-    ///     .unwrap()
+    ///     .unwrap();
     /// ```
     ///
     /// Using cert files without enforcing client authentication.
     ///
-    /// ```rust,edition2021
+    /// ```rust,edition2021,no_run
+    /// # use rustls::RootCertStore;
+    /// # use rustls::pki_types::CertificateDer;
+    /// # use rustls::pki_types::pem::PemObject;
     /// let mut root_store = RootCertStore {
     ///     roots: webpki_roots::TLS_SERVER_ROOTS.into(),
     /// };
@@ -88,7 +95,7 @@ pub struct ClientPolicy {
     ///
     /// let tls_config = rustls::ClientConfig::builder()
     ///     .with_root_certificates(root_store)
-    ///     .with_no_client_auth()
+    ///     .with_no_client_auth();
     /// ```
     #[cfg(feature = "tls")]
     pub tls_config: Option<ClientConfig>,

--- a/aerospike-core/src/value.rs
+++ b/aerospike-core/src/value.rs
@@ -880,8 +880,9 @@ macro_rules! as_blob {
 /// ```rust,edition2018
 /// # use aerospike::*;
 /// # use std::vec::Vec;
+/// # #[tokio::main]
 /// # async fn main() {
-/// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+/// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
 /// # let client = Client::new(&ClientPolicy::default(), &hosts).await.unwrap();
 /// # let key = as_key!("test", "test", "mykey");
 /// let list = as_list!("a", "b", "c");
@@ -911,8 +912,9 @@ macro_rules! as_list {
 /// ```rust,should_panic,edition2018
 /// # use aerospike::*;
 /// # use std::vec::Vec;
+///  # #[tokio::main]
 /// # async fn main() {
-/// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+/// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
 /// # let client = Client::new(&ClientPolicy::default(), &hosts).await.unwrap();
 /// # let key = as_key!("test", "test", "mykey");
 /// let module = "myUDF";
@@ -943,8 +945,9 @@ macro_rules! as_values {
 ///
 /// ```rust,edition2018
 /// # use aerospike::*;
+/// # #[tokio::main]
 /// # async fn main() {
-/// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+/// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
 /// # let client = Client::new(&ClientPolicy::default(), &hosts).await.unwrap();
 /// # let key = as_key!("test", "test", "mykey");
 /// let map = as_map!("a" => 1, "b" => 2);
@@ -973,8 +976,9 @@ macro_rules! as_map {
 ///
 /// ```rust,edition2018
 /// # use aerospike::*;
+/// # #[tokio::main]
 /// # async fn main() {
-/// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+/// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
 /// # let client = Client::new(&ClientPolicy::default(), &hosts).await.unwrap();
 /// # let key = as_key!("test", "test", "mykey");
 /// let map = as_ord_map!("a" => 1, "b" => 2);

--- a/aerospike-sync/Cargo.toml
+++ b/aerospike-sync/Cargo.toml
@@ -25,3 +25,4 @@ rt-async-std = ["aerospike-core/rt-async-std"]
 
 [dev-dependencies]
 aerospike = {path = "../"}
+tokio = { version = "1", features = ["rt-multi-thread"] } # for doc tests

--- a/aerospike-sync/src/client.rs
+++ b/aerospike-sync/src/client.rs
@@ -78,10 +78,10 @@ impl Client {
     ///
     /// Using an environment variable to set the list of seed hosts.
     ///
-    /// ```rust,edition2018
-    /// use aerospike::{Client, ClientPolicy};
+    /// ```rust,edition2021,no_run
+    /// use aerospike_sync::{Client, ClientPolicy};
     ///
-    /// let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// ```
     pub fn new(policy: &ClientPolicy, hosts: &(dyn ToHosts + Send + Sync)) -> Result<Self> {
@@ -125,16 +125,16 @@ impl Client {
     ///
     /// Fetch specified bins for a record with the given key.
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
     /// match client.get(&ReadPolicy::default(), &key, ["a", "b"]) {
     ///     Ok(record)
     ///         => println!("a={:?}", record.bins.get("a")),
-    ///     Err(Error::ServerError(ResultCode::KeyNotFoundError))
+    ///     Err(Error::ServerError(ResultCode::KeyNotFoundError, _, _))
     ///         => println!("No such record: {}", key),
     ///     Err(err)
     ///         => println!("Error fetching record: {}", err),
@@ -143,10 +143,10 @@ impl Client {
     ///
     /// Determine the remaining time-to-live of a record.
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
     /// match client.get(&ReadPolicy::default(), &key, Bins::None) {
@@ -156,7 +156,7 @@ impl Client {
     ///             Some(duration) => println!("ttl: {} secs", duration.as_secs()),
     ///         }
     ///     },
-    ///     Err(Error::ServerError(ResultCode::KeyNotFoundError))
+    ///     Err(Error::ServerError(ResultCode::KeyNotFoundError, _, _))
     ///         => println!("No such record: {}", key),
     ///     Err(err)
     ///         => println!("Error fetching record: {}", err),
@@ -182,18 +182,19 @@ impl Client {
     ///
     /// Fetch multiple records in a single client request
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let bins = Bins::from(["name", "age"]);
-    /// let mut batch_reads = vec![];
+    /// let bpr = BatchReadPolicy::default();
+    /// let mut batch_ops = vec![];
     /// for i in 0..10 {
     ///   let key = as_key!("test", "test", i);
-    ///   batch_reads.push(BatchRead::new(key, bins.clone()));
+    ///   batch_ops.push(BatchOperation::read(&bpr, key, bins.clone()));
     /// }
-    /// match client.batch(&BatchPolicy::default(), batch_reads) {
+    /// match client.batch(&BatchPolicy::default(), &batch_ops) {
     ///     Ok(results) => {
     ///       for result in results {
     ///         match result.record {
@@ -221,10 +222,10 @@ impl Client {
     ///
     /// Write a record with a single integer bin.
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
     /// let bin = as_bin!("i", 42);
@@ -236,10 +237,10 @@ impl Client {
     ///
     /// Write a record with an expiration of 10 seconds.
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
     /// let bin = as_bin!("i", 42);
@@ -267,10 +268,10 @@ impl Client {
     ///
     /// Add two integer values to two existing bin values.
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
     /// let bina = as_bin!("a", 1);
@@ -321,10 +322,10 @@ impl Client {
     ///
     /// Delete a record.
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
     /// match client.delete(&WritePolicy::default(), &key) {
@@ -344,10 +345,10 @@ impl Client {
     ///
     /// Reset a record's time to expiration to the default ttl for the namespace.
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
     /// let mut policy = WritePolicy::default();
@@ -377,10 +378,10 @@ impl Client {
     /// Add an integer value to an existing record and then read the result, all in one database
     /// call.
     ///
-    /// ```rust,edition2018
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let key = as_key!("test", "test", "mykey");
     /// let bin = as_bin!("a", 42);
@@ -408,11 +409,10 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,edition2018
-    /// # extern crate aerospike;
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let code = r#"
     /// -- Validate value before writing.
@@ -438,7 +438,7 @@ impl Client {
     /// end
     /// "#;
     ///
-    /// client.register_udf(code.as_bytes(),
+    /// client.register_udf(&AdminPolicy::default(), code.as_bytes(),
     ///                     "example.lua", UDFLang::Lua).unwrap();
     /// ```
     pub fn register_udf(
@@ -505,11 +505,10 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,edition2018
-    /// # extern crate aerospike;
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let stmt = Statement::new("test", "test", Bins::All);
     /// let pf = PartitionFilter::all();
@@ -583,17 +582,14 @@ impl Client {
     /// The following example creates an index `idx_foo_bar_baz`. The index is in namespace `foo`
     /// within set `bar` and bin `baz`:
     ///
-    /// ```rust,edition2021
-    /// # extern crate aerospike;
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
-    /// match client.create_index("foo", "bar", "baz",
-    ///     "idx_foo_bar_baz", IndexType::Numeric, CollectionIndexType::Default, None) {
-    ///     Err(err) => println!("Failed to create index: {}", err),
-    ///     _ => {}
-    /// }
+    /// // Returns a Future; use futures::executor::block_on or similar from sync code.
+    /// let _ = client.create_index_on_bin(&AdminPolicy::default(), "foo", "bar", "baz",
+    ///     "idx_foo_bar_baz", IndexType::Numeric, CollectionIndexType::Default, None);
     /// ```
     pub async fn create_index_on_bin(
         &self,
@@ -626,18 +622,16 @@ impl Client {
     /// The following example creates an index `idx_foo_bar_baz`. The index is in namespace `foo`
     /// within set `bar` with the expression `int_bin("a") == 500`:
     ///
-    /// ```rust,edition2021
-    /// # extern crate aerospike;
-    /// # use aerospike::*;
+    /// ```rust,edition2021,no_run
+    /// # use aerospike_sync::*;
+    /// # use aerospike_sync::expressions::{Expression, eq, int_bin, int_val};
     ///
-    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
+    /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
     /// let fe: Expression = eq(int_bin("a".to_string()), int_val(500));
-    /// match client.create_index("foo", "bar", "baz",
-    ///     "idx_foo_bar_baz", IndexType::Numeric, CollectionIndexType::Default, &fe) {
-    ///     Err(err) => println!("Failed to create index: {}", err),
-    ///     _ => {}
-    /// }
+    /// // Returns a Future; use futures::executor::block_on or similar from sync code.
+    /// let _ = client.create_index_using_expression(&AdminPolicy::default(), "foo", "bar",
+    ///     "idx_foo_bar_baz", IndexType::Numeric, CollectionIndexType::Default, &fe);
     /// ```
     pub async fn create_index_using_expression(
         &self,

--- a/aerospike-sync/src/client.rs
+++ b/aerospike-sync/src/client.rs
@@ -78,8 +78,10 @@ impl Client {
     ///
     /// Using an environment variable to set the list of seed hosts.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// use aerospike_sync::{Client, ClientPolicy};
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -125,8 +127,10 @@ impl Client {
     ///
     /// Fetch specified bins for a record with the given key.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -143,8 +147,10 @@ impl Client {
     ///
     /// Determine the remaining time-to-live of a record.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -182,8 +188,10 @@ impl Client {
     ///
     /// Fetch multiple records in a single client request
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -222,8 +230,10 @@ impl Client {
     ///
     /// Write a record with a single integer bin.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -237,8 +247,10 @@ impl Client {
     ///
     /// Write a record with an expiration of 10 seconds.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -268,8 +280,10 @@ impl Client {
     ///
     /// Add two integer values to two existing bin values.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -322,8 +336,10 @@ impl Client {
     ///
     /// Delete a record.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -345,8 +361,10 @@ impl Client {
     ///
     /// Reset a record's time to expiration to the default ttl for the namespace.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -378,8 +396,10 @@ impl Client {
     /// Add an integer value to an existing record and then read the result, all in one database
     /// call.
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -409,8 +429,10 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -505,8 +527,10 @@ impl Client {
     ///
     /// # Examples
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -582,8 +606,10 @@ impl Client {
     /// The following example creates an index `idx_foo_bar_baz`. The index is in namespace `foo`
     /// within set `bar` and bin `baz`:
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();
@@ -622,9 +648,11 @@ impl Client {
     /// The following example creates an index `idx_foo_bar_baz`. The index is in namespace `foo`
     /// within set `bar` with the expression `int_bin("a") == 500`:
     ///
-    /// ```rust,edition2021,no_run
+    /// ```rust,edition2021
     /// # use aerospike_sync::*;
     /// # use aerospike_sync::expressions::{Expression, eq, int_bin, int_val};
+    /// # let rt = tokio::runtime::Runtime::new().unwrap();
+    /// # let _guard = rt.enter();
     ///
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| "127.0.0.1:3000".to_string());
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).unwrap();

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -15,7 +15,7 @@
 use aerospike::{
     as_bin, as_blob, as_geo, as_key, as_list, as_map, as_val, Bins, ReadPolicy, Value, WritePolicy,
 };
-use aerospike::{operations, Error, Expiration, ReadTouchTTL, ResultCode};
+use aerospike::{operations, Expiration, ReadTouchTTL};
 use aerospike_rt::sleep;
 use aerospike_rt::time::Duration;
 
@@ -54,22 +54,6 @@ async fn read_touch_ttl() {
     match record {
         Err(_) => (),
         _ => panic!("expected key not found error"),
-    }
-}
-
-#[aerospike_macro::test]
-async fn get_nonexisting_key() {
-    let client = common::client().await;
-    let namespace: &str = common::namespace();
-    let set_name = &common::rand_str(10);
-    let key = as_key!(namespace, set_name, "nonexisting_key");
-    let policy = ReadPolicy::default();
-
-    let result = client.get(&policy, &key, Bins::All).await;
-    match result {
-        Err(Error::ServerError(ResultCode::KeyNotFoundError, _, _)) => (),
-        Ok(_) => panic!("expected key not found error, got Ok(record)"),
-        Err(e) => panic!("expected KeyNotFoundError, got {:?}", e),
     }
 }
 

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -15,7 +15,7 @@
 use aerospike::{
     as_bin, as_blob, as_geo, as_key, as_list, as_map, as_val, Bins, ReadPolicy, Value, WritePolicy,
 };
-use aerospike::{operations, Expiration, ReadTouchTTL};
+use aerospike::{operations, Error, Expiration, ReadTouchTTL, ResultCode};
 use aerospike_rt::sleep;
 use aerospike_rt::time::Duration;
 
@@ -54,6 +54,22 @@ async fn read_touch_ttl() {
     match record {
         Err(_) => (),
         _ => panic!("expected key not found error"),
+    }
+}
+
+#[aerospike_macro::test]
+async fn get_nonexisting_key() {
+    let client = common::client().await;
+    let namespace: &str = common::namespace();
+    let set_name = &common::rand_str(10);
+    let key = as_key!(namespace, set_name, "nonexisting_key");
+    let policy = ReadPolicy::default();
+
+    let result = client.get(&policy, &key, Bins::All).await;
+    match result {
+        Err(Error::ServerError(ResultCode::KeyNotFoundError, _, _)) => (),
+        Ok(_) => panic!("expected key not found error, got Ok(record)"),
+        Err(e) => panic!("expected KeyNotFoundError, got {:?}", e),
     }
 }
 


### PR DESCRIPTION
This change makes all doc-tests runnable, except for sync-client tests which need an async runtime. That will require some modifications in how we enable the features.

For now, its good to go with all compiling doctests:

```
cargo test --doc --workspace
```