### PR TITLE
Client 4405 execute query failing during nodechurn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ lazy_static = "1.4"
 ripemd = "0.1"
 aerospike-macro = {path = "./aerospike-macro"}
 aerospike-rt = {path = "./aerospike-rt"}
-futures = {version = "0.3.16" }
+futures = { version = "0.3.32" }
 tokio = { version = "1.48.0", features = ["full"] }
 proptest = "1.6.0"
 tokio-rustls = {version = "0.26.0"}

--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0.40"
 pwhash = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 aerospike-rt = { path = "../aerospike-rt", version = "2.0.0" }
-futures = { version = "0.3.16" }
+futures = { version = "0.3.32" }
 async-trait = "0.1.51"
 rhexdump = "0.2.0"
 regex = "1"

--- a/aerospike-core/src/batch/batch_executor.rs
+++ b/aerospike-core/src/batch/batch_executor.rs
@@ -13,8 +13,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::collections::HashMap;
-use std::sync::Arc;
 use crate::batch::BatchOperation;
 use crate::cluster::partition::Partition;
 use crate::cluster::{Cluster, Node};
@@ -25,6 +23,8 @@ use crate::Error;
 use crate::Key;
 use crate::{BatchRecord, Policy};
 use aerospike_rt::time::Duration;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 pub struct BatchExecutor {
     cluster: Arc<Cluster>,

--- a/aerospike-core/src/batch/batch_executor.rs
+++ b/aerospike-core/src/batch/batch_executor.rs
@@ -14,8 +14,7 @@
 // the License.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Weak};
-
+use std::sync::Arc;
 use crate::batch::BatchOperation;
 use crate::cluster::partition::Partition;
 use crate::cluster::{Cluster, Node};
@@ -38,7 +37,7 @@ impl BatchExecutor {
 
     fn node_for_key(&self, key: &Key, replica: crate::policy::Replica) -> Result<Arc<Node>> {
         let partition = Partition::new_by_key(key);
-        let node = self.cluster.get_node(&partition, replica, Weak::new())?;
+        let node = self.cluster.get_node(&partition, replica, None)?;
         Ok(node)
     }
 

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -23,8 +23,8 @@ pub mod version_parser;
 use aerospike_rt::time::{Duration, Instant};
 use std::cell::OnceCell;
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
+use std::sync::Arc;
 use std::vec::Vec;
 
 pub use self::node::Node;
@@ -211,7 +211,7 @@ impl Cluster {
         let tend_interval = cluster.client_policy.load().tend_interval;
 
         loop {
-            if rx.try_next().is_ok() {
+            if rx.try_recv().is_ok() {
                 unreachable!();
             } else if let Err(err) = cluster.tend().await {
                 log_error_chain!(err, "Error tending cluster");
@@ -566,7 +566,7 @@ impl Cluster {
                         }
                     } else if refresh_count >= 1 && failures > 0 {
                         debug!(
-                            "multi-node: refresh failed repeatedly, removing node despite peer reference_count {}", tnode
+                            "multi-node: refresh failed repeatedly, removing node despite peer reference_count {tnode}"
                         );
                         remove_list.push(tnode);
                     }
@@ -586,19 +586,16 @@ impl Cluster {
 
     fn remove_nodes_and_aliases(&self, mut nodes_to_remove: Vec<Arc<Node>>) {
         for node in &nodes_to_remove {
-            debug!("Removing alias for node {}", node);
+            debug!("Removing alias for node {node}");
             for alias in node.aliases() {
                 self.remove_alias(&alias);
-            }    
+            }
         }
         self.remove_nodes(&nodes_to_remove);
-        
+
         for node in &mut nodes_to_remove {
-            debug!("Attempt to close node {}", node);
-            if let Some(node) = Arc::get_mut(node) {
-                debug!("Closing node {}", node);
-                node.close();
-            }
+            debug!("Closing node {node}");
+            node.close();
         }
     }
 

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -585,21 +585,26 @@ impl Cluster {
     }
 
     fn remove_nodes_and_aliases(&self, mut nodes_to_remove: Vec<Arc<Node>>) {
-        for node in &mut nodes_to_remove {
+        for node in &nodes_to_remove {
             debug!("Removing alias for node {}", node);
 
             for alias in node.aliases() {
                 self.remove_alias(&alias);
             }
+        }
+        self.remove_nodes(&nodes_to_remove);
+        for node in &mut nodes_to_remove {
             debug!("Attempt to close node {}", node);
             if let Some(node) = Arc::get_mut(node) {
                 debug!("Node closed {}", node);
                 node.close();
             } else {
-                debug!("Fail to closed node {}", node);
+                debug!(
+                    "Failed to close node {} — other strong or weak refs to this allocation remain",
+                    node
+                );
             }
         }
-        self.remove_nodes(&nodes_to_remove);
     }
 
     fn add_alias(&self, host: Host, node: Arc<Node>) {

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -599,10 +599,7 @@ impl Cluster {
                 debug!("Node closed {}", node);
                 node.close();
             } else {
-                debug!(
-                    "Failed to close node {}",
-                    node
-                );
+                debug!("Failed to close node {}", node);
             }
         }
     }
@@ -717,23 +714,6 @@ impl Cluster {
 
         namespace.get_node(self, partition, replica, last_tried)
     }
-
-    // pub fn get_master_node(&self, namespace: &str, partition_id: usize) -> Result<Arc<Node>> {
-    //     let partitions = self.partition_map.load();
-
-    //     let ns_partition = partitions.get(namespace).ok_or_else(|| {
-    //         Error::InvalidNode(format!(
-    //             "Cannot get appropriate node for namespace: {namespace}"
-    //         ))
-    //     })?;
-
-    //     let node = ns_partition.all_replicas(partition_id).next().flatten();
-    //     node.ok_or_else(|| {
-    //         Error::InvalidNode(format!(
-    //             "Cannot get appropriate node for namespace: {namespace} partition: {partition_id}"
-    //         ))
-    //     })
-    // }
 
     pub fn get_random_node(&self) -> Result<Arc<Node>> {
         let node_array = self.nodes();

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -42,7 +42,7 @@ use crate::policy::Replica;
 use crate::AdminPolicy;
 use aerospike_rt::Mutex;
 use futures::channel::mpsc;
-use futures::channel::mpsc::{Receiver, Sender};
+use futures::channel::mpsc::{Receiver, Sender, TryRecvError};
 use hazarc::AtomicArc;
 
 static CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -83,7 +83,6 @@ impl PartitionForNamespace {
                         if let Some(in_sequence_after) = replicas.next() {
                             return Some(in_sequence_after);
                         }
-
                         // No more after this? Drop through to try from the beginning.
                         break;
                     }
@@ -211,22 +210,17 @@ impl Cluster {
         let tend_interval = cluster.client_policy.load().tend_interval;
 
         loop {
-            if rx.try_recv().is_ok() {
-                unreachable!();
-            } else if let Err(err) = cluster.tend().await {
-                log_error_chain!(err, "Error tending cluster");
+            match rx.try_recv() {
+                Ok(()) => unreachable!(),
+                Err(TryRecvError::Closed) => break,
+                Err(TryRecvError::Empty) => {
+                    if let Err(err) = cluster.tend().await {
+                        log_error_chain!(err, "Error tending cluster");
+                    }
+                    aerospike_rt::sleep(Duration::from_millis(u64::from(tend_interval))).await;
+                }
             }
-            aerospike_rt::sleep(Duration::from_millis(u64::from(tend_interval))).await;
         }
-
-        // close all nodes
-        //let nodes = cluster.nodes().await;
-        //for mut node in nodes {
-        //    if let Some(node) = Arc::get_mut(&mut node) {
-        //        node.close().await;
-        //    }
-        //}
-        //cluster.set_nodes(vec![]).await;
     }
 
     async fn tend(&self) -> Result<()> {
@@ -591,12 +585,11 @@ impl Cluster {
                 self.remove_alias(&alias);
             }
         }
-        self.remove_nodes(&nodes_to_remove);
-
         for node in &mut nodes_to_remove {
             debug!("Closing node {node}");
             node.close();
         }
+        self.remove_nodes(&nodes_to_remove);
     }
 
     fn add_alias(&self, host: Host, node: Arc<Node>) {

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -94,9 +94,17 @@ impl PartitionForNamespace {
         }
 
         let node = match replica {
-            Replica::Master => self.all_replicas(partition.partition_id).next().flatten(),
+            Replica::Master => self
+                .all_replicas(partition.partition_id)
+                .next()
+                .flatten()
+                .filter(|node| node.is_active()),
             Replica::Sequence => get_next_in_sequence(
-                || self.all_replicas(partition.partition_id).flatten(),
+                || {
+                    self.all_replicas(partition.partition_id)
+                        .flatten()
+                        .filter(|node| node.is_active())
+                },
                 last_tried,
             ),
             Replica::PreferRack => {
@@ -106,13 +114,19 @@ impl PartitionForNamespace {
                     || {
                         self.all_replicas(partition.partition_id)
                             .flatten()
-                            .filter(|node| node.is_in_rack(partition.namespace, rack_ids))
+                            .filter(|node| {
+                                node.is_in_rack(partition.namespace, rack_ids) && node.is_active()
+                            })
                     },
                     last_tried.clone(),
                 )
                 .or_else(|| {
                     get_next_in_sequence(
-                        || self.all_replicas(partition.partition_id).flatten(),
+                        || {
+                            self.all_replicas(partition.partition_id)
+                                .flatten()
+                                .filter(|node| node.is_active())
+                        },
                         last_tried,
                     )
                 })
@@ -550,11 +564,11 @@ impl Cluster {
                                     "some node refreshes but the current node is active but not referenced in partition-map"
                                 );
                         }
-                    } else if refresh_count >= 1 && failures > 2 {
-                        remove_list.push(tnode);
+                    } else if refresh_count >= 1 && failures > 0 {
                         debug!(
-                            "multi-node: refresh failed repeatedly, removing node despite peer reference_count"
+                            "multi-node: refresh failed repeatedly, removing node despite peer reference_count {}", tnode
                         );
+                        remove_list.push(tnode);
                     }
                 }
             }
@@ -572,11 +586,17 @@ impl Cluster {
 
     fn remove_nodes_and_aliases(&self, mut nodes_to_remove: Vec<Arc<Node>>) {
         for node in &mut nodes_to_remove {
+            debug!("Removing alias for node {}", node);
+
             for alias in node.aliases() {
                 self.remove_alias(&alias);
             }
+            debug!("Attempt to close node {}", node);
             if let Some(node) = Arc::get_mut(node) {
+                debug!("Node closed {}", node);
                 node.close();
+            } else {
+                debug!("Fail to closed node {}", node);
             }
         }
         self.remove_nodes(&nodes_to_remove);
@@ -674,22 +694,22 @@ impl Cluster {
         namespace.get_node(self, partition, replica, last_tried)
     }
 
-    pub fn get_master_node(&self, namespace: &str, partition_id: usize) -> Result<Arc<Node>> {
-        let partitions = self.partition_map.load();
+    // pub fn get_master_node(&self, namespace: &str, partition_id: usize) -> Result<Arc<Node>> {
+    //     let partitions = self.partition_map.load();
 
-        let ns_partition = partitions.get(namespace).ok_or_else(|| {
-            Error::InvalidNode(format!(
-                "Cannot get appropriate node for namespace: {namespace}"
-            ))
-        })?;
+    //     let ns_partition = partitions.get(namespace).ok_or_else(|| {
+    //         Error::InvalidNode(format!(
+    //             "Cannot get appropriate node for namespace: {namespace}"
+    //         ))
+    //     })?;
 
-        let node = ns_partition.all_replicas(partition_id).next().flatten();
-        node.ok_or_else(|| {
-            Error::InvalidNode(format!(
-                "Cannot get appropriate node for namespace: {namespace} partition: {partition_id}"
-            ))
-        })
-    }
+    //     let node = ns_partition.all_replicas(partition_id).next().flatten();
+    //     node.ok_or_else(|| {
+    //         Error::InvalidNode(format!(
+    //             "Cannot get appropriate node for namespace: {namespace} partition: {partition_id}"
+    //         ))
+    //     })
+    // }
 
     pub fn get_random_node(&self) -> Result<Arc<Node>> {
         let node_array = self.nodes();

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -585,26 +585,23 @@ impl Cluster {
     }
 
     fn remove_nodes_and_aliases(&self, mut nodes_to_remove: Vec<Arc<Node>>) {
-        for node in &nodes_to_remove {
+        self.scrub_nodes_from_partition_map(&nodes_to_remove);
+        for node in &mut nodes_to_remove {
             debug!("Removing alias for node {}", node);
-
             for alias in node.aliases() {
                 self.remove_alias(&alias);
             }
-        }
-        self.remove_nodes(&nodes_to_remove);
-        for node in &mut nodes_to_remove {
-            debug!("Attempt to close node {}", node);
             if let Some(node) = Arc::get_mut(node) {
                 debug!("Node closed {}", node);
                 node.close();
             } else {
                 debug!(
-                    "Failed to close node {} — other strong or weak refs to this allocation remain",
+                    "Failed to close node {}",
                     node
                 );
             }
         }
+        self.remove_nodes(&nodes_to_remove);
     }
 
     fn add_alias(&self, host: Host, node: Arc<Node>) {
@@ -634,6 +631,25 @@ impl Cluster {
         (*partitions)
             .values()
             .any(|map| map.nodes.iter().any(|(_, node)| *node == filter))
+    }
+
+    /// Clears replica slots that still point at removed nodes so extra `Arc` handles from the
+    /// partition table are dropped before `Arc::get_mut` runs `Node::close`.
+    fn scrub_nodes_from_partition_map(&self, removed: &[Arc<Node>]) {
+        if removed.is_empty() {
+            return;
+        }
+        let mut local_pmap = (*self.partition_map.load().clone()).clone();
+        for partition_namespace in local_pmap.values_mut() {
+            for (_, slot) in partition_namespace.nodes.iter_mut() {
+                if let Some(arc) = slot {
+                    if removed.iter().any(|r| r.name() == arc.name()) {
+                        *slot = None;
+                    }
+                }
+            }
+        }
+        self.partition_map.store(Arc::new(local_pmap));
     }
 
     fn add_nodes(&self, friend_list: &[Arc<Node>]) {

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -586,11 +586,15 @@ impl Cluster {
 
     fn remove_nodes_and_aliases(&self, mut nodes_to_remove: Vec<Arc<Node>>) {
         self.scrub_nodes_from_partition_map(&nodes_to_remove);
-        for node in &mut nodes_to_remove {
+        for node in &nodes_to_remove {
             debug!("Removing alias for node {}", node);
             for alias in node.aliases() {
                 self.remove_alias(&alias);
             }
+        }
+        self.remove_nodes(&nodes_to_remove);
+        for node in &mut nodes_to_remove {
+            debug!("Attempt to close node {}", node);
             if let Some(node) = Arc::get_mut(node) {
                 debug!("Node closed {}", node);
                 node.close();
@@ -601,7 +605,6 @@ impl Cluster {
                 );
             }
         }
-        self.remove_nodes(&nodes_to_remove);
     }
 
     fn add_alias(&self, host: Host, node: Arc<Node>) {

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -23,8 +23,8 @@ pub mod version_parser;
 use aerospike_rt::time::{Duration, Instant};
 use std::cell::OnceCell;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
-use std::sync::{Arc, Weak};
 use std::vec::Vec;
 
 pub use self::node::Node;
@@ -69,13 +69,13 @@ impl PartitionForNamespace {
         cluster: &Cluster,
         partition: &Partition<'_>,
         replica: crate::policy::Replica,
-        last_tried: Weak<Node>,
+        last_tried: Option<Arc<Node>>,
     ) -> Result<Arc<Node>> {
         fn get_next_in_sequence<I: Iterator<Item = Arc<Node>>, F: Fn() -> I>(
             get_sequence: F,
-            last_tried: Weak<Node>,
+            last_tried: Option<Arc<Node>>,
         ) -> Option<Arc<Node>> {
-            if let Some(last_tried) = last_tried.upgrade() {
+            if let Some(last_tried) = last_tried {
                 // If this isn't the first attempt, try the replica immediately after in sequence (that is actually valid)
                 let mut replicas = get_sequence();
                 while let Some(replica) = replicas.next() {
@@ -585,21 +585,19 @@ impl Cluster {
     }
 
     fn remove_nodes_and_aliases(&self, mut nodes_to_remove: Vec<Arc<Node>>) {
-        self.scrub_nodes_from_partition_map(&nodes_to_remove);
         for node in &nodes_to_remove {
             debug!("Removing alias for node {}", node);
             for alias in node.aliases() {
                 self.remove_alias(&alias);
-            }
+            }    
         }
         self.remove_nodes(&nodes_to_remove);
+        
         for node in &mut nodes_to_remove {
             debug!("Attempt to close node {}", node);
             if let Some(node) = Arc::get_mut(node) {
-                debug!("Node closed {}", node);
+                debug!("Closing node {}", node);
                 node.close();
-            } else {
-                debug!("Failed to close node {}", node);
             }
         }
     }
@@ -633,25 +631,6 @@ impl Cluster {
             .any(|map| map.nodes.iter().any(|(_, node)| *node == filter))
     }
 
-    /// Clears replica slots that still point at removed nodes so extra `Arc` handles from the
-    /// partition table are dropped before `Arc::get_mut` runs `Node::close`.
-    fn scrub_nodes_from_partition_map(&self, removed: &[Arc<Node>]) {
-        if removed.is_empty() {
-            return;
-        }
-        let mut local_pmap = (*self.partition_map.load().clone()).clone();
-        for partition_namespace in local_pmap.values_mut() {
-            for (_, slot) in partition_namespace.nodes.iter_mut() {
-                if let Some(arc) = slot {
-                    if removed.iter().any(|r| r.name() == arc.name()) {
-                        *slot = None;
-                    }
-                }
-            }
-        }
-        self.partition_map.store(Arc::new(local_pmap));
-    }
-
     fn add_nodes(&self, friend_list: &[Arc<Node>]) {
         if friend_list.is_empty() {
             return;
@@ -675,7 +654,6 @@ impl Cluster {
                 node_array.push(node.clone());
             }
         }
-
         self.set_nodes(node_array);
     }
 
@@ -701,7 +679,7 @@ impl Cluster {
         &self,
         partition: &Partition<'_>,
         replica: crate::policy::Replica,
-        last_tried: Weak<Node>,
+        last_tried: Option<Arc<Node>>,
     ) -> Result<Arc<Node>> {
         let partitions = self.partition_map.load();
 

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -287,17 +287,17 @@ impl Node {
 
     // Get a connection to the node from the connection pool
     pub async fn get_connection(&self, hint: u8) -> Result<PooledConnection> {
-        if self.is_active() {
-            if let Ok(conn) = self.connection_pool.get(hint) {
-                return Ok(conn);
-            }
-
-            self.connection_pool.make_conn(0).await
-        } else {
-            Err(Error::InvalidNode(format!(
+        if !self.is_active() {
+            return Err(Error::InvalidNode(format!(
                 "Cannot get a connection for node. The node `{self}` is inactive"
-            )))
+            )));
         }
+
+        if let Ok(conn) = self.connection_pool.get(hint) {
+            return Ok(conn);
+        }
+
+        self.connection_pool.make_conn(0).await
     }
 
     // Put a connection to the node back in the connection pool
@@ -551,5 +551,4 @@ mod node_tests {
             "Node::drop should clear pooled connections"
         );
     }
-
 }

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -59,6 +59,13 @@ pub struct Node {
     version: Version,
 }
 
+impl Drop for Node {
+    fn drop(&mut self) {
+        debug!("Node closed {}", self);
+        self.close();
+    }
+}
+
 impl Node {
     #![allow(missing_docs)]
     pub fn new(client_policy: ClientPolicy, nv: Arc<NodeValidator>) -> Self {

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -306,6 +306,10 @@ impl Node {
             if let Some(conn) = pconn.conn.take() {
                 pconn.queue.put_back(conn);
             }
+        } else {
+            // Inactive: do not return a Ready connection to the pool — `PooledConnection`'s
+            // `Drop` would otherwise `put_back` it.
+            pconn.invalidate();
         }
     }
 
@@ -438,4 +442,114 @@ impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
         format!("{}: {}", self.name, self.host).fmt(f)
     }
+}
+
+#[cfg(test)]
+mod node_tests {
+    use std::sync::Arc;
+
+    use crate::cluster::node_validator::NodeValidator;
+    use crate::errors::Error;
+    use crate::net::Host;
+    use crate::policy::ClientPolicy;
+    use crate::Version;
+
+    use super::Node;
+
+    fn test_node() -> Node {
+        let policy = ClientPolicy::default();
+        let nv = Arc::new(NodeValidator {
+            name: "test-node".to_string(),
+            aliases: vec![Host::new("127.0.0.1", 3000)],
+            services: vec![],
+            address: "127.0.0.1:3000".to_string(),
+            client_policy: policy.clone(),
+            use_new_info: true,
+            version: Version::default(),
+        });
+        Node::new(policy, nv)
+    }
+
+    /// One idle connection in the pool, using the test [`crate::net::Connection`] (no real socket).
+    async fn create_node_with_connection() -> Node {
+        let node = test_node();
+        let pconn = node
+            .connection_pool
+            .make_conn(0)
+            .await
+            .expect("make_conn uses test Connection");
+        node.put_connection(pconn);
+        assert_eq!(node.connection_pool.num_conns(), 1);
+        node
+    }
+
+    #[aerospike_macro::test]
+    async fn get_connection_returns_invalid_node_when_inactive() {
+        let node = create_node_with_connection().await;
+        let before = node.connection_pool.num_conns();
+        node.close();
+        assert!(!node.is_active());
+
+        let err = node.get_connection(0).await.unwrap_err();
+        match err {
+            Error::InvalidNode(msg) => assert!(msg.contains("inactive"), "unexpected: {}", msg),
+            other => panic!("expected InvalidNode, got {:?}", other),
+        }
+        assert_eq!(
+            node.connection_pool.num_conns(),
+            before,
+            "inactive node must not open or hand out pool connections"
+        );
+    }
+
+    #[aerospike_macro::test]
+    async fn put_connection_does_not_return_conn_to_pool_when_inactive() {
+        let node = create_node_with_connection().await;
+        let pconn = node
+            .get_connection(0)
+            .await
+            .expect("active node with one mock conn in pool");
+        assert_eq!(node.connection_pool.num_conns(), 0);
+
+        node.close();
+        assert!(!node.is_active());
+
+        node.put_connection(pconn);
+        assert_eq!(
+            node.connection_pool.num_conns(),
+            0,
+            "inactive node must not return connections to the pool"
+        );
+    }
+
+    #[aerospike_macro::test]
+    async fn node_drop_inactivates_and_closes_pool_when_last_arc_dropped() {
+        let arc = Arc::new(create_node_with_connection().await);
+        let queue_witness = {
+            let pconn = arc
+                .get_connection(0)
+                .await
+                .expect("pool should have one connection");
+            let q = pconn.queue.clone();
+            arc.put_connection(pconn);
+            q
+        };
+        let weak = Arc::downgrade(&arc);
+        assert_eq!(Arc::strong_count(&arc), 1);
+
+        assert!(arc.is_active());
+        assert_eq!(arc.connection_pool.num_conns(), 1);
+
+        drop(arc);
+        assert!(
+            weak.upgrade().is_none(),
+            "expected Node to be dropped after the last Arc was released"
+        );
+        assert_eq!(
+            queue_witness.num_conns(),
+            0,
+            "Node::drop should clear pooled connections"
+        );
+    }
+
 }

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -61,8 +61,9 @@ pub struct Node {
 
 impl Drop for Node {
     fn drop(&mut self) {
-        debug!("Node closed {}", self);
+        debug!("Node closed {self}");
         self.close();
+        self.connection_pool.close();
     }
 }
 
@@ -286,17 +287,25 @@ impl Node {
 
     // Get a connection to the node from the connection pool
     pub async fn get_connection(&self, hint: u8) -> Result<PooledConnection> {
-        if let Ok(conn) = self.connection_pool.get(hint) {
-            return Ok(conn);
-        }
+        if self.is_active() {
+            if let Ok(conn) = self.connection_pool.get(hint) {
+                return Ok(conn);
+            }
 
-        self.connection_pool.make_conn(0).await
+            self.connection_pool.make_conn(0).await
+        } else {
+            Err(Error::InvalidNode(format!(
+                "Cannot get a connection for node. The node `{self}` is inactive"
+            )))
+        }
     }
 
     // Put a connection to the node back in the connection pool
     pub fn put_connection(&self, mut pconn: PooledConnection) {
-        if let Some(conn) = pconn.conn.take() {
-            pconn.queue.put_back(conn);
+        if self.is_active() {
+            if let Some(conn) = pconn.conn.take() {
+                pconn.queue.put_back(conn);
+            }
         }
     }
 
@@ -337,9 +346,8 @@ impl Node {
     }
 
     // Set the node inactive and close all connections in the pool
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         self.inactivate();
-        self.connection_pool.close();
     }
 
     // Send info commands to this node
@@ -391,18 +399,24 @@ impl Node {
     /// Fills the connection pool to the minimum required
     /// by the [`ClientPolicy.min_conns_per_node`]
     pub(crate) async fn fill_min_conns(&self) -> Result<usize> {
-        let mut count = 0;
+        if self.is_active() {
+            let mut count = 0;
 
-        let client_policy = self.client_policy();
-        if client_policy.min_conns_per_node > 0 {
-            let to_fill = client_policy.min_conns_per_node - self.connection_pool.num_conns();
-            for _ in 0..to_fill {
-                self.connection_pool.make_conn(count).await?;
-                count += 1;
+            let client_policy = self.client_policy();
+            if client_policy.min_conns_per_node > 0 {
+                let to_fill = client_policy.min_conns_per_node - self.connection_pool.num_conns();
+                for _ in 0..to_fill {
+                    self.connection_pool.make_conn(count).await?;
+                    count += 1;
+                }
             }
-        }
 
-        Ok(count)
+            Ok(count)
+        } else {
+            Err(Error::InvalidNode(format!(
+                "Cannot fill the connection pool to 'policy.min_conns_per_node'. The node `{self}` is inactive"
+            )))
+        }
     }
 }
 

--- a/aerospike-core/src/commands/batch_operate_command.rs
+++ b/aerospike-core/src/commands/batch_operate_command.rs
@@ -94,7 +94,7 @@ impl BatchOperateCommand {
                     let node = cluster.get_node(
                         &partition,
                         self.policy.replica,
-                        Arc::downgrade(&self.node),
+                        Some(self.node.clone()),
                     )?;
 
                     if !Self::request_group(individual_op, &self.policy, deadline, node).await? {

--- a/aerospike-core/src/commands/delete_command.rs
+++ b/aerospike-core/src/commands/delete_command.rs
@@ -30,7 +30,7 @@ pub struct DeleteCommand<'a> {
 impl<'a> DeleteCommand<'a> {
     pub fn new(policy: &'a WritePolicy, cluster: Arc<Cluster>, key: &'a Key) -> Self {
         DeleteCommand {
-            single_command: SingleCommand::new(cluster, key, crate::policy::Replica::Master),
+            single_command: SingleCommand::new(cluster, key, crate::policy::Replica::Sequence),
             policy,
             existed: false,
         }

--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use crate::cluster::partition::Partition;
 use crate::cluster::{Cluster, Node};
@@ -28,7 +28,7 @@ pub struct SingleCommand<'a> {
     cluster: Arc<Cluster>,
     pub key: &'a Key,
     partition: Partition<'a>,
-    last_tried: Weak<Node>,
+    last_tried: Option<Arc<Node>>,
     replica: crate::policy::Replica,
 }
 
@@ -39,7 +39,7 @@ impl<'a> SingleCommand<'a> {
             cluster,
             key,
             partition,
-            last_tried: Weak::new(),
+            last_tried: None,
             replica,
         }
     }
@@ -49,11 +49,12 @@ impl<'a> SingleCommand<'a> {
     }
 
     pub fn get_node(&mut self) -> Result<Arc<Node>> {
-        let this_time =
-            self.cluster
-                .get_node(&self.partition, self.replica, self.last_tried.clone())?;
-        self.last_tried = Arc::downgrade(&this_time);
-        Ok(this_time)
+        let node = self
+            .cluster
+            .get_node(&self.partition, self.replica, self.last_tried.clone())?;
+
+        self.last_tried = Some(node.clone());
+        Ok(node)
     }
 
     pub async fn empty_socket(conn: &mut Connection) -> Result<()> {

--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -142,6 +142,8 @@ impl<'a> SingleCommand<'a> {
                 e @ Err(Error::InvalidArgument(_)) => e?,
                 Err(e) => {
                     warn!("Error selecting node from the partition table: {e}");
+                    // Brief async sleep so tend/refresh can run; avoids a tight retry loop when get_node fails fast.
+                    sleep(Duration::from_micros(50)).await;
                     continue;
                 } // Node is currently inactive. Retry.
             };
@@ -186,7 +188,6 @@ impl<'a> SingleCommand<'a> {
                 if commands::is_network_error(&err) {
                     continue;
                 }
-
                 return Err(err);
             }
 

--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -142,8 +142,6 @@ impl<'a> SingleCommand<'a> {
                 e @ Err(Error::InvalidArgument(_)) => e?,
                 Err(e) => {
                     warn!("Error selecting node from the partition table: {e}");
-                    // Brief async sleep so tend/refresh can run; avoids a tight retry loop when get_node fails fast.
-                    sleep(Duration::from_micros(50)).await;
                     continue;
                 } // Node is currently inactive. Retry.
             };

--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -104,13 +104,14 @@ impl<'a> SingleCommand<'a> {
 
         // set timeout outside the loop
         let deadline = policy.deadline();
+        let effective_attempt = policy.max_retries() + 1;
 
         // Execute command until successful, timed out or maximum iterations have been reached.
         loop {
             iterations += 1;
 
             // check for max retries
-            if policy.max_retries() > 0 && iterations > policy.max_retries() {
+            if iterations > effective_attempt {
                 // first attempt isn't a retry
                 return Err(Error::Timeout(format!("Timeout after {iterations} tries")));
             }

--- a/aerospike-core/src/commands/write_command.rs
+++ b/aerospike-core/src/commands/write_command.rs
@@ -38,7 +38,7 @@ impl<'a> WriteCommand<'a> {
         operation: OperationType,
     ) -> Self {
         WriteCommand {
-            single_command: SingleCommand::new(cluster, key, crate::policy::Replica::Master),
+            single_command: SingleCommand::new(cluster, key, crate::policy::Replica::Sequence),
             bins,
             policy,
             operation,

--- a/aerospike-core/src/operations/lists.rs
+++ b/aerospike-core/src/operations/lists.rs
@@ -557,7 +557,7 @@ pub fn remove_by_value_range<TLR: ToListReturnTypeBitmask>(
     ];
 
     if !end.is_nil() {
-        args.push(CdtArgument::Value(end))
+        args.push(CdtArgument::Value(end));
     }
 
     let cdt_op = CdtOperation {
@@ -1060,7 +1060,7 @@ pub fn get_by_value_range<TLR: ToListReturnTypeBitmask>(
     ];
 
     if !end.is_nil() {
-        args.push(CdtArgument::Value(end))
+        args.push(CdtArgument::Value(end));
     }
 
     let cdt_op = CdtOperation {

--- a/aerospike-core/src/policy/write_policy.rs
+++ b/aerospike-core/src/policy/write_policy.rs
@@ -84,8 +84,10 @@ impl WritePolicy {
 
 impl Default for WritePolicy {
     fn default() -> Self {
+        let mut base_policy = BasePolicy::default();
+        base_policy.max_retries = 0;
         WritePolicy {
-            base_policy: BasePolicy::default(),
+            base_policy,
             record_exists_action: RecordExistsAction::Update,
             generation_policy: GenerationPolicy::None,
             commit_level: CommitLevel::CommitAll,
@@ -101,5 +103,18 @@ impl Default for WritePolicy {
 impl PolicyLike for WritePolicy {
     fn base(&self) -> &BasePolicy {
         &self.base_policy
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::policy::{Policy, WritePolicy};
+
+    #[test]
+    fn default_write_policy_max_retries_is_zero() {
+        let policy = WritePolicy::default();
+        assert_eq!(policy.max_retries(), 0);
+        assert_eq!(policy.base_policy.max_retries, 0);
     }
 }

--- a/aerospike-core/src/policy/write_policy.rs
+++ b/aerospike-core/src/policy/write_policy.rs
@@ -84,8 +84,11 @@ impl WritePolicy {
 
 impl Default for WritePolicy {
     fn default() -> Self {
-        let mut base_policy = BasePolicy::default();
-        base_policy.max_retries = 0;
+        let base_policy = BasePolicy {
+            max_retries: 0,
+            ..BasePolicy::default()
+        };
+
         WritePolicy {
             base_policy,
             record_exists_action: RecordExistsAction::Update,
@@ -105,7 +108,6 @@ impl PolicyLike for WritePolicy {
         &self.base_policy
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/aerospike-core/src/query/filter.rs
+++ b/aerospike-core/src/query/filter.rs
@@ -117,8 +117,11 @@ impl EqFilterValue for Value {
 impl RangeFilterValue for Value {
     fn into_filter_value(self) -> Value {
         assert!(
-            matches!(self.particle_type(), ParticleType::INTEGER),
-            "range filter value must be integer"
+            matches!(
+                self.particle_type(),
+                ParticleType::INTEGER | ParticleType::STRING | ParticleType::BLOB
+            ),
+            "equality/contains filter value must be integer, string, or blob"
         );
         self
     }

--- a/aerospike-core/src/query/partition_tracker.rs
+++ b/aerospike-core/src/query/partition_tracker.rs
@@ -33,7 +33,6 @@ use aerospike_rt::{
 use std::cmp::max;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use std::sync::Weak;
 #[derive(Debug)]
 pub struct PartitionTracker {
     partitions_capacity: usize,
@@ -168,14 +167,7 @@ impl PartitionTracker {
             };
             if retry || part_retry {
                 let partition = Partition::new(namespace, part_id as usize);
-                let last_tried = {
-                    let ps = part.lock().await;
-                    ps.node
-                        .as_ref()
-                        .map(Arc::downgrade)
-                        .unwrap_or_else(Weak::new)
-                };
-
+                let last_tried = part.lock().await.node.as_ref().map(Arc::clone);
                 let node = cluster.get_node(&partition, self.replica, last_tried)?;
 
                 // Use node name to check for single node equality because

--- a/aerospike-core/src/query/partition_tracker.rs
+++ b/aerospike-core/src/query/partition_tracker.rs
@@ -169,11 +169,11 @@ impl PartitionTracker {
             if retry || part_retry {
                 let partition = Partition::new(namespace, part_id as usize);
                 let last_tried = {
-                   let ps = part.lock().await;
-                   ps.node
-                   .as_ref()
-                   .map(Arc::downgrade)
-                   .unwrap_or_else(Weak::new)
+                    let ps = part.lock().await;
+                    ps.node
+                        .as_ref()
+                        .map(Arc::downgrade)
+                        .unwrap_or_else(Weak::new)
                 };
 
                 let node = cluster.get_node(&partition, self.replica, last_tried)?;

--- a/aerospike-core/src/query/partition_tracker.rs
+++ b/aerospike-core/src/query/partition_tracker.rs
@@ -14,6 +14,7 @@
 // the License.
 
 use crate::cluster::node;
+use crate::cluster::partition::Partition;
 use crate::cluster::Cluster;
 use crate::errors::{Error, Result};
 use crate::policy::Replica;
@@ -32,6 +33,7 @@ use aerospike_rt::{
 use std::cmp::max;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::Weak;
 #[derive(Debug)]
 pub struct PartitionTracker {
     partitions_capacity: usize,
@@ -165,7 +167,8 @@ impl PartitionTracker {
                 (part.retry, part.id)
             };
             if retry || part_retry {
-                let node = cluster.get_master_node(namespace, part_id as usize)?;
+                let partition = Partition::new(namespace, part_id as usize);
+                let node = cluster.get_node(&partition, self.replica, Weak::new())?;
 
                 // Use node name to check for single node equality because
                 // partition map may be in transitional state between

--- a/aerospike-core/src/query/partition_tracker.rs
+++ b/aerospike-core/src/query/partition_tracker.rs
@@ -168,7 +168,15 @@ impl PartitionTracker {
             };
             if retry || part_retry {
                 let partition = Partition::new(namespace, part_id as usize);
-                let node = cluster.get_node(&partition, self.replica, Weak::new())?;
+                let last_tried = {
+                   let ps = part.lock().await;
+                   ps.node
+                   .as_ref()
+                   .map(Arc::downgrade)
+                   .unwrap_or_else(Weak::new)
+                };
+
+                let node = cluster.get_node(&partition, self.replica, last_tried)?;
 
                 // Use node name to check for single node equality because
                 // partition map may be in transitional state between

--- a/aerospike-sync/Cargo.toml
+++ b/aerospike-sync/Cargo.toml
@@ -18,7 +18,7 @@ publish = true
 
 [dependencies]
 aerospike-core = {path = "../aerospike-core", version = "2.0.0", features = ["sync"]}
-futures = {version = "0.3.16" }
+futures = { version = "0.3.32" }
 
 [features]
 rt-tokio = ["aerospike-core/rt-tokio"]

--- a/tests/proptests/cdt_lists.rs
+++ b/tests/proptests/cdt_lists.rs
@@ -35,7 +35,7 @@ proptest_async::proptest! {
         let rec = client.operate(&wpolicy, &key, ops).await.unwrap();
         assert_eq!(
             *rec.bins.get("bin").unwrap(),
-            as_list!(6, as_list!("0", v1, v2, v3, 1, 2.1f64))
+            Value::MultiResult(vec![as_val!(6), as_list!("0", v1, v2, v3, 1, 2.1f64)])
         );
     }
 }

--- a/tests/src/connection_seed.rs
+++ b/tests/src/connection_seed.rs
@@ -67,7 +67,7 @@ use crate::common;
 ///     STOP_CMD="docker kill aerolab-mydc_3" \
 ///     START_CMD="docker start aerolab-mydc_3" \
 ///     RESTART_ASD_CMD="docker exec aerolab-mydc_3 /usr/bin/asd --config-file /etc/aerospike/aerospike.conf" \
-///     cargo test --features rt-tokio -- test_seed_connection_and_partition_map_staleness --nocapture
+///     cargo test --features rt-tokio -- --ignored test_seed_connection_and_partition_map_staleness --nocapture
 ///
 /// RUN (with debug logging):
 ///   RUST_LOG=debug RUN_WRITE_BUG=1 \
@@ -76,7 +76,7 @@ use crate::common;
 ///     STOP_CMD="docker kill aerolab-mydc_3" \
 ///     START_CMD="docker start aerolab-mydc_3" \
 ///     RESTART_ASD_CMD="docker exec aerolab-mydc_3 /usr/bin/asd --config-file /etc/aerospike/aerospike.conf" \
-///     cargo test --features rt-tokio -- test_seed_connection_and_partition_map_staleness --nocapture 2>&1 | tee /tmp/write_bug.log
+///     cargo test --features rt-tokio -- --ignored test_seed_connection_and_partition_map_staleness --nocapture 2>&1 | tee /tmp/write_bug.log
 #[aerospike_macro::test]
 #[ignore = "manual repro: needs aerolab cluster; run with cargo test -- --ignored and RUN_WRITE_BUG=1"]
 async fn test_seed_connection_and_partition_map_staleness() {
@@ -195,8 +195,6 @@ async fn test_seed_connection_and_partition_map_staleness() {
         get_ok, get_fail, get_elapsed
     );
 
-    let (put_ok, put_fail) = (0, 0);
-    let put_elapsed = start.elapsed().as_secs_f64();
     let start = Instant::now();
     let (put_ok, put_fail) = probe_put(&client, namespace, set_name, bin_name, num_records).await;
     let put_elapsed = start.elapsed().as_secs_f64();
@@ -276,7 +274,8 @@ async fn test_seed_connection_and_partition_map_staleness() {
 async fn probe_get(client: &Client, ns: &str, set: &str, _bin: &str, n: i64) -> (i64, i64) {
     let mut rp = ReadPolicy::default();
     rp.base_policy.total_timeout = 3000;
-    rp.base_policy.max_retries = 0;
+    println!("   rp.base_policy.max_retries={}: ", rp.base_policy.max_retries);
+    // rp.base_policy.max_retries = 0;
 
     let (mut ok, mut fail) = (0i64, 0i64);
     for i in 0..n {
@@ -297,8 +296,10 @@ async fn probe_get(client: &Client, ns: &str, set: &str, _bin: &str, n: i64) -> 
 async fn probe_put(client: &Client, ns: &str, set: &str, bin: &str, n: i64) -> (i64, i64) {
     let mut wp = WritePolicy::default();
     wp.base_policy.total_timeout = 3000;
-    wp.base_policy.max_retries = 0;
-
+    wp.base_policy.sleep_between_retries = 200;
+    wp.base_policy.max_retries = 2;
+    // wp.base_policy.max_retries = 0;
+   
     let (mut ok, mut fail) = (0i64, 0i64);
     for i in 0..n {
         let key = as_key!(ns, set, i);
@@ -325,7 +326,10 @@ fn partition_id_for_key(key: &Key) -> usize {
 async fn probe_remove(client: &Client, ns: &str, set: &str, _bin: &str, n: i64) -> (i64, i64) {
     let mut wp = WritePolicy::default();
     wp.base_policy.total_timeout = 3000;
-    wp.base_policy.max_retries = 0;
+    wp.base_policy.max_retries = 2;
+    wp.base_policy.sleep_between_retries = 200;
+
+    // wp.base_policy.max_retries = 0;
 
     let (mut ok, mut fail) = (0i64, 0i64);
     for i in 0..n {

--- a/tests/src/connection_seed.rs
+++ b/tests/src/connection_seed.rs
@@ -1,0 +1,352 @@
+// Copyright 2015-2018 Aerospike, Inc.
+//
+// Portions may be licensed to Aerospike, Inc. under one or more contributor
+// license agreements.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+use std::time::Instant;
+
+use aerospike::{as_bin, as_key, AdminPolicy, Bins, Client, Key, ReadPolicy, WritePolicy};
+use aerospike_rt::time::Duration;
+
+use crate::common;
+
+/// Reproduce: single-key WRITE operations (put/remove) fail with
+/// "Command timed out after ~N tries" after a node is killed and
+/// the client evicts it via tend, because the partition map still
+/// references the dead node as the master for some partitions.
+///
+/// TOPOLOGY: Start with a 4-node cluster (RF=2), kill one → 3 surviving.
+/// The 4-node starting state ensures some partitions have their
+/// ONLY master on the killed node in the stale partition map.
+///
+/// ─── CLUSTER LIFECYCLE COMMANDS ───────────────────────────────────────
+///
+/// TEARDOWN (stop & remove all 4 nodes):
+///   aerolab cluster destroy -n mydc -f
+///
+///   If aerolab is unavailable, manual Docker commands:
+///     docker kill aerolab-mydc_1 aerolab-mydc_2 aerolab-mydc_3 aerolab-mydc_4
+///     docker rm   aerolab-mydc_1 aerolab-mydc_2 aerolab-mydc_3 aerolab-mydc_4
+///
+/// SETUP (create fresh 4-node cluster, ubuntu 22.04):
+///   aerolab cluster create -n mydc -c 4 -i 22.04
+///
+/// VERIFY (all 4 nodes up, same cluster key):
+///   docker ps --format '{{.Names}} {{.Status}}' | grep mydc
+///   for i in 1 2 3 4; do
+///     echo "node $i: $(docker exec aerolab-mydc_$i asinfo -v 'cluster-stable')";
+///   done
+///
+/// MANUAL STOP ALL 4 (without destroying containers):
+///   docker kill aerolab-mydc_1 aerolab-mydc_2 aerolab-mydc_3 aerolab-mydc_4
+///
+/// MANUAL START ALL 4 (restart containers + asd):
+///   for i in 1 2 3 4; do docker start aerolab-mydc_$i; done
+///   sleep 2
+///   for i in 1 2 3 4; do
+///     docker exec aerolab-mydc_$i /usr/bin/asd --config-file /etc/aerospike/aerospike.conf;
+///   done
+///   sleep 5   # wait for cluster to form
+///
+/// ─── RUN THE TEST ─────────────────────────────────────────────────────
+///
+/// RUN:
+///   RUN_WRITE_BUG=1 \
+///     AEROSPIKE_HOSTS="127.0.0.1:3100" \
+///     AEROSPIKE_USE_SERVICES_ALTERNATE=true \
+///     STOP_CMD="docker kill aerolab-mydc_3" \
+///     START_CMD="docker start aerolab-mydc_3" \
+///     RESTART_ASD_CMD="docker exec aerolab-mydc_3 /usr/bin/asd --config-file /etc/aerospike/aerospike.conf" \
+///     cargo test --features rt-tokio -- test_seed_connection_and_partition_map_staleness --nocapture
+///
+/// RUN (with debug logging):
+///   RUST_LOG=debug RUN_WRITE_BUG=1 \
+///     AEROSPIKE_HOSTS="127.0.0.1:3100" \
+///     AEROSPIKE_USE_SERVICES_ALTERNATE=true \
+///     STOP_CMD="docker kill aerolab-mydc_3" \
+///     START_CMD="docker start aerolab-mydc_3" \
+///     RESTART_ASD_CMD="docker exec aerolab-mydc_3 /usr/bin/asd --config-file /etc/aerospike/aerospike.conf" \
+///     cargo test --features rt-tokio -- test_seed_connection_and_partition_map_staleness --nocapture 2>&1 | tee /tmp/write_bug.log
+#[aerospike_macro::test]
+#[ignore = "manual repro: needs aerolab cluster; run with cargo test -- --ignored and RUN_WRITE_BUG=1"]
+async fn test_seed_connection_and_partition_map_staleness() {
+    use std::process::Command as ShellCmd;
+
+    let run_flag = std::env::var("RUN_WRITE_BUG").unwrap_or_default();
+    if !["1", "true", "yes"].contains(&run_flag.as_str()) {
+        println!("Skipping: set RUN_WRITE_BUG=1 to run");
+        return;
+    }
+
+    let stop_cmd =
+        std::env::var("STOP_CMD").expect("Set STOP_CMD (e.g. 'docker kill aerolab-mydc_3')");
+    let start_cmd =
+        std::env::var("START_CMD").expect("Set START_CMD (e.g. 'docker start aerolab-mydc_3')");
+    let restart_asd_cmd = std::env::var("RESTART_ASD_CMD").unwrap_or_default();
+
+    let namespace = common::namespace();
+    let set_name = "write_bug_repro";
+    let bin_name = "v";
+    let num_records: i64 = 10000;
+
+    let client = common::client().await;
+    let wpolicy = WritePolicy::default();
+
+    let run_cmd = |cmd_str: &str, label: &str| -> bool {
+        println!("  [{}] Running: {}", label, cmd_str);
+        let parts: Vec<&str> = cmd_str.split_whitespace().collect();
+        let output = ShellCmd::new(parts[0])
+            .args(&parts[1..])
+            .output()
+            .unwrap_or_else(|e| panic!("[{}] Failed to execute: {}", label, e));
+        if !output.status.success() {
+            println!(
+                "  [{}] Command failed (rc={}): stderr={:?}",
+                label,
+                output.status,
+                String::from_utf8_lossy(&output.stderr),
+            );
+            return false;
+        }
+        println!("  [{}] OK", label);
+        true
+    };
+
+    // ── Phase 1: Verify starting state (need 4+ nodes) ──────────────────
+    let initial_nodes = client.nodes().len();
+    println!("\n[PHASE 1] Client sees {} nodes", initial_nodes);
+    if initial_nodes < 4 {
+        println!(
+            "  Need 4+ nodes to reproduce. Got {}.\n\
+             Create a 4-node cluster first:\n\
+               aerolab cluster create -n mydc -c 4 -i 22.04\n\
+             Skipping test.",
+            initial_nodes
+        );
+        return;
+    }
+
+    // ── Phase 2: Load data + verify baseline ─────────────────────────────
+    println!(
+        "\n[PHASE 2] Loading {} records into {}.{}...",
+        num_records, namespace, set_name
+    );
+    for i in 0..num_records {
+        let key = as_key!(namespace, set_name, i);
+        let bins = vec![as_bin!(bin_name, i)];
+        client.put(&wpolicy, &key, &bins).await.unwrap();
+    }
+    println!("  Done loading {} records", num_records);
+
+    let (_, baseline_fail) = probe_get(&client, namespace, set_name, bin_name, num_records).await;
+    assert_eq!(baseline_fail, 0, "Baseline get should have 0 failures");
+    println!("  Baseline get: all {} passed", num_records);
+
+    // ── Phase 3: Kill one node ───────────────────────────────────────────
+    println!(
+        "\n[PHASE 3] Killing one node (cluster {}→{})...",
+        initial_nodes,
+        initial_nodes - 1
+    );
+    assert!(run_cmd(&stop_cmd, "STOP-NODE"), "Stop command failed");
+
+    println!("  Waiting for tend to evict dead node...");
+    let evict_start = Instant::now();
+    loop {
+        let n = client.nodes().len();
+        if n < initial_nodes {
+            println!(
+                "  Node evicted after {:.1}s (now {} nodes)",
+                evict_start.elapsed().as_secs_f64(),
+                n
+            );
+            break;
+        }
+        if evict_start.elapsed() > Duration::from_secs(30) {
+            println!(
+                "  WARNING: Dead node not evicted after 30s (still {} nodes). Proceeding anyway.",
+                n
+            );
+            break;
+        }
+        aerospike_rt::sleep(Duration::from_millis(500)).await;
+    }
+
+    // ── Phase 4: Probe immediately — this is where the bug shows ─────────
+    println!("\n[PHASE 4] Probing single-key ops immediately after tend eviction");
+    println!("  (partition map likely stale — dead node still listed as master)");
+    println!("  Nodes visible: {}", client.nodes().len());
+
+    let start = Instant::now();
+    let (get_ok, get_fail) = probe_get(&client, namespace, set_name, bin_name, num_records).await;
+    let get_elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "  get:    ok={:<5} fail={:<5} ({:.1}s)",
+        get_ok, get_fail, get_elapsed
+    );
+
+    let (put_ok, put_fail) = (0, 0);
+    let put_elapsed = start.elapsed().as_secs_f64();
+    let start = Instant::now();
+    let (put_ok, put_fail) = probe_put(&client, namespace, set_name, bin_name, num_records).await;
+    let put_elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "  put:    ok={:<5} fail={:<5} ({:.1}s)",
+        put_ok, put_fail, put_elapsed
+    );
+
+    let start = Instant::now();
+    let (rm_ok, rm_fail) = probe_remove(&client, namespace, set_name, bin_name, num_records).await;
+    let rm_elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "  remove: ok={:<5} fail={:<5} ({:.1}s)",
+        rm_ok, rm_fail, rm_elapsed
+    );
+
+    // ── Cleanup: restart killed node ─────────────────────────────────────
+    // aerolab containers use a keep-alive loop as CMD, so `docker start`
+    // only restarts the container — asd must be re-launched separately.
+    println!("\n[CLEANUP]");
+    let _ = std::panic::catch_unwind(|| {
+        run_cmd(&start_cmd, "START-NODE");
+    });
+    if !restart_asd_cmd.is_empty() {
+        let _ = std::panic::catch_unwind(|| {
+            run_cmd(&restart_asd_cmd, "RESTART-ASD");
+        });
+    }
+    // Give the restarted node time to rejoin the cluster
+    aerospike_rt::sleep(Duration::from_secs(5)).await;
+    let ap = AdminPolicy::default();
+    let _ = client.truncate(&ap, namespace, set_name, 0).await;
+    let _ = client.close().await;
+
+    // ── Verdict ──────────────────────────────────────────────────────────
+    println!("\n{}", "=".repeat(60));
+    println!(
+        "RESULTS (topology: {} nodes → kill 1 → {})",
+        initial_nodes,
+        initial_nodes - 1
+    );
+    println!("{}", "=".repeat(60));
+    println!(
+        "  get:    {}/{} failures in {:.1}s",
+        get_fail, num_records, get_elapsed
+    );
+    println!(
+        "  put:    {}/{} failures in {:.1}s",
+        put_fail, num_records, put_elapsed
+    );
+    println!(
+        "  remove: {}/{} failures in {:.1}s",
+        rm_fail, num_records, rm_elapsed
+    );
+
+    let total_fail = get_fail + put_fail + rm_fail;
+    if total_fail > 0 {
+        panic!(
+            "\nSTALE PARTITION MAP WRITE BUG CONFIRMED\n\
+             {}/{} total single-key operations failed after node eviction.\n\
+             get={} put={} remove={}\n\n\
+             Root cause: partition map still references dead node as master.\n\
+             is_active() filter rejects it, but no fallback for writes.\n\
+             Client spin-retries until total_timeout expires.",
+            total_fail,
+            num_records * 3,
+            get_fail,
+            put_fail,
+            rm_fail,
+        );
+    } else {
+        println!("\n  No stale partition map write bug detected this run.");
+        println!("  (partition map may have refreshed before probes ran)");
+    }
+}
+
+async fn probe_get(client: &Client, ns: &str, set: &str, _bin: &str, n: i64) -> (i64, i64) {
+    let mut rp = ReadPolicy::default();
+    rp.base_policy.total_timeout = 3000;
+    rp.base_policy.max_retries = 0;
+
+    let (mut ok, mut fail) = (0i64, 0i64);
+    for i in 0..n {
+        let key = as_key!(ns, set, i);
+        match client.get(&rp, &key, Bins::All).await {
+            Ok(_) => ok += 1,
+            Err(e) => {
+                if fail < 5 {
+                    println!("    get key={}: {:?}", i, e);
+                }
+                fail += 1;
+            }
+        }
+    }
+    (ok, fail)
+}
+
+async fn probe_put(client: &Client, ns: &str, set: &str, bin: &str, n: i64) -> (i64, i64) {
+    let mut wp = WritePolicy::default();
+    wp.base_policy.total_timeout = 3000;
+    wp.base_policy.max_retries = 0;
+
+    let (mut ok, mut fail) = (0i64, 0i64);
+    for i in 0..n {
+        let key = as_key!(ns, set, i);
+        let bins = vec![as_bin!(bin, i + 1)];
+        match client.put(&wp, &key, &bins).await {
+            Ok(_) => ok += 1,
+            Err(e) => {
+                if fail < 5 {
+                    println!("    put key={}: {:?}", i, e);
+                }
+                fail += 1;
+            }
+        }
+    }
+    (ok, fail)
+}
+
+/// Matches `Partition::new_by_key` in aerospike-core (digest → partition id, 0..4096).
+fn partition_id_for_key(key: &Key) -> usize {
+    const PARTITIONS: usize = 4096;
+    (u16::from_le_bytes([key.digest[0], key.digest[1]]) as usize) & (PARTITIONS - 1)
+}
+
+async fn probe_remove(client: &Client, ns: &str, set: &str, _bin: &str, n: i64) -> (i64, i64) {
+    let mut wp = WritePolicy::default();
+    wp.base_policy.total_timeout = 3000;
+    wp.base_policy.max_retries = 0;
+
+    let (mut ok, mut fail) = (0i64, 0i64);
+    for i in 0..n {
+        let key = as_key!(ns, set, i);
+        if i == 0i64 || i == 2i64 || i == 6i64 {
+            let pid = partition_id_for_key(&key);
+            println!(
+                "  [probe_remove] sample key i={} partition_id={} ns={} set={}",
+                i, pid, ns, set
+            );
+        }
+
+        match client.delete(&wp, &key).await {
+            Ok(_) => ok += 1,
+            Err(e) => {
+                if fail < 5 {
+                    println!("    remove key={}: {:?}", i, e);
+                }
+                fail += 1;
+            }
+        }
+    }
+    (ok, fail)
+}

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -37,6 +37,7 @@ mod query;
 mod scan;
 #[cfg(feature = "serialization")]
 mod serialization;
+mod connection_seed;
 mod task;
 mod truncate;
 mod udf;


### PR DESCRIPTION
**Node Removal Process:** 
Before fix: 
   -    Remove alias 
   -    close node
   -   update  active node list

After fix:-
---------
- Make node inactive during discovery phase for node eviction
- Closing connection pool, when drop trait is invoked and that happen when all strong refs are gone

- set write policy - 0 by default
- honouring no-retries condition