### PR TITLE
Rust Client v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+## [2.1.0]
+
+* **Bug Fixes**
+  * [CLIENT-4685] Reject `operate` calls with empty ops list.
+  * [CLIENT-4686] Fix unexpected behavior for partition-based query with `QueryDuration::Short`.
+  * [CLIENT-4405] Execute query failing during node churn (#195)
+    * Check node active status before selecting node for partition.
+    * State to remember last tried node for a partition retry.
+    * added drop trait for node, to close node eventually and removed all weak ref to Arc node for last tried node
+    * Check for node active status before returning a connection. Drain the conn pool on Node drop.
+    * Removed deprecated `try_next`.
+    * Change default policy for `max-retries` to `0` for writes, honoring `max-retries=0` as no retries.
+    * Change policy to sequence for write/delete commands.
 
 ## [2.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [2.1.0]
 
 * **Bug Fixes**
+  * [CLIENT-4711] `close()` does not stop the `tend_thread`.
   * [CLIENT-4685] Reject `operate` calls with empty ops list.
   * [CLIENT-4686] Fix unexpected behavior for partition-based query with `QueryDuration::Short`.
   * [CLIENT-4405] Execute query failing during node churn (#195)
@@ -13,6 +14,11 @@
     * Removed deprecated `try_next`.
     * Change default policy for `max-retries` to `0` for writes, honoring `max-retries=0` as no retries.
     * Change policy to sequence for write/delete commands.
+
+* **Improvements**
+  * Update all dependencies to the latest, and adapt the code to the deprecation and removals.
+  * Adds a cleanup test that is ignored by default.
+    Can be manually invoked to remove indexes and then truncate of the tested namespace
 
 ## [2.0.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "2.0.0"
+version = "2.1.0"
 edition = "2018"
 rust-version = "1.87"
 authors = ["Khosrow Afroozeh <khosrow@aerospike.com>", "Jan Hecking <jhecking@aerospike.com>"]
@@ -38,9 +38,9 @@ travis-ci = { repository = "aerospike/aerospike-client-rust" }
 appveyor = { repository = "aerospike/aerospike-client-rust" }
 
 [dependencies]
-aerospike-core = {path = "aerospike-core", optional = true, version = "2.0.0"}
-aerospike-sync = {path = "aerospike-sync", optional = true, version = "2.0.0"}
-aerospike-macro = {path = "aerospike-macro", optional = true, version = "2.0.0"}
+aerospike-core = {path = "aerospike-core", optional = true, version = "2.1.0"}
+aerospike-sync = {path = "aerospike-sync", optional = true, version = "2.1.0"}
+aerospike-macro = {path = "aerospike-macro", optional = true, version = "2.1.0"}
 
 [features]
 default = ["async", "serialization", "rt-tokio", "tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ lazy_static = "1.4"
 ripemd = "0.1"
 aerospike-macro = {path = "./aerospike-macro"}
 aerospike-rt = {path = "./aerospike-rt"}
-futures = {version = "0.3.16" }
+futures = { version = "0.3.32" }
 tokio = { version = "1.48.0", features = ["full"] }
 proptest = "1.6.0"
 tokio-rustls = {version = "0.26.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,20 +60,20 @@ members = ["tools/benchmark", "aerospike-core", "aerospike-rt", "aerospike-sync"
 
 [dev-dependencies]
 log = "0.4.29"
-env_logger = "0.11.8"
+env_logger = "0.11.10"
 hex = "0.4"
 bencher = "0.1"
 serde_json = "1.0"
-rand = "0.7"
-lazy_static = "1.4"
-ripemd = "0.1"
+rand = "0.10"
+lazy_static = "1.5"
+ripemd = "0.2"
 aerospike-macro = {path = "./aerospike-macro"}
 aerospike-rt = {path = "./aerospike-rt"}
 futures = { version = "0.3.32" }
-tokio = { version = "1.48.0", features = ["full"] }
-proptest = "1.6.0"
-tokio-rustls = {version = "0.26.0"}
-rustls = {version = "0.23.31"}
+tokio = { version = "1.52.1", features = ["full"] }
+proptest = "1.11.0"
+tokio-rustls = {version = "0.26.4"}
+rustls = {version = "0.23.40"}
 webpki-roots = "1"
 #console-subscriber = "0.1.5"
 

--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -17,21 +17,21 @@ rust-version.workspace = true
 
 [dependencies]
 log = "0.4"
-byteorder = "1.3"
-ripemd = "0.1"
-base64 = "0.13"
-rand = "0.8"
-lazy_static = "1.4"
-thiserror = "1.0.40"
+byteorder = "1.5"
+ripemd = "0.2"
+base64 = "0.22"
+rand = "0.10"
+lazy_static = "1.5"
+thiserror = "2.0.18"
 pwhash = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 aerospike-rt = { path = "../aerospike-rt", version = "2.1.0" }
 futures = { version = "0.3.32" }
-async-trait = "0.1.51"
+async-trait = "0.1.89"
 rhexdump = "0.2.0"
 regex = "1"
-tokio-rustls = { version = "0.26.0", optional = true }
-rustls = { version = "0.23.31", optional = true }
+tokio-rustls = { version = "0.26.4", optional = true }
+rustls = { version = "0.23.40", optional = true }
 async-channel = "2.5.0"
 hazarc = "0.2.0"
 
@@ -43,12 +43,12 @@ tls = ["rustls", "tokio-rustls"]
 sync = []
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = "0.11"
 hex = "0.4"
 bencher = "0.1"
 serde_json = "1.0"
 aerospike = { path = "../" }
 aerospike-macro = {path = "../aerospike-macro"}
-lazy_static = "1.4"
-tokio = { version = "1.48.0", features = ["full"] }
+lazy_static = "1.5"
+tokio = { version = "1.52.1", features = ["full"] }
 webpki-roots = "1"

--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "1.0.40"
 pwhash = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 aerospike-rt = { path = "../aerospike-rt", version = "2.0.0" }
-futures = { version = "0.3.16" }
+futures = { version = "0.3.32" }
 async-trait = "0.1.51"
 rhexdump = "0.2.0"
 regex = "1"

--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4"
 thiserror = "1.0.40"
 pwhash = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
-aerospike-rt = { path = "../aerospike-rt", version = "2.0.0" }
+aerospike-rt = { path = "../aerospike-rt", version = "2.1.0" }
 futures = { version = "0.3.32" }
 async-trait = "0.1.51"
 rhexdump = "0.2.0"

--- a/aerospike-core/src/batch/batch_executor.rs
+++ b/aerospike-core/src/batch/batch_executor.rs
@@ -13,9 +13,6 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Weak};
-
 use crate::batch::BatchOperation;
 use crate::cluster::partition::Partition;
 use crate::cluster::{Cluster, Node};
@@ -26,6 +23,8 @@ use crate::Error;
 use crate::Key;
 use crate::{BatchRecord, Policy};
 use aerospike_rt::time::Duration;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 pub struct BatchExecutor {
     cluster: Arc<Cluster>,
@@ -38,7 +37,7 @@ impl BatchExecutor {
 
     fn node_for_key(&self, key: &Key, replica: crate::policy::Replica) -> Result<Arc<Node>> {
         let partition = Partition::new_by_key(key);
-        let node = self.cluster.get_node(&partition, replica, Weak::new())?;
+        let node = self.cluster.get_node(&partition, replica, None)?;
         Ok(node)
     }
 

--- a/aerospike-core/src/client.rs
+++ b/aerospike-core/src/client.rs
@@ -19,6 +19,7 @@ use std::str;
 use std::sync::Arc;
 use std::vec::Vec;
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -923,7 +924,7 @@ impl Client {
         server_path: &str,
         language: UDFLang,
     ) -> Result<RegisterTask> {
-        let udf_body = base64::encode(udf_body);
+        let udf_body = BASE64.encode(udf_body);
 
         let cmd = format!(
             "udf-put:filename={};content={};content-len={};udf-type={};",
@@ -1564,7 +1565,7 @@ impl Client {
             let mut buf = Buffer::new(0);
             buf.resize_buffer(size)?;
             let _ = expression.pack(&mut Some(&mut buf));
-            let exp_str = base64::encode(&buf.data_buffer);
+            let exp_str = BASE64.encode(&buf.data_buffer);
 
             format!("xdr-set-filter:dc={datacenter};namespace={namespace};exp={exp_str}")
         } else {

--- a/aerospike-core/src/client.rs
+++ b/aerospike-core/src/client.rs
@@ -837,6 +837,13 @@ impl Client {
         key: &Key,
         ops: &[Operation],
     ) -> Result<Record> {
+        if ops.is_empty() {
+            return Err(Error::ServerError(
+                ResultCode::ParameterError,
+                false,
+                "no operations defined".into(),
+            ));
+        }
         let mut command = OperateCommand::new(policy, self.cluster.clone(), key, ops);
         command.execute().await?;
         Ok(command.read_command.record.unwrap())
@@ -1257,6 +1264,13 @@ impl Client {
         statement: Statement,
         operations: &[Operation],
     ) -> Result<ExecuteTask> {
+        if operations.is_empty() {
+            return Err(Error::ServerError(
+                ResultCode::ParameterError,
+                false,
+                "no operations defined".into(),
+            ));
+        }
         statement.validate()?;
 
         let nodes = self.cluster.nodes();

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -221,9 +221,25 @@ impl Cluster {
                 }
             }
         }
+
+        // Cleanup is performed here — as the last act of the tend thread —
+        // rather than in `close()`, so the "all node additions/deletions are
+        // performed in tend thread" invariant (see `tend()`) is preserved.
+        // This makes the cleanup race-free without any cross-thread sync.
+        cluster.partition_map.store(Arc::new(HashMap::default()));
+        cluster.hashed_pass.store(Arc::new(None));
+        cluster.set_nodes(vec![]);
+        cluster.aliases.store(Arc::new(HashMap::new()));
+        cluster.seeds.store(Arc::new(vec![]));
     }
 
     async fn tend(&self) -> Result<()> {
+        // If close() has been called, bail before any work — otherwise an
+        // in-flight cycle would repopulate nodes after close() cleared them.
+        if self.closed.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+
         let mut nodes = self.nodes();
 
         // All node additions/deletions are performed in tend thread.
@@ -734,13 +750,19 @@ impl Cluster {
     }
 
     pub async fn close(&self) -> Result<()> {
-        if !self.closed.load(Ordering::Relaxed) {
-            // close tend by closing the channel
-            let tx = self.tend_channel.lock().await;
-            drop(tx);
-            self.closed.store(true, Ordering::Relaxed);
+        // Mark closed first so any in-flight tend cycle bails early.
+        if self.closed.swap(true, Ordering::SeqCst) {
+            return Ok(());
         }
 
+        // Actually close the tend channel: locking the Mutex and dropping
+        // the *guard* only releases the lock — it doesn't drop the Sender,
+        // which is what tend_thread's `try_recv` watches via TryRecvError::
+        // Closed. Use Sender::close_channel() to signal closure. The tend
+        // thread itself clears `nodes` and `aliases` as its last act before
+        // exiting (see `tend_thread`), preserving the single-writer
+        // invariant on those fields.
+        self.tend_channel.lock().await.close_channel();
         Ok(())
     }
 }

--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -24,7 +24,7 @@ use aerospike_rt::time::{Duration, Instant};
 use std::cell::OnceCell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 use std::vec::Vec;
 
 pub use self::node::Node;
@@ -42,7 +42,7 @@ use crate::policy::Replica;
 use crate::AdminPolicy;
 use aerospike_rt::Mutex;
 use futures::channel::mpsc;
-use futures::channel::mpsc::{Receiver, Sender};
+use futures::channel::mpsc::{Receiver, Sender, TryRecvError};
 use hazarc::AtomicArc;
 
 static CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -69,13 +69,13 @@ impl PartitionForNamespace {
         cluster: &Cluster,
         partition: &Partition<'_>,
         replica: crate::policy::Replica,
-        last_tried: Weak<Node>,
+        last_tried: Option<Arc<Node>>,
     ) -> Result<Arc<Node>> {
         fn get_next_in_sequence<I: Iterator<Item = Arc<Node>>, F: Fn() -> I>(
             get_sequence: F,
-            last_tried: Weak<Node>,
+            last_tried: Option<Arc<Node>>,
         ) -> Option<Arc<Node>> {
-            if let Some(last_tried) = last_tried.upgrade() {
+            if let Some(last_tried) = last_tried {
                 // If this isn't the first attempt, try the replica immediately after in sequence (that is actually valid)
                 let mut replicas = get_sequence();
                 while let Some(replica) = replicas.next() {
@@ -83,7 +83,6 @@ impl PartitionForNamespace {
                         if let Some(in_sequence_after) = replicas.next() {
                             return Some(in_sequence_after);
                         }
-
                         // No more after this? Drop through to try from the beginning.
                         break;
                     }
@@ -94,9 +93,17 @@ impl PartitionForNamespace {
         }
 
         let node = match replica {
-            Replica::Master => self.all_replicas(partition.partition_id).next().flatten(),
+            Replica::Master => self
+                .all_replicas(partition.partition_id)
+                .next()
+                .flatten()
+                .filter(|node| node.is_active()),
             Replica::Sequence => get_next_in_sequence(
-                || self.all_replicas(partition.partition_id).flatten(),
+                || {
+                    self.all_replicas(partition.partition_id)
+                        .flatten()
+                        .filter(|node| node.is_active())
+                },
                 last_tried,
             ),
             Replica::PreferRack => {
@@ -106,13 +113,19 @@ impl PartitionForNamespace {
                     || {
                         self.all_replicas(partition.partition_id)
                             .flatten()
-                            .filter(|node| node.is_in_rack(partition.namespace, rack_ids))
+                            .filter(|node| {
+                                node.is_in_rack(partition.namespace, rack_ids) && node.is_active()
+                            })
                     },
                     last_tried.clone(),
                 )
                 .or_else(|| {
                     get_next_in_sequence(
-                        || self.all_replicas(partition.partition_id).flatten(),
+                        || {
+                            self.all_replicas(partition.partition_id)
+                                .flatten()
+                                .filter(|node| node.is_active())
+                        },
                         last_tried,
                     )
                 })
@@ -197,22 +210,17 @@ impl Cluster {
         let tend_interval = cluster.client_policy.load().tend_interval;
 
         loop {
-            if rx.try_next().is_ok() {
-                unreachable!();
-            } else if let Err(err) = cluster.tend().await {
-                log_error_chain!(err, "Error tending cluster");
+            match rx.try_recv() {
+                Ok(()) => unreachable!(),
+                Err(TryRecvError::Closed) => break,
+                Err(TryRecvError::Empty) => {
+                    if let Err(err) = cluster.tend().await {
+                        log_error_chain!(err, "Error tending cluster");
+                    }
+                    aerospike_rt::sleep(Duration::from_millis(u64::from(tend_interval))).await;
+                }
             }
-            aerospike_rt::sleep(Duration::from_millis(u64::from(tend_interval))).await;
         }
-
-        // close all nodes
-        //let nodes = cluster.nodes().await;
-        //for mut node in nodes {
-        //    if let Some(node) = Arc::get_mut(&mut node) {
-        //        node.close().await;
-        //    }
-        //}
-        //cluster.set_nodes(vec![]).await;
     }
 
     async fn tend(&self) -> Result<()> {
@@ -550,11 +558,11 @@ impl Cluster {
                                     "some node refreshes but the current node is active but not referenced in partition-map"
                                 );
                         }
-                    } else if refresh_count >= 1 && failures > 2 {
-                        remove_list.push(tnode);
+                    } else if refresh_count >= 1 && failures > 0 {
                         debug!(
-                            "multi-node: refresh failed repeatedly, removing node despite peer reference_count"
+                            "multi-node: refresh failed repeatedly, removing node despite peer reference_count {tnode}"
                         );
+                        remove_list.push(tnode);
                     }
                 }
             }
@@ -571,13 +579,15 @@ impl Cluster {
     }
 
     fn remove_nodes_and_aliases(&self, mut nodes_to_remove: Vec<Arc<Node>>) {
-        for node in &mut nodes_to_remove {
+        for node in &nodes_to_remove {
+            debug!("Removing alias for node {node}");
             for alias in node.aliases() {
                 self.remove_alias(&alias);
             }
-            if let Some(node) = Arc::get_mut(node) {
-                node.close();
-            }
+        }
+        for node in &mut nodes_to_remove {
+            debug!("Closing node {node}");
+            node.close();
         }
         self.remove_nodes(&nodes_to_remove);
     }
@@ -634,7 +644,6 @@ impl Cluster {
                 node_array.push(node.clone());
             }
         }
-
         self.set_nodes(node_array);
     }
 
@@ -660,7 +669,7 @@ impl Cluster {
         &self,
         partition: &Partition<'_>,
         replica: crate::policy::Replica,
-        last_tried: Weak<Node>,
+        last_tried: Option<Arc<Node>>,
     ) -> Result<Arc<Node>> {
         let partitions = self.partition_map.load();
 
@@ -672,23 +681,6 @@ impl Cluster {
         })?;
 
         namespace.get_node(self, partition, replica, last_tried)
-    }
-
-    pub fn get_master_node(&self, namespace: &str, partition_id: usize) -> Result<Arc<Node>> {
-        let partitions = self.partition_map.load();
-
-        let ns_partition = partitions.get(namespace).ok_or_else(|| {
-            Error::InvalidNode(format!(
-                "Cannot get appropriate node for namespace: {namespace}"
-            ))
-        })?;
-
-        let node = ns_partition.all_replicas(partition_id).next().flatten();
-        node.ok_or_else(|| {
-            Error::InvalidNode(format!(
-                "Cannot get appropriate node for namespace: {namespace} partition: {partition_id}"
-            ))
-        })
     }
 
     pub fn get_random_node(&self) -> Result<Arc<Node>> {

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -59,6 +59,14 @@ pub struct Node {
     version: Version,
 }
 
+impl Drop for Node {
+    fn drop(&mut self) {
+        debug!("Node closed {self}");
+        self.close();
+        self.connection_pool.close();
+    }
+}
+
 impl Node {
     #![allow(missing_docs)]
     pub fn new(client_policy: ClientPolicy, nv: Arc<NodeValidator>) -> Self {
@@ -279,6 +287,12 @@ impl Node {
 
     // Get a connection to the node from the connection pool
     pub async fn get_connection(&self, hint: u8) -> Result<PooledConnection> {
+        if !self.is_active() {
+            return Err(Error::InvalidNode(format!(
+                "Cannot get a connection for node. The node `{self}` is inactive"
+            )));
+        }
+
         if let Ok(conn) = self.connection_pool.get(hint) {
             return Ok(conn);
         }
@@ -288,8 +302,14 @@ impl Node {
 
     // Put a connection to the node back in the connection pool
     pub fn put_connection(&self, mut pconn: PooledConnection) {
-        if let Some(conn) = pconn.conn.take() {
-            pconn.queue.put_back(conn);
+        if self.is_active() {
+            if let Some(conn) = pconn.conn.take() {
+                pconn.queue.put_back(conn);
+            }
+        } else {
+            // Inactive: do not return a Ready connection to the pool — `PooledConnection`'s
+            // `Drop` would otherwise `put_back` it.
+            pconn.invalidate();
         }
     }
 
@@ -330,9 +350,8 @@ impl Node {
     }
 
     // Set the node inactive and close all connections in the pool
-    pub fn close(&mut self) {
+    pub fn close(&self) {
         self.inactivate();
-        self.connection_pool.close();
     }
 
     // Send info commands to this node
@@ -384,18 +403,24 @@ impl Node {
     /// Fills the connection pool to the minimum required
     /// by the [`ClientPolicy.min_conns_per_node`]
     pub(crate) async fn fill_min_conns(&self) -> Result<usize> {
-        let mut count = 0;
+        if self.is_active() {
+            let mut count = 0;
 
-        let client_policy = self.client_policy();
-        if client_policy.min_conns_per_node > 0 {
-            let to_fill = client_policy.min_conns_per_node - self.connection_pool.num_conns();
-            for _ in 0..to_fill {
-                self.connection_pool.make_conn(count).await?;
-                count += 1;
+            let client_policy = self.client_policy();
+            if client_policy.min_conns_per_node > 0 {
+                let to_fill = client_policy.min_conns_per_node - self.connection_pool.num_conns();
+                for _ in 0..to_fill {
+                    self.connection_pool.make_conn(count).await?;
+                    count += 1;
+                }
             }
-        }
 
-        Ok(count)
+            Ok(count)
+        } else {
+            Err(Error::InvalidNode(format!(
+                "Cannot fill the connection pool to 'policy.min_conns_per_node'. The node `{self}` is inactive"
+            )))
+        }
     }
 }
 
@@ -416,5 +441,114 @@ impl Eq for Node {}
 impl fmt::Display for Node {
     fn fmt(&self, f: &mut fmt::Formatter) -> StdResult<(), fmt::Error> {
         format!("{}: {}", self.name, self.host).fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod node_tests {
+    use std::sync::Arc;
+
+    use crate::cluster::node_validator::NodeValidator;
+    use crate::errors::Error;
+    use crate::net::Host;
+    use crate::policy::ClientPolicy;
+    use crate::Version;
+
+    use super::Node;
+
+    fn test_node() -> Node {
+        let policy = ClientPolicy::default();
+        let nv = Arc::new(NodeValidator {
+            name: "test-node".to_string(),
+            aliases: vec![Host::new("127.0.0.1", 3000)],
+            services: vec![],
+            address: "127.0.0.1:3000".to_string(),
+            client_policy: policy.clone(),
+            use_new_info: true,
+            version: Version::default(),
+        });
+        Node::new(policy, nv)
+    }
+
+    /// One idle connection in the pool, using the test [`crate::net::Connection`] (no real socket).
+    async fn create_node_with_connection() -> Node {
+        let node = test_node();
+        let pconn = node
+            .connection_pool
+            .make_conn(0)
+            .await
+            .expect("make_conn uses test Connection");
+        node.put_connection(pconn);
+        assert_eq!(node.connection_pool.num_conns(), 1);
+        node
+    }
+
+    #[aerospike_macro::test]
+    async fn get_connection_returns_invalid_node_when_inactive() {
+        let node = create_node_with_connection().await;
+        let before = node.connection_pool.num_conns();
+        node.close();
+        assert!(!node.is_active());
+
+        let err = node.get_connection(0).await.unwrap_err();
+        match err {
+            Error::InvalidNode(msg) => assert!(msg.contains("inactive"), "unexpected: {}", msg),
+            other => panic!("expected InvalidNode, got {:?}", other),
+        }
+        assert_eq!(
+            node.connection_pool.num_conns(),
+            before,
+            "inactive node must not open or hand out pool connections"
+        );
+    }
+
+    #[aerospike_macro::test]
+    async fn put_connection_does_not_return_conn_to_pool_when_inactive() {
+        let node = create_node_with_connection().await;
+        let pconn = node
+            .get_connection(0)
+            .await
+            .expect("active node with one mock conn in pool");
+        assert_eq!(node.connection_pool.num_conns(), 0);
+
+        node.close();
+        assert!(!node.is_active());
+
+        node.put_connection(pconn);
+        assert_eq!(
+            node.connection_pool.num_conns(),
+            0,
+            "inactive node must not return connections to the pool"
+        );
+    }
+
+    #[aerospike_macro::test]
+    async fn node_drop_inactivates_and_closes_pool_when_last_arc_dropped() {
+        let arc = Arc::new(create_node_with_connection().await);
+        let queue_witness = {
+            let pconn = arc
+                .get_connection(0)
+                .await
+                .expect("pool should have one connection");
+            let q = pconn.queue.clone();
+            arc.put_connection(pconn);
+            q
+        };
+        let weak = Arc::downgrade(&arc);
+        assert_eq!(Arc::strong_count(&arc), 1);
+
+        assert!(arc.is_active());
+        assert_eq!(arc.connection_pool.num_conns(), 1);
+
+        drop(arc);
+        assert!(
+            weak.upgrade().is_none(),
+            "expected Node to be dropped after the last Arc was released"
+        );
+        assert_eq!(
+            queue_witness.num_conns(),
+            0,
+            "Node::drop should clear pooled connections"
+        );
     }
 }

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -20,6 +20,7 @@ use std::result::Result as StdResult;
 use std::sync::atomic::{AtomicBool, AtomicIsize, AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use hazarc::AtomicArc;
 
 use crate::cluster::node_validator::NodeValidator;
@@ -391,7 +392,7 @@ impl Node {
         // Source user-agent payload
         // Format: "1,rust-<version>,<application-id>"
         let user_agent_id = format!("1,rust-{CLIENT_VERSION},{app_id}");
-        let user_agent_id = base64::encode(&user_agent_id);
+        let user_agent_id = BASE64.encode(&user_agent_id);
         let user_agent_command = format!("user-agent-set:value={user_agent_id}");
 
         let policy = AdminPolicy {

--- a/aerospike-core/src/cluster/partition_tokenizer.rs
+++ b/aerospike-core/src/cluster/partition_tokenizer.rs
@@ -16,6 +16,8 @@ use std::str;
 use std::sync::Arc;
 use std::vec::Vec;
 
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
 use crate::cluster::node;
 use crate::cluster::Node;
 use crate::commands::Message;
@@ -91,7 +93,7 @@ impl PartitionTokenizer {
                     for (section, replica) in
                         info_section.zip(entry.nodes.chunks_mut(node::PARTITIONS))
                     {
-                        let restore_buffer = base64::decode(section)?;
+                        let restore_buffer = BASE64.decode(section)?;
                         for (idx, (this_reigimes, item)) in replica.iter_mut().enumerate() {
                             if restore_buffer[idx >> 3] & (0x80 >> (idx & 7) as u8) != 0
                                 && reigime >= *this_reigimes

--- a/aerospike-core/src/commands/batch_operate_command.rs
+++ b/aerospike-core/src/commands/batch_operate_command.rs
@@ -94,7 +94,7 @@ impl BatchOperateCommand {
                     let node = cluster.get_node(
                         &partition,
                         self.policy.replica,
-                        Arc::downgrade(&self.node),
+                        Some(self.node.clone()),
                     )?;
 
                     if !Self::request_group(individual_op, &self.policy, deadline, node).await? {

--- a/aerospike-core/src/commands/buffer.rs
+++ b/aerospike-core/src/commands/buffer.rs
@@ -838,10 +838,17 @@ impl Buffer {
             read_attr |= INFO1_NOBINDATA;
         }
 
+        let mut write_attr = 0;
+        match policy.expected_duration {
+            QueryDuration::Short => read_attr |= INFO1_SHORT_QUERY,
+            QueryDuration::LongRelaxAP => write_attr |= INFO2_RELAX_AP_LONG_QUERY,
+            QueryDuration::Long => (),
+        }
+
         self.write_header_read(
             &policy.base_policy,
             read_attr,
-            0,
+            write_attr,
             INFO3_PARTITION_DONE,
             field_count,
             bin_count as u16,

--- a/aerospike-core/src/commands/delete_command.rs
+++ b/aerospike-core/src/commands/delete_command.rs
@@ -30,7 +30,7 @@ pub struct DeleteCommand<'a> {
 impl<'a> DeleteCommand<'a> {
     pub fn new(policy: &'a WritePolicy, cluster: Arc<Cluster>, key: &'a Key) -> Self {
         DeleteCommand {
-            single_command: SingleCommand::new(cluster, key, crate::policy::Replica::Master),
+            single_command: SingleCommand::new(cluster, key, crate::policy::Replica::Sequence),
             policy,
             existed: false,
         }

--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use crate::cluster::partition::Partition;
 use crate::cluster::{Cluster, Node};
@@ -28,7 +28,7 @@ pub struct SingleCommand<'a> {
     cluster: Arc<Cluster>,
     pub key: &'a Key,
     partition: Partition<'a>,
-    last_tried: Weak<Node>,
+    last_tried: Option<Arc<Node>>,
     replica: crate::policy::Replica,
 }
 
@@ -39,7 +39,7 @@ impl<'a> SingleCommand<'a> {
             cluster,
             key,
             partition,
-            last_tried: Weak::new(),
+            last_tried: None,
             replica,
         }
     }
@@ -49,11 +49,12 @@ impl<'a> SingleCommand<'a> {
     }
 
     pub fn get_node(&mut self) -> Result<Arc<Node>> {
-        let this_time =
-            self.cluster
-                .get_node(&self.partition, self.replica, self.last_tried.clone())?;
-        self.last_tried = Arc::downgrade(&this_time);
-        Ok(this_time)
+        let node = self
+            .cluster
+            .get_node(&self.partition, self.replica, self.last_tried.clone())?;
+
+        self.last_tried = Some(node.clone());
+        Ok(node)
     }
 
     pub async fn empty_socket(conn: &mut Connection) -> Result<()> {
@@ -103,13 +104,14 @@ impl<'a> SingleCommand<'a> {
 
         // set timeout outside the loop
         let deadline = policy.deadline();
+        let effective_attempt = policy.max_retries() + 1;
 
         // Execute command until successful, timed out or maximum iterations have been reached.
         loop {
             iterations += 1;
 
             // check for max retries
-            if policy.max_retries() > 0 && iterations > policy.max_retries() {
+            if iterations > effective_attempt {
                 // first attempt isn't a retry
                 return Err(Error::Timeout(format!("Timeout after {iterations} tries")));
             }
@@ -185,7 +187,6 @@ impl<'a> SingleCommand<'a> {
                 if commands::is_network_error(&err) {
                     continue;
                 }
-
                 return Err(err);
             }
 

--- a/aerospike-core/src/commands/write_command.rs
+++ b/aerospike-core/src/commands/write_command.rs
@@ -38,7 +38,7 @@ impl<'a> WriteCommand<'a> {
         operation: OperationType,
     ) -> Self {
         WriteCommand {
-            single_command: SingleCommand::new(cluster, key, crate::policy::Replica::Master),
+            single_command: SingleCommand::new(cluster, key, crate::policy::Replica::Sequence),
             bins,
             policy,
             operation,

--- a/aerospike-core/src/expressions/mod.rs
+++ b/aerospike-core/src/expressions/mod.rs
@@ -20,6 +20,8 @@ pub mod hll;
 pub mod lists;
 pub mod maps;
 pub mod regex_flag;
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
 use crate::commands::buffer::Buffer;
 use crate::msgpack::encoder::{pack_array_begin, pack_integer, pack_raw_string, pack_value};
 use crate::operations::cdt_context::CdtContext;
@@ -337,7 +339,7 @@ impl Expression {
         let mut buf = Buffer::new(sz);
         buf.resize_buffer(sz)?;
         self.pack(&mut Some(&mut buf))?;
-        Ok(base64::encode(&buf.data_buffer[..buf.data_offset]))
+        Ok(BASE64.encode(&buf.data_buffer[..buf.data_offset]))
     }
 }
 
@@ -360,7 +362,8 @@ pub fn key(exp_type: ExpType) -> Expression {
 
 /// Creates an expression from a base64-encoded expression string.
 pub fn from_base64(b64: &str) -> Result<Expression> {
-    let bytes = base64::decode(b64)
+    let bytes = BASE64
+        .decode(b64)
         .map_err(|e| Error::BadResponse(format!("Invalid base64 expression: {e}")))?;
     Ok(Expression {
         cmd: None,

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -298,7 +298,7 @@ impl Connection {
         if self.socket_timeout > 0 {
             Duration::from_millis(u64::from(self.socket_timeout))
         } else {
-            Duration::from_millis(30_000) // 30 secs
+            Duration::from_secs(30) // 30 secs
         }
     }
 

--- a/aerospike-core/src/operations/cdt_context.rs
+++ b/aerospike-core/src/operations/cdt_context.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 //! Operation Context for nested Operations
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+
 use crate::commands::buffer::Buffer;
 use crate::errors::Result;
 use crate::msgpack::encoder::pack_ctx_for_index;
@@ -56,7 +58,7 @@ pub fn to_base64(ctx: &[CdtContext]) -> Result<String> {
     let mut buf = Buffer::new(0);
     buf.resize_buffer(size)?;
     let _ = pack_ctx_for_index(&mut Some(&mut buf), ctx);
-    Ok(base64::encode(&buf.data_buffer))
+    Ok(BASE64.encode(&buf.data_buffer))
 }
 
 /// Defines Lookup list by index offset.

--- a/aerospike-core/src/operations/lists.rs
+++ b/aerospike-core/src/operations/lists.rs
@@ -557,7 +557,7 @@ pub fn remove_by_value_range<TLR: ToListReturnTypeBitmask>(
     ];
 
     if !end.is_nil() {
-        args.push(CdtArgument::Value(end))
+        args.push(CdtArgument::Value(end));
     }
 
     let cdt_op = CdtOperation {
@@ -1060,7 +1060,7 @@ pub fn get_by_value_range<TLR: ToListReturnTypeBitmask>(
     ];
 
     if !end.is_nil() {
-        args.push(CdtArgument::Value(end))
+        args.push(CdtArgument::Value(end));
     }
 
     let cdt_op = CdtOperation {

--- a/aerospike-core/src/policy/client_policy.rs
+++ b/aerospike-core/src/policy/client_policy.rs
@@ -241,7 +241,7 @@ impl ClientPolicy {
         if self.timeout > 0 {
             Duration::from_millis(u64::from(self.timeout))
         } else {
-            Duration::from_millis(30_000)
+            Duration::from_secs(30)
         }
     }
 

--- a/aerospike-core/src/policy/write_policy.rs
+++ b/aerospike-core/src/policy/write_policy.rs
@@ -84,8 +84,13 @@ impl WritePolicy {
 
 impl Default for WritePolicy {
     fn default() -> Self {
+        let base_policy = BasePolicy {
+            max_retries: 0,
+            ..BasePolicy::default()
+        };
+
         WritePolicy {
-            base_policy: BasePolicy::default(),
+            base_policy,
             record_exists_action: RecordExistsAction::Update,
             generation_policy: GenerationPolicy::None,
             commit_level: CommitLevel::CommitAll,
@@ -101,5 +106,17 @@ impl Default for WritePolicy {
 impl PolicyLike for WritePolicy {
     fn base(&self) -> &BasePolicy {
         &self.base_policy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::policy::{Policy, WritePolicy};
+
+    #[test]
+    fn default_write_policy_max_retries_is_zero() {
+        let policy = WritePolicy::default();
+        assert_eq!(policy.max_retries(), 0);
+        assert_eq!(policy.base_policy.max_retries, 0);
     }
 }

--- a/aerospike-core/src/query/filter.rs
+++ b/aerospike-core/src/query/filter.rs
@@ -117,8 +117,11 @@ impl EqFilterValue for Value {
 impl RangeFilterValue for Value {
     fn into_filter_value(self) -> Value {
         assert!(
-            matches!(self.particle_type(), ParticleType::INTEGER),
-            "range filter value must be integer"
+            matches!(
+                self.particle_type(),
+                ParticleType::INTEGER | ParticleType::STRING | ParticleType::BLOB
+            ),
+            "equality/contains filter value must be integer, string, or blob"
         );
         self
     }

--- a/aerospike-core/src/query/partition_tracker.rs
+++ b/aerospike-core/src/query/partition_tracker.rs
@@ -14,6 +14,7 @@
 // the License.
 
 use crate::cluster::node;
+use crate::cluster::partition::Partition;
 use crate::cluster::Cluster;
 use crate::errors::{Error, Result};
 use crate::policy::Replica;
@@ -165,7 +166,9 @@ impl PartitionTracker {
                 (part.retry, part.id)
             };
             if retry || part_retry {
-                let node = cluster.get_master_node(namespace, part_id as usize)?;
+                let partition = Partition::new(namespace, part_id as usize);
+                let last_tried = part.lock().await.node.as_ref().map(Arc::clone);
+                let node = cluster.get_node(&partition, self.replica, last_tried)?;
 
                 // Use node name to check for single node equality because
                 // partition map may be in transitional state between

--- a/aerospike-core/src/query/recordset.rs
+++ b/aerospike-core/src/query/recordset.rs
@@ -13,16 +13,12 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-extern crate rand;
-
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use aerospike_rt::Mutex;
 
 use async_channel::{Receiver, Sender};
-
-use rand::Rng;
 
 use crate::errors::Result;
 use crate::query::{PartitionFilter, PartitionTracker};
@@ -42,7 +38,7 @@ pub struct Recordset {
     rx: Receiver<Result<Record>>,
     tx: Sender<Result<Record>>,
     active: AtomicBool,
-    task_id: AtomicUsize,
+    task_id: AtomicU64,
     pub(crate) tracker: Arc<Mutex<PartitionTracker>>,
 }
 
@@ -59,8 +55,7 @@ impl Recordset {
         nodes: usize,
         tracker: Arc<Mutex<PartitionTracker>>,
     ) -> Self {
-        let mut rng = rand::thread_rng();
-        let task_id = rng.gen::<usize>();
+        let task_id = rand::random::<u64>();
 
         let (tx, rx) = async_channel::bounded(rec_queue_size);
         Recordset {
@@ -68,7 +63,7 @@ impl Recordset {
             rx,
             tx,
             active: AtomicBool::new(true),
-            task_id: AtomicUsize::new(task_id),
+            task_id: AtomicU64::new(task_id),
             tracker,
         }
     }
@@ -91,8 +86,7 @@ impl Recordset {
     }
 
     pub(crate) fn reset_task_id(&self) {
-        let mut rng = rand::thread_rng();
-        let task_id = rng.gen::<usize>();
+        let task_id = rand::random::<u64>();
         self.task_id.store(task_id, Ordering::Relaxed);
     }
 

--- a/aerospike-core/src/task/drop_index_task.rs
+++ b/aerospike-core/src/task/drop_index_task.rs
@@ -43,7 +43,7 @@ impl DropIndexTask {
         let node_version = node.version();
 
         if node_version >= &Version::new(8, 1, 0, 0) {
-            format!("sindex-exists:namespace={namespace};indexname={index_name}",)
+            format!("sindex-exists:namespace={namespace};indexname={index_name}")
         } else {
             format!("sindex-exists:ns={namespace};indexname={index_name}")
         }

--- a/aerospike-macro/Cargo.toml
+++ b/aerospike-macro/Cargo.toml
@@ -21,7 +21,7 @@ proc-macro = true
 proc-macro2 = "1.0.28"
 syn = {version = "2.0.98", default-features = false, features = ["full"]}
 quote = {version = "1.0.6"}
-aerospike-rt = {path = "../aerospike-rt", version = "2.0.0"}
+aerospike-rt = {path = "../aerospike-rt", version = "2.1.0"}
 
 [features]
 rt-tokio = ["aerospike-rt/rt-tokio"]

--- a/aerospike-macro/Cargo.toml
+++ b/aerospike-macro/Cargo.toml
@@ -18,9 +18,9 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-proc-macro2 = "1.0.28"
-syn = {version = "2.0.98", default-features = false, features = ["full"]}
-quote = {version = "1.0.6"}
+proc-macro2 = "1.0.106"
+syn = {version = "2.0.117", default-features = false, features = ["full"]}
+quote = {version = "1.0.45"}
 aerospike-rt = {path = "../aerospike-rt", version = "2.1.0"}
 
 [features]
@@ -28,4 +28,4 @@ rt-tokio = ["aerospike-rt/rt-tokio"]
 rt-async-std = ["aerospike-rt/rt-async-std"]
 
 [build-dependencies]
-syn = "2.0.98"
+syn = "2.0.117"

--- a/aerospike-rt/Cargo.toml
+++ b/aerospike-rt/Cargo.toml
@@ -16,9 +16,9 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.48.0", features = ["fs", "net", "rt", "rt-multi-thread", "time", "io-util", "sync"], optional = true }
-async-std = {version = "1.13.0", optional = true}
-async-lock = { version = "3.4.1", optional = true}
+tokio = { version = "1.52.1", features = ["fs", "net", "rt", "rt-multi-thread", "time", "io-util", "sync"], optional = true }
+async-std = {version = "1.13.2", optional = true}
+async-lock = { version = "3.4.2", optional = true}
 
 [features]
 rt-tokio = ["tokio"]

--- a/aerospike-sync/Cargo.toml
+++ b/aerospike-sync/Cargo.toml
@@ -17,7 +17,7 @@ publish = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aerospike-core = {path = "../aerospike-core", version = "2.0.0", features = ["sync"]}
+aerospike-core = {path = "../aerospike-core", version = "2.1.0", features = ["sync"]}
 futures = { version = "0.3.32" }
 
 [features]

--- a/aerospike-sync/Cargo.toml
+++ b/aerospike-sync/Cargo.toml
@@ -18,7 +18,7 @@ publish = true
 
 [dependencies]
 aerospike-core = {path = "../aerospike-core", version = "2.0.0", features = ["sync"]}
-futures = {version = "0.3.16" }
+futures = { version = "0.3.32" }
 
 [features]
 rt-tokio = ["aerospike-core/rt-tokio"]

--- a/benches/client_server.rs
+++ b/benches/client_server.rs
@@ -19,7 +19,7 @@ extern crate bencher;
 extern crate lazy_static;
 extern crate rand;
 
-use rand::Rng;
+use rand::RngExt;
 
 use aerospike::operations;
 use aerospike::{as_bin, as_key, as_val};
@@ -38,7 +38,7 @@ lazy_static! {
 }
 
 fn rand_key_from_range(low: i64, high: i64) -> i64 {
-    rand::thread_rng().gen_range(low, high)
+    rand::rng().random_range(low..high)
 }
 
 fn single_key_read(bench: &mut Bencher) {

--- a/examples/batch_operations.rs
+++ b/examples/batch_operations.rs
@@ -8,8 +8,8 @@ use aerospike_core::{
     AdminPolicy, BatchDeletePolicy, BatchOperation, BatchReadPolicy, BatchUDFPolicy,
     BatchWritePolicy, Task,
 };
-use rand::distributions::Alphanumeric;
-use rand::Rng;
+use rand::distr::Alphanumeric;
+use rand::RngExt;
 use std::env;
 
 #[tokio::main]
@@ -132,8 +132,8 @@ end
 }
 
 fn generate_random_set_name() -> String {
-    let rng = rand::thread_rng();
-    rng.sample_iter(&Alphanumeric)
+    rand::rng()
+        .sample_iter(&Alphanumeric)
         .take(10)
         .map(char::from)
         .collect()

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -7,8 +7,8 @@ use aerospike::{Bins, Client, ClientPolicy, QueryPolicy, Statement};
 use aerospike_core::expressions::{eq, int_bin, int_val};
 use aerospike_core::{AdminPolicy, CollectionIndexType, IndexType, Task, WritePolicy};
 use futures::stream::StreamExt;
-use rand::distributions::Alphanumeric;
-use rand::Rng;
+use rand::distr::Alphanumeric;
+use rand::RngExt;
 use std::env;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -258,8 +258,8 @@ async fn create_test_set(client: &Client, namespace: &str, num_records: usize) -
 }
 
 fn generate_random_set_name() -> String {
-    let rng = rand::thread_rng();
-    rng.sample_iter(&Alphanumeric)
+    rand::rng()
+        .sample_iter(&Alphanumeric)
         .take(10)
         .map(char::from)
         .collect()

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -20,7 +20,9 @@ extern crate rand;
 #[cfg(feature = "tls")]
 extern crate webpki_roots;
 
+use aerospike::Bins;
 use aerospike::Client;
+use aerospike_rt::time::Duration;
 
 mod common;
 
@@ -104,4 +106,53 @@ async fn tls_client_auth() {
     let names = client.node_names();
     assert!(!names.is_empty());
     client.close().await.unwrap();
+}
+
+#[aerospike_macro::test]
+async fn test_close_does_not_stop_tend_thread() {
+    let client = common::client().await;
+    let namespace = common::namespace();
+
+    let key = aerospike::as_key!(namespace, "close_bug_test", "key1");
+    let bin = aerospike::as_bin!("val", 42);
+    client
+        .put(&aerospike::WritePolicy::default(), &key, &[bin])
+        .await
+        .unwrap();
+
+    let nodes_before = client.node_names();
+    assert!(!nodes_before.is_empty(), "Should have nodes before close");
+
+    client.close().await.unwrap();
+    assert!(
+        !client.is_connected(),
+        "Expected is_connected()=false after close"
+    );
+
+    let tend_interval = common::client_policy().tend_interval;
+    let wait_ms = u64::from(tend_interval) * 2;
+    aerospike_rt::sleep(Duration::from_millis(wait_ms)).await;
+
+    let nodes_after = client.node_names();
+
+    // After close(), tend_thread should stop and nodes should be cleared.
+    // This assert passes if nodes are NOT cleared — tend_thread is still running.
+    assert!(nodes_after.is_empty(), "Nodes were NOT cleared after close");
+
+    let get_result = client
+        .get(&aerospike::ReadPolicy::default(), &key, Bins::All)
+        .await;
+    assert!(get_result.is_err(), "get should have failed",);
+
+    let key2 = aerospike::as_key!(namespace, "close_bug_test", "key2");
+    let bin2 = aerospike::as_bin!("val", 99);
+    let put_result = client
+        .put(&aerospike::WritePolicy::default(), &key2, &[bin2])
+        .await;
+    assert!(put_result.is_err(), "put should have failed",);
+
+    let delete_result = client
+        .delete(&aerospike::WritePolicy::default(), &key2)
+        .await;
+    assert!(delete_result.is_err(), "delete should have failed",);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,8 +21,8 @@ use aerospike::CollectionIndexType;
 use aerospike::Task;
 
 use rand;
-use rand::distributions::Alphanumeric;
-use rand::Rng;
+use rand::distr::Alphanumeric;
+use rand::RngExt;
 
 use tokio::sync::OnceCell;
 
@@ -202,8 +202,11 @@ pub async fn singleton_client() -> &'static Client {
 }
 
 pub fn rand_str(sz: usize) -> String {
-    let rng = rand::thread_rng();
-    rng.sample_iter(&Alphanumeric).take(sz).collect()
+    rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(sz)
+        .map(char::from)
+        .collect()
 }
 
 pub async fn enterprise_edition() -> bool {

--- a/tests/proptests/cdt_lists.rs
+++ b/tests/proptests/cdt_lists.rs
@@ -35,7 +35,7 @@ proptest_async::proptest! {
         let rec = client.operate(&wpolicy, &key, ops).await.unwrap();
         assert_eq!(
             *rec.bins.get("bin").unwrap(),
-            as_list!(6, as_list!("0", v1, v2, v3, 1, 2.1f64))
+            Value::MultiResult(vec![as_val!(6), as_list!("0", v1, v2, v3, 1, 2.1f64)])
         );
     }
 }

--- a/tests/proptests/scans.rs
+++ b/tests/proptests/scans.rs
@@ -9,7 +9,7 @@ use aerospike::*;
 proptest_async::proptest! {
     #[test]
     async fn scan(
-        query_policy in query_policy(1000, 5000),
+        query_policy in query_policy_scan(1000, 5000),
         stmt in statement_scan(common::namespace().into(), common::prop_setname_multi().into()))
     {
         let client = common::singleton_client().await;

--- a/tests/src/cleanup.rs
+++ b/tests/src/cleanup.rs
@@ -1,0 +1,89 @@
+// Copyright 2015-2026 Aerospike, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Post-test cleanup: drops every secondary index in the test namespace and
+//! truncates the namespace.
+
+use std::collections::HashMap;
+
+use aerospike::{AdminPolicy, Client};
+
+use crate::common;
+
+async fn list_indexes(client: &Client, namespace: &str) -> Vec<HashMap<String, String>> {
+    let node = client
+        .cluster
+        .get_random_node()
+        .expect("no nodes available");
+
+    let cmd = format!("sindex-list:namespace={}", namespace);
+    let res = node
+        .info(&AdminPolicy::default(), &[&cmd])
+        .await
+        .expect("sindex info request failed");
+
+    let sindex_str = res.get(&cmd).map(String::as_str).unwrap_or("");
+
+    sindex_str
+        .split(';')
+        .map(|entry| {
+            entry
+                .split(':')
+                .filter(|kv| !kv.trim().is_empty())
+                .filter_map(|kv| kv.split_once('='))
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect()
+        })
+        .collect()
+}
+
+async fn drop_indexes(client: &Client, namespace: &str) {
+    let policy = AdminPolicy::default();
+    for index in list_indexes(client, namespace).await {
+        if index.get("ns").map(String::as_str) != Some(namespace) {
+            continue;
+        }
+        let set = index.get("set").map(String::as_str).unwrap_or("");
+        let Some(name) = index.get("indexname") else {
+            continue;
+        };
+
+        match client.drop_index(&policy, namespace, set, name).await {
+            Ok(_) => println!("Success: Removing Namespace/Set/Index: {namespace}/{set}/{name}"),
+            Err(e) => {
+                println!("Failed: Removing Namespace/Set/Index: {namespace}/{set}/{name} ({e})")
+            }
+        }
+    }
+}
+
+async fn truncate_namespace(client: &Client, namespace: &str) {
+    match client
+        .truncate(&AdminPolicy::default(), namespace, "", 0)
+        .await
+    {
+        Ok(_) => println!("Success: Removing Namespace: {namespace}"),
+        Err(e) => println!("Failed: Removing Namespace: {namespace} ({e})"),
+    }
+}
+
+#[ignore]
+#[aerospike_macro::test]
+async fn cleanup_after_tests() {
+    let client = common::client().await;
+    let namespace = common::namespace();
+    drop_indexes(&client, namespace).await;
+    truncate_namespace(&client, namespace).await;
+    client.close().await.unwrap();
+}

--- a/tests/src/connection_seed.rs
+++ b/tests/src/connection_seed.rs
@@ -274,7 +274,10 @@ async fn test_seed_connection_and_partition_map_staleness() {
 async fn probe_get(client: &Client, ns: &str, set: &str, _bin: &str, n: i64) -> (i64, i64) {
     let mut rp = ReadPolicy::default();
     rp.base_policy.total_timeout = 3000;
-    println!("   rp.base_policy.max_retries={}: ", rp.base_policy.max_retries);
+    println!(
+        "   rp.base_policy.max_retries={}: ",
+        rp.base_policy.max_retries
+    );
     // rp.base_policy.max_retries = 0;
 
     let (mut ok, mut fail) = (0i64, 0i64);
@@ -299,7 +302,7 @@ async fn probe_put(client: &Client, ns: &str, set: &str, bin: &str, n: i64) -> (
     wp.base_policy.sleep_between_retries = 200;
     wp.base_policy.max_retries = 2;
     // wp.base_policy.max_retries = 0;
-   
+
     let (mut ok, mut fail) = (0i64, 0i64);
     for i in 0..n {
         let key = as_key!(ns, set, i);

--- a/tests/src/connection_seed.rs
+++ b/tests/src/connection_seed.rs
@@ -1,0 +1,356 @@
+// Copyright 2015-2018 Aerospike, Inc.
+//
+// Portions may be licensed to Aerospike, Inc. under one or more contributor
+// license agreements.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+use std::time::Instant;
+
+use aerospike::{as_bin, as_key, AdminPolicy, Bins, Client, Key, ReadPolicy, WritePolicy};
+use aerospike_rt::time::Duration;
+
+use crate::common;
+
+/// Reproduce: single-key WRITE operations (put/remove) fail with
+/// "Command timed out after ~N tries" after a node is killed and
+/// the client evicts it via tend, because the partition map still
+/// references the dead node as the master for some partitions.
+///
+/// TOPOLOGY: Start with a 4-node cluster (RF=2), kill one → 3 surviving.
+/// The 4-node starting state ensures some partitions have their
+/// ONLY master on the killed node in the stale partition map.
+///
+/// ─── CLUSTER LIFECYCLE COMMANDS ───────────────────────────────────────
+///
+/// TEARDOWN (stop & remove all 4 nodes):
+///   aerolab cluster destroy -n mydc -f
+///
+///   If aerolab is unavailable, manual Docker commands:
+///     docker kill aerolab-mydc_1 aerolab-mydc_2 aerolab-mydc_3 aerolab-mydc_4
+///     docker rm   aerolab-mydc_1 aerolab-mydc_2 aerolab-mydc_3 aerolab-mydc_4
+///
+/// SETUP (create fresh 4-node cluster, ubuntu 22.04):
+///   aerolab cluster create -n mydc -c 4 -i 22.04
+///
+/// VERIFY (all 4 nodes up, same cluster key):
+///   docker ps --format '{{.Names}} {{.Status}}' | grep mydc
+///   for i in 1 2 3 4; do
+///     echo "node $i: $(docker exec aerolab-mydc_$i asinfo -v 'cluster-stable')";
+///   done
+///
+/// MANUAL STOP ALL 4 (without destroying containers):
+///   docker kill aerolab-mydc_1 aerolab-mydc_2 aerolab-mydc_3 aerolab-mydc_4
+///
+/// MANUAL START ALL 4 (restart containers + asd):
+///   for i in 1 2 3 4; do docker start aerolab-mydc_$i; done
+///   sleep 2
+///   for i in 1 2 3 4; do
+///     docker exec aerolab-mydc_$i /usr/bin/asd --config-file /etc/aerospike/aerospike.conf;
+///   done
+///   sleep 5   # wait for cluster to form
+///
+/// ─── RUN THE TEST ─────────────────────────────────────────────────────
+///
+/// RUN:
+///   RUN_WRITE_BUG=1 \
+///     AEROSPIKE_HOSTS="127.0.0.1:3100" \
+///     AEROSPIKE_USE_SERVICES_ALTERNATE=true \
+///     STOP_CMD="docker kill aerolab-mydc_3" \
+///     START_CMD="docker start aerolab-mydc_3" \
+///     RESTART_ASD_CMD="docker exec aerolab-mydc_3 /usr/bin/asd --config-file /etc/aerospike/aerospike.conf" \
+///     cargo test --features rt-tokio -- --ignored test_seed_connection_and_partition_map_staleness --nocapture
+///
+/// RUN (with debug logging):
+///   RUST_LOG=debug RUN_WRITE_BUG=1 \
+///     AEROSPIKE_HOSTS="127.0.0.1:3100" \
+///     AEROSPIKE_USE_SERVICES_ALTERNATE=true \
+///     STOP_CMD="docker kill aerolab-mydc_3" \
+///     START_CMD="docker start aerolab-mydc_3" \
+///     RESTART_ASD_CMD="docker exec aerolab-mydc_3 /usr/bin/asd --config-file /etc/aerospike/aerospike.conf" \
+///     cargo test --features rt-tokio -- --ignored test_seed_connection_and_partition_map_staleness --nocapture 2>&1 | tee /tmp/write_bug.log
+#[aerospike_macro::test]
+#[ignore = "manual repro: needs aerolab cluster; run with cargo test -- --ignored and RUN_WRITE_BUG=1"]
+async fn test_seed_connection_and_partition_map_staleness() {
+    use std::process::Command as ShellCmd;
+
+    let run_flag = std::env::var("RUN_WRITE_BUG").unwrap_or_default();
+    if !["1", "true", "yes"].contains(&run_flag.as_str()) {
+        println!("Skipping: set RUN_WRITE_BUG=1 to run");
+        return;
+    }
+
+    let stop_cmd =
+        std::env::var("STOP_CMD").expect("Set STOP_CMD (e.g. 'docker kill aerolab-mydc_3')");
+    let start_cmd =
+        std::env::var("START_CMD").expect("Set START_CMD (e.g. 'docker start aerolab-mydc_3')");
+    let restart_asd_cmd = std::env::var("RESTART_ASD_CMD").unwrap_or_default();
+
+    let namespace = common::namespace();
+    let set_name = "write_bug_repro";
+    let bin_name = "v";
+    let num_records: i64 = 10000;
+
+    let client = common::client().await;
+    let wpolicy = WritePolicy::default();
+
+    let run_cmd = |cmd_str: &str, label: &str| -> bool {
+        println!("  [{}] Running: {}", label, cmd_str);
+        let parts: Vec<&str> = cmd_str.split_whitespace().collect();
+        let output = ShellCmd::new(parts[0])
+            .args(&parts[1..])
+            .output()
+            .unwrap_or_else(|e| panic!("[{}] Failed to execute: {}", label, e));
+        if !output.status.success() {
+            println!(
+                "  [{}] Command failed (rc={}): stderr={:?}",
+                label,
+                output.status,
+                String::from_utf8_lossy(&output.stderr),
+            );
+            return false;
+        }
+        println!("  [{}] OK", label);
+        true
+    };
+
+    // ── Phase 1: Verify starting state (need 4+ nodes) ──────────────────
+    let initial_nodes = client.nodes().len();
+    println!("\n[PHASE 1] Client sees {} nodes", initial_nodes);
+    if initial_nodes < 4 {
+        println!(
+            "  Need 4+ nodes to reproduce. Got {}.\n\
+             Create a 4-node cluster first:\n\
+               aerolab cluster create -n mydc -c 4 -i 22.04\n\
+             Skipping test.",
+            initial_nodes
+        );
+        return;
+    }
+
+    // ── Phase 2: Load data + verify baseline ─────────────────────────────
+    println!(
+        "\n[PHASE 2] Loading {} records into {}.{}...",
+        num_records, namespace, set_name
+    );
+    for i in 0..num_records {
+        let key = as_key!(namespace, set_name, i);
+        let bins = vec![as_bin!(bin_name, i)];
+        client.put(&wpolicy, &key, &bins).await.unwrap();
+    }
+    println!("  Done loading {} records", num_records);
+
+    let (_, baseline_fail) = probe_get(&client, namespace, set_name, bin_name, num_records).await;
+    assert_eq!(baseline_fail, 0, "Baseline get should have 0 failures");
+    println!("  Baseline get: all {} passed", num_records);
+
+    // ── Phase 3: Kill one node ───────────────────────────────────────────
+    println!(
+        "\n[PHASE 3] Killing one node (cluster {}→{})...",
+        initial_nodes,
+        initial_nodes - 1
+    );
+    assert!(run_cmd(&stop_cmd, "STOP-NODE"), "Stop command failed");
+
+    println!("  Waiting for tend to evict dead node...");
+    let evict_start = Instant::now();
+    loop {
+        let n = client.nodes().len();
+        if n < initial_nodes {
+            println!(
+                "  Node evicted after {:.1}s (now {} nodes)",
+                evict_start.elapsed().as_secs_f64(),
+                n
+            );
+            break;
+        }
+        if evict_start.elapsed() > Duration::from_secs(30) {
+            println!(
+                "  WARNING: Dead node not evicted after 30s (still {} nodes). Proceeding anyway.",
+                n
+            );
+            break;
+        }
+        aerospike_rt::sleep(Duration::from_millis(500)).await;
+    }
+
+    // ── Phase 4: Probe immediately — this is where the bug shows ─────────
+    println!("\n[PHASE 4] Probing single-key ops immediately after tend eviction");
+    println!("  (partition map likely stale — dead node still listed as master)");
+    println!("  Nodes visible: {}", client.nodes().len());
+
+    let start = Instant::now();
+    let (get_ok, get_fail) = probe_get(&client, namespace, set_name, bin_name, num_records).await;
+    let get_elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "  get:    ok={:<5} fail={:<5} ({:.1}s)",
+        get_ok, get_fail, get_elapsed
+    );
+
+    let start = Instant::now();
+    let (put_ok, put_fail) = probe_put(&client, namespace, set_name, bin_name, num_records).await;
+    let put_elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "  put:    ok={:<5} fail={:<5} ({:.1}s)",
+        put_ok, put_fail, put_elapsed
+    );
+
+    let start = Instant::now();
+    let (rm_ok, rm_fail) = probe_remove(&client, namespace, set_name, bin_name, num_records).await;
+    let rm_elapsed = start.elapsed().as_secs_f64();
+    println!(
+        "  remove: ok={:<5} fail={:<5} ({:.1}s)",
+        rm_ok, rm_fail, rm_elapsed
+    );
+
+    // ── Cleanup: restart killed node ─────────────────────────────────────
+    // aerolab containers use a keep-alive loop as CMD, so `docker start`
+    // only restarts the container — asd must be re-launched separately.
+    println!("\n[CLEANUP]");
+    let _ = std::panic::catch_unwind(|| {
+        run_cmd(&start_cmd, "START-NODE");
+    });
+    if !restart_asd_cmd.is_empty() {
+        let _ = std::panic::catch_unwind(|| {
+            run_cmd(&restart_asd_cmd, "RESTART-ASD");
+        });
+    }
+    // Give the restarted node time to rejoin the cluster
+    aerospike_rt::sleep(Duration::from_secs(5)).await;
+    let ap = AdminPolicy::default();
+    let _ = client.truncate(&ap, namespace, set_name, 0).await;
+    let _ = client.close().await;
+
+    // ── Verdict ──────────────────────────────────────────────────────────
+    println!("\n{}", "=".repeat(60));
+    println!(
+        "RESULTS (topology: {} nodes → kill 1 → {})",
+        initial_nodes,
+        initial_nodes - 1
+    );
+    println!("{}", "=".repeat(60));
+    println!(
+        "  get:    {}/{} failures in {:.1}s",
+        get_fail, num_records, get_elapsed
+    );
+    println!(
+        "  put:    {}/{} failures in {:.1}s",
+        put_fail, num_records, put_elapsed
+    );
+    println!(
+        "  remove: {}/{} failures in {:.1}s",
+        rm_fail, num_records, rm_elapsed
+    );
+
+    let total_fail = get_fail + put_fail + rm_fail;
+    if total_fail > 0 {
+        panic!(
+            "\nSTALE PARTITION MAP WRITE BUG CONFIRMED\n\
+             {}/{} total single-key operations failed after node eviction.\n\
+             get={} put={} remove={}\n\n\
+             Root cause: partition map still references dead node as master.\n\
+             is_active() filter rejects it, but no fallback for writes.\n\
+             Client spin-retries until total_timeout expires.",
+            total_fail,
+            num_records * 3,
+            get_fail,
+            put_fail,
+            rm_fail,
+        );
+    } else {
+        println!("\n  No stale partition map write bug detected this run.");
+        println!("  (partition map may have refreshed before probes ran)");
+    }
+}
+
+async fn probe_get(client: &Client, ns: &str, set: &str, _bin: &str, n: i64) -> (i64, i64) {
+    let mut rp = ReadPolicy::default();
+    rp.base_policy.total_timeout = 3000;
+    println!("   rp.base_policy.max_retries={}: ", rp.base_policy.max_retries);
+    // rp.base_policy.max_retries = 0;
+
+    let (mut ok, mut fail) = (0i64, 0i64);
+    for i in 0..n {
+        let key = as_key!(ns, set, i);
+        match client.get(&rp, &key, Bins::All).await {
+            Ok(_) => ok += 1,
+            Err(e) => {
+                if fail < 5 {
+                    println!("    get key={}: {:?}", i, e);
+                }
+                fail += 1;
+            }
+        }
+    }
+    (ok, fail)
+}
+
+async fn probe_put(client: &Client, ns: &str, set: &str, bin: &str, n: i64) -> (i64, i64) {
+    let mut wp = WritePolicy::default();
+    wp.base_policy.total_timeout = 3000;
+    wp.base_policy.sleep_between_retries = 200;
+    wp.base_policy.max_retries = 2;
+    // wp.base_policy.max_retries = 0;
+   
+    let (mut ok, mut fail) = (0i64, 0i64);
+    for i in 0..n {
+        let key = as_key!(ns, set, i);
+        let bins = vec![as_bin!(bin, i + 1)];
+        match client.put(&wp, &key, &bins).await {
+            Ok(_) => ok += 1,
+            Err(e) => {
+                if fail < 5 {
+                    println!("    put key={}: {:?}", i, e);
+                }
+                fail += 1;
+            }
+        }
+    }
+    (ok, fail)
+}
+
+/// Matches `Partition::new_by_key` in aerospike-core (digest → partition id, 0..4096).
+fn partition_id_for_key(key: &Key) -> usize {
+    const PARTITIONS: usize = 4096;
+    (u16::from_le_bytes([key.digest[0], key.digest[1]]) as usize) & (PARTITIONS - 1)
+}
+
+async fn probe_remove(client: &Client, ns: &str, set: &str, _bin: &str, n: i64) -> (i64, i64) {
+    let mut wp = WritePolicy::default();
+    wp.base_policy.total_timeout = 3000;
+    wp.base_policy.max_retries = 2;
+    wp.base_policy.sleep_between_retries = 200;
+
+    // wp.base_policy.max_retries = 0;
+
+    let (mut ok, mut fail) = (0i64, 0i64);
+    for i in 0..n {
+        let key = as_key!(ns, set, i);
+        if i == 0i64 || i == 2i64 || i == 6i64 {
+            let pid = partition_id_for_key(&key);
+            println!(
+                "  [probe_remove] sample key i={} partition_id={} ns={} set={}",
+                i, pid, ns, set
+            );
+        }
+
+        match client.delete(&wp, &key).await {
+            Ok(_) => ok += 1,
+            Err(e) => {
+                if fail < 5 {
+                    println!("    remove key={}: {:?}", i, e);
+                }
+                fail += 1;
+            }
+        }
+    }
+    (ok, fail)
+}

--- a/tests/src/kv.rs
+++ b/tests/src/kv.rs
@@ -15,7 +15,7 @@
 use aerospike::{
     as_bin, as_blob, as_geo, as_key, as_list, as_map, as_val, Bins, ReadPolicy, Value, WritePolicy,
 };
-use aerospike::{operations, Expiration, ReadTouchTTL};
+use aerospike::{operations, Error, Expiration, ReadTouchTTL, ResultCode};
 use aerospike_rt::sleep;
 use aerospike_rt::time::Duration;
 
@@ -147,6 +147,38 @@ async fn connect() {
 
     let existed = client.delete(&wpolicy, &key).await.unwrap();
     assert!(!existed);
+
+    client.close().await.unwrap();
+}
+
+#[aerospike_macro::test]
+async fn operate_empty_ops_returns_parameter_error() {
+    let client = common::client().await;
+    let namespace = common::namespace();
+    let set_name = &common::rand_str(10);
+    let key = as_key!(namespace, set_name, 1);
+
+    let wpolicy = WritePolicy::default();
+
+    // Calling operate with an empty operations slice must be rejected
+    // client-side with a ParameterError, instead of being forwarded to the
+    // server (which would either reject it with an opaque error or perform
+    // a meaningless round-trip). The server happens to also reject empty
+    // ops with ParameterError, so we additionally verify that the error
+    // message identifies the client-side guard — a server response would
+    // carry the node address in that field instead.
+    let result = client.operate(&wpolicy, &key, &[]).await;
+
+    match result {
+        Err(Error::ServerError(ResultCode::ParameterError, _, ref msg))
+            if msg.contains("no operations") => {}
+        Err(other) => panic!(
+            "expected client-side ParameterError ('operate called with no \
+             operations'); got {:?}",
+            other
+        ),
+        Ok(_) => panic!("expected ParameterError, got Ok"),
+    }
 
     client.close().await.unwrap();
 }

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -24,6 +24,7 @@ mod batch;
 mod cdt_bitwise;
 mod cdt_list;
 mod cdt_map;
+mod cleanup;
 mod connection_seed;
 mod exp;
 mod exp_bitwise;

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -37,6 +37,7 @@ mod query;
 mod scan;
 #[cfg(feature = "serialization")]
 mod serialization;
+mod connection_seed;
 mod task;
 mod truncate;
 mod udf;

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -24,6 +24,7 @@ mod batch;
 mod cdt_bitwise;
 mod cdt_list;
 mod cdt_map;
+mod connection_seed;
 mod exp;
 mod exp_bitwise;
 mod exp_hll;
@@ -37,7 +38,6 @@ mod query;
 mod scan;
 #[cfg(feature = "serialization")]
 mod serialization;
-mod connection_seed;
 mod task;
 mod truncate;
 mod udf;

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -794,6 +794,36 @@ async fn query_operate_scan_all() {
     client.close().await.unwrap();
 }
 
+#[aerospike_macro::test]
+async fn query_operate_empty_ops_returns_parameter_error() {
+    let client = common::client().await;
+    let namespace = common::namespace();
+    let set_name = &common::rand_str(10);
+
+    let wpolicy = WritePolicy::default();
+    let statement = Statement::new(namespace, set_name, Bins::All);
+
+    // Calling query_operate with no operations must be rejected client-side
+    // with a ParameterError before any server fan-out. We verify the message
+    // contains "no operations" so the assertion would not be satisfied by an
+    // accidental server-returned ParameterError (server fills the node addr
+    // in that field instead).
+    let result = client.query_operate(&wpolicy, statement, &[]).await;
+
+    match result {
+        Err(Error::ServerError(ResultCode::ParameterError, _, ref msg))
+            if msg.contains("no operations") => {}
+        Err(other) => panic!(
+            "expected client-side ParameterError ('query_operate called with no \
+             operations'); got {:?}",
+            other
+        ),
+        Ok(_) => panic!("expected ParameterError, got Ok"),
+    }
+
+    client.close().await.unwrap();
+}
+
 // ============================================================================
 // Filter::equal_by_index — equality filter targeting a named secondary index
 // ============================================================================

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -1331,3 +1331,117 @@ async fn query_filter_expression_with_policy_filter() {
 
     client.close().await.unwrap();
 }
+
+#[aerospike_macro::test]
+async fn test_short_query_not_tracked() {
+    let client = common::client().await;
+    let ns = common::namespace();
+    // Use a unique per-run set name so we can filter `query-show` to only
+    // entries from this test, and avoid clashing with concurrent tests.
+    let set_owned = format!("short_q_bug_{}", common::rand_str(10));
+    let set: &str = &set_owned;
+    let bin_name = "val";
+    let num_records: i64 = 100;
+
+    let wp = WritePolicy::default();
+    let ap = AdminPolicy::default();
+
+    // Load test data
+    // println!(
+    //     "\n[SETUP] Loading {} records into {}.{}",
+    //     num_records, ns, set
+    // );
+    for i in 0..num_records {
+        let key = as_key!(ns, set, i);
+        let bins = vec![as_bin!(bin_name, i)];
+        client.put(&wp, &key, &bins).await.unwrap();
+    }
+
+    // Set query-max-done to 100 so completed queries are tracked
+    // println!("[SETUP] Setting query-max-done=100 on all nodes");
+    let nodes = client.nodes();
+    for node in &nodes {
+        let set_cfg_cmd: &str = "set-config:context=service;query-max-done=100";
+        let _ = node.info(&ap, &vec![set_cfg_cmd]).await;
+    }
+    aerospike_rt::sleep(Duration::from_secs(1)).await;
+
+    // Clear any stale tracked queries: set to 0, wait, set back to 100
+    for node in &nodes {
+        let reset_cmd: &str = "set-config:context=service;query-max-done=0";
+        let _ = node.info(&ap, &vec![reset_cmd]).await;
+    }
+    aerospike_rt::sleep(Duration::from_millis(500)).await;
+    for node in &nodes {
+        let set_cmd: &str = "set-config:context=service;query-max-done=100";
+        let _ = node.info(&ap, &vec![set_cmd]).await;
+    }
+    aerospike_rt::sleep(Duration::from_millis(500)).await;
+
+    // ──────────────────────────────────────────────────────────────
+    // Test: PI query (no filter) with QueryDuration::Short
+    //         Server should NOT track this in query-show
+    // ──────────────────────────────────────────────────────────────
+    // println!("\n[TEST 1] PI query with QueryDuration::Short (Rust partition-based)");
+    {
+        let mut qpolicy = QueryPolicy::default();
+        qpolicy.expected_duration = QueryDuration::Short;
+
+        let stmt = Statement::new(ns, set, Bins::All);
+        let pf = PartitionFilter::all();
+
+        let rs = client.query(&qpolicy, pf, stmt).await.unwrap();
+        let mut rs = rs.into_stream();
+        let mut count = 0;
+        while let Some(res) = rs.next().await {
+            match res {
+                Ok(_) => count += 1,
+                Err(err) => panic!("  Error: {:?}", err),
+            }
+        }
+        // println!("  Returned {} records", count);
+        assert_eq!(
+            count, num_records,
+            "Expected {} records, but got {}",
+            num_records, count
+        );
+    }
+    aerospike_rt::sleep(Duration::from_millis(500)).await;
+
+    // Check query-show for tracked queries belonging to *this* test only.
+    // `query-show` returns server-wide tracked queries; concurrent tests
+    // running long queries (the default duration) would otherwise pollute
+    // this count and make the assertion flaky in parallel runs.
+    let set_marker = format!(":set={}", set);
+    let mut total_tracked = 0;
+    for node in &nodes {
+        let result = node.info(&ap, &vec!["query-show"]).await;
+        match result {
+            Ok(info_map) => {
+                for (_, value) in &info_map {
+                    if !value.is_empty() && value != "ok" {
+                        for entry in value.split(';').filter(|s| !s.is_empty()) {
+                            if entry.contains(&set_marker) {
+                                total_tracked += 1;
+                            }
+                        }
+                    }
+                }
+            }
+            Err(e) => panic!("  Info error: {:?}", e),
+        }
+    }
+
+    // println!(
+    //     "\n[RESULT 1] Total tracked queries after SHORT pi_query: {}",
+    //     total_tracked
+    // );
+
+    client.close().await.unwrap();
+
+    assert_eq!(
+        total_tracked, 0,
+        "QueryDuration::Short should not be tracked by the server's query monitor; \
+         got {total_tracked} tracked entries — set_scan likely failed to set INFO1_SHORT_QUERY"
+    );
+}

--- a/tools/benchmark/Cargo.toml
+++ b/tools/benchmark/Cargo.toml
@@ -11,14 +11,14 @@ rust-version = "1.87"
 
 [dependencies]
 chrono = "0.4"
-clap = "2.33"
+clap = "4.6"
 log = "0.4"
-env_logger = "0.9"
-lazy_static = "1.4"
-rand = { version = "0.8", features = ["getrandom", "small_rng"] }
+env_logger = "0.11"
+lazy_static = "1.5"
+rand = { version = "0.10" }
 aerospike = { path = "../.." }
 # Minimal features to reduce Tokio task heap and binary size (no fs, process, signal, etc.)
-tokio = { version = "1.0", features = ["rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1.52", features = ["rt-multi-thread", "sync", "time", "macros"] }
 
 [[bin]]
 path = "src/main.rs"


### PR DESCRIPTION

* **Bug Fixes**
  * [CLIENT-4711] `close()` does not stop the `tend_thread`.
  * [CLIENT-4685] Reject `operate` calls with empty ops list.
  * [CLIENT-4686] Fix unexpected behavior for partition-based query with `QueryDuration::Short`.
  * [CLIENT-4405] Execute query failing during node churn (#195)
    * Check node active status before selecting node for partition.
    * State to remember last tried node for a partition retry.
    * added drop trait for node, to close node eventually and removed all weak ref to Arc node for last tried node
    * Check for node active status before returning a connection. Drain the conn pool on Node drop.
    * Removed deprecated `try_next`.
    * Change default policy for `max-retries` to `0` for writes, honoring `max-retries=0` as no retries.
    * Change policy to sequence for write/delete commands.

* **Improvements**
  * Update all dependencies to the latest, and adapt the code to the deprecation and removals.
  * Adds a cleanup test that is ignored by default.
    Can be manually invoked to remove indexes and then truncate of the tested namespace

[CLIENT-4685]: https://aerospike.atlassian.net/browse/CLIENT-4685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-4686]: https://aerospike.atlassian.net/browse/CLIENT-4686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLIENT-4405]: https://aerospike.atlassian.net/browse/CLIENT-4405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CLIENT-4711]: https://aerospike.atlassian.net/browse/CLIENT-4711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ