### PR TITLE
CLIENT-4891 fix MessagePack string encoding for str8 range

### DIFF
--- a/aerospike-core/src/expressions/mod.rs
+++ b/aerospike-core/src/expressions/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Aerospike, Inc.
+// Copyright 2015-2026 Aerospike, Inc.
 //
 // Portions may be licensed to Aerospike, Inc. under one or more contributor
 // license agreements.
@@ -2043,6 +2043,31 @@ mod tests {
         let decoded = from_base64(&b64).unwrap();
         assert_eq!(b64, decoded.base64().unwrap());
     }
+
+    #[test]
+    fn string_pack_roundtrip() {
+        let literal = "b".repeat(31);
+
+        let expr = eq(string_bin("a".to_string()), string_val(literal.clone()));
+        let b64 = expr.base64().unwrap();
+        let decoded = from_base64(&b64).unwrap();
+        let decoded_b64 = decoded.base64().unwrap();
+        let bytes = decoded.bytes.unwrap();
+
+        assert!(
+            bytes.windows(3).any(|w| w == [0xd9, 0x20, 0x03]),
+            "expected str8 prefix 0xd9 0x20 then STRING 0x03; got: {:02x?}",
+            bytes
+        );
+        assert!(
+            !bytes.windows(4).any(|w| w == [0xda, 0x00, 0x20, 0x03]),
+            "must not use str16 0xda 0x00 0x20 for length 32; got: {:02x?}",
+            bytes
+        );
+
+        assert_eq!(b64, decoded_b64);
+    }
+
 }
 
 // ===== Path Expression helpers =====

--- a/aerospike-core/src/msgpack/encoder.rs
+++ b/aerospike-core/src/msgpack/encoder.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2020 Aerospike, Inc.
+// Copyright 2015-2026 Aerospike, Inc.
 //
 // Portions may be licensed to Aerospike, Inc. under one or more contributor
 // license agreements.
@@ -333,6 +333,8 @@ pub fn pack_array_begin(buf: &mut Option<&mut Buffer>, length: usize) -> usize {
 pub fn pack_string_begin(buf: &mut Option<&mut Buffer>, length: usize) -> usize {
     if length < 32 {
         pack_half_byte(buf, 0xa0 | (length as u8))
+    } else if length < 256 {
+        pack_type_u8(buf, 0xd9, length as u8)
     } else if length < 1 << 16 {
         pack_type_u16(buf, 0xda, length as u16)
     } else {
@@ -430,6 +432,15 @@ pub fn pack_integer(buf: &mut Option<&mut Buffer>, value: i64) -> usize {
         9
     }
 }
+
+pub fn pack_type_u8(buf: &mut Option<&mut Buffer>, marker: u8, value: u8) -> usize {
+    if let Some(ref mut buf) = *buf {
+        buf.write_u8(marker);
+        buf.write_u8(value);
+    }
+    2
+}
+
 pub fn pack_type_u16(buf: &mut Option<&mut Buffer>, marker: u8, value: u16) -> usize {
     if let Some(ref mut buf) = *buf {
         buf.write_u8(marker);


### PR DESCRIPTION
For str8 range, the encoding is supposed to be `0xd9` followed by the length. This matches to how it is done in Java SDK or C/GO clients.

ref: https://github.com/aerospike/aerospike-client-java-sdk/blob/35ed5d3dacd802d4a1a43b68a864e32b4ac6bcc4/client/src/main/java/com/aerospike/client/sdk/util/Packer.java#L515-L517