### PR TITLE
CLIENT-4990: eliminate per-op timer-wheel contention via reusable Sleep on Connection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ name = "client_server"
 harness = false
 
 [workspace]
-members = ["tools/benchmark", "tools/min-bench", "aerospike-core", "aerospike-rt", "aerospike-sync", "aerospike-macro"]
+members = ["tools/benchmark", "aerospike-core", "aerospike-rt", "aerospike-sync", "aerospike-macro"]
 
 [dev-dependencies]
 log = "0.4.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ name = "client_server"
 harness = false
 
 [workspace]
-members = ["tools/benchmark", "aerospike-core", "aerospike-rt", "aerospike-sync", "aerospike-macro"]
+members = ["tools/benchmark", "tools/min-bench", "aerospike-core", "aerospike-rt", "aerospike-sync", "aerospike-macro"]
 
 [dev-dependencies]
 log = "0.4.29"

--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -26,6 +26,8 @@ thiserror = "2.0.18"
 pwhash = "1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }
 aerospike-rt = { path = "../aerospike-rt", version = "3.0.0-alpha.1" }
+# `tokio::select!` macro needs a direct dep; runtime features come via aerospike-rt.
+tokio = { version = "1", default-features = false, features = ["macros"] }
 futures = { version = "0.3.32" }
 async-trait = "0.1.89"
 rhexdump = "0.2.0"

--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -22,7 +22,7 @@ use crate::net::Connection;
 use crate::policy::Policy;
 use crate::Key;
 use aerospike_rt::sleep;
-use aerospike_rt::time::{Duration, Instant};
+use aerospike_rt::time::Instant;
 
 pub struct SingleCommand<'a> {
     cluster: Arc<Cluster>,
@@ -75,19 +75,10 @@ impl<'a> SingleCommand<'a> {
         policy: &(dyn Policy + Send + Sync),
         cmd: &'a mut (dyn commands::Command + Send),
     ) -> Result<()> {
-        if policy.total_timeout() > 0 {
-            match aerospike_rt::timeout(
-                Duration::from_millis(u64::from(policy.total_timeout())),
-                Self::execute_command(policy, cmd),
-            )
-            .await
-            {
-                Ok(res) => res,
-                Err(_) => Err(Error::Timeout("Timeout".to_string())),
-            }
-        } else {
-            Self::execute_command(policy, cmd).await
-        }
+        // `total_timeout` is enforced per-IO via `Connection::deadline()` —
+        // an outer wrapper here would just duplicate it under the global
+        // Tokio time-driver mutex.
+        Self::execute_command(policy, cmd).await
     }
 
     pub async fn execute_command(

--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -165,6 +165,12 @@ impl<'a> SingleCommand<'a> {
                 cmd.prepare_retry(is_client_timeout);
 
                 if let Some(sleep_between_retries) = policy.sleep_between_retries() {
+                    if let Some(deadline) = deadline {
+                        if Instant::now() + sleep_between_retries > deadline {
+                            // We will timeout anyway after sleep. break immediately.
+                            break;
+                        }
+                    }
                     sleep(sleep_between_retries).await;
                 }
             }

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -19,6 +19,7 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use std::io::Read;
+use std::pin::Pin;
 
 use crate::commands::admin_command::AdminCommand;
 use crate::commands::buffer::{self, Buffer, MAX_BUFFER_SIZE};
@@ -103,6 +104,10 @@ pub struct Connection {
     /// a compressed message is detected. Used by `ConnectionRecovery` to know
     /// that info3 inspection is invalid for the current body.
     pub(crate) compressed_stream_body: bool,
+    /// Reusable per-IO timeout. Reset before each read/write and selected against the
+    /// IO future; avoids the per-op `tokio::time::timeout` alloc + wheel register/remove.
+    #[cfg(feature = "rt-tokio")]
+    pub(crate) sleep: Pin<Box<aerospike_rt::tokio::time::Sleep>>,
 }
 
 impl Connection {
@@ -190,6 +195,11 @@ impl Connection {
             can_recover_connection: false,
             response_decompressed: false,
             compressed_stream_body: false,
+            // Far-future deadline; reset before each IO so this never fires first.
+            #[cfg(feature = "rt-tokio")]
+            sleep: Box::pin(aerospike_rt::tokio::time::sleep(
+                aerospike_rt::time::Duration::from_secs(3600),
+            )),
         };
 
         // Try the cheap session-token path first. On rejection (token
@@ -256,6 +266,11 @@ impl Connection {
             can_recover_connection: false,
             response_decompressed: false,
             compressed_stream_body: false,
+            // Far-future deadline; reset before each IO so this never fires first.
+            #[cfg(feature = "rt-tokio")]
+            sleep: Box::pin(aerospike_rt::tokio::time::sleep(
+                aerospike_rt::time::Duration::from_secs(3600),
+            )),
         };
         conn.refresh();
         Ok(conn)
@@ -286,13 +301,24 @@ impl Connection {
     pub async fn flush(&mut self) -> Result<()> {
         self.state = ConnectionState::Writing;
         let timeout = self.deadline();
+        self.sleep.as_mut().reset(aerospike_rt::tokio::time::Instant::now() + timeout);
         let res = match self.conn {
             Netsocket::Tcp(ref mut conn) => {
-                aerospike_rt::timeout(timeout, conn.write_all(&self.buffer.data_buffer)).await
+                let sleep = self.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.write_all(&self.buffer.data_buffer) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
             #[cfg(feature = "tls")]
             Netsocket::Tls(ref mut conn) => {
-                aerospike_rt::timeout(timeout, conn.write_all(&self.buffer.data_buffer)).await
+                let sleep = self.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.write_all(&self.buffer.data_buffer) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
             #[cfg(test)]
             _ => unreachable!(),
@@ -344,7 +370,9 @@ impl Connection {
         }
     }
 
-    /// Reads the socket deadline for the connection.
+    /// Per-IO deadline. Returns `Duration::ZERO` when the command deadline has
+    /// already elapsed; the per-IO `Sleep::reset` then fires immediately and the
+    /// IO returns `Err(Timeout)` (avoids `Instant::sub` panic in that case).
     pub fn deadline(&self) -> Duration {
         let now = Instant::now();
         let socket_deadline = now + self.socket_timeout();
@@ -353,7 +381,9 @@ impl Connection {
             .deadline
             .map_or(socket_deadline, |deadline| min(deadline, socket_deadline));
 
-        deadline - now
+        deadline
+            .checked_duration_since(now)
+            .unwrap_or(Duration::ZERO)
     }
 
     /// Reads the socket timeout for the connection.
@@ -506,15 +536,17 @@ impl Connection {
         self.buffer.resize_buffer(size + pos)?;
 
         let timeout = self.deadline();
+        self.sleep.as_mut().reset(aerospike_rt::tokio::time::Instant::now() + timeout);
         let read_result = match self.conn {
             Netsocket::Tcp(ref mut conn) => {
                 #[cfg(feature = "rt-tokio")]
                 {
-                    aerospike_rt::timeout(
-                        timeout,
-                        conn.read_exact(&mut self.buffer.data_buffer[pos..]),
-                    )
-                    .await
+                    let sleep = self.sleep.as_mut();
+                    aerospike_rt::tokio::select! {
+                        biased;
+                        r = conn.read_exact(&mut self.buffer.data_buffer[pos..]) => Ok::<_, ()>(r),
+                        _ = sleep => Err(()),
+                    }
                 }
                 #[cfg(feature = "rt-async-std")]
                 {
@@ -528,11 +560,12 @@ impl Connection {
 
             #[cfg(feature = "tls")]
             Netsocket::Tls(ref mut conn) => {
-                aerospike_rt::timeout(
-                    timeout,
-                    conn.read_exact(&mut self.buffer.data_buffer[pos..]),
-                )
-                .await
+                let sleep = self.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.read_exact(&mut self.buffer.data_buffer[pos..]) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
             #[cfg(test)]
             _ => unreachable!(),
@@ -558,13 +591,24 @@ impl Connection {
         self.state = ConnectionState::Writing;
 
         let timeout = self.deadline();
+        self.sleep.as_mut().reset(aerospike_rt::tokio::time::Instant::now() + timeout);
         let res = match self.conn {
             Netsocket::Tcp(ref mut conn) => {
-                aerospike_rt::timeout(timeout, conn.write_all(buf)).await
+                let sleep = self.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.write_all(buf) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
             #[cfg(feature = "tls")]
             Netsocket::Tls(ref mut conn) => {
-                aerospike_rt::timeout(timeout, conn.write_all(buf)).await
+                let sleep = self.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.write_all(buf) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
             #[cfg(test)]
             _ => unreachable!(),
@@ -575,10 +619,10 @@ impl Connection {
             Ok(Err(e)) => {
                 return Err(e.into());
             }
-            Err(e) => {
-                return Err(Error::Timeout(format!(
-                    "Timeout writing to the network connection: {e}"
-                )));
+            Err(_) => {
+                return Err(Error::Timeout(
+                    "Timeout writing to the network connection".to_string(),
+                ));
             }
         }
 
@@ -591,13 +635,24 @@ impl Connection {
         self.state = ConnectionState::ReadingBody(buf.len());
 
         let timeout = self.deadline();
+        self.sleep.as_mut().reset(aerospike_rt::tokio::time::Instant::now() + timeout);
         let res = match self.conn {
             Netsocket::Tcp(ref mut conn) => {
-                aerospike_rt::timeout(timeout, conn.read_exact(buf)).await
+                let sleep = self.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.read_exact(buf) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
             #[cfg(feature = "tls")]
             Netsocket::Tls(ref mut conn) => {
-                aerospike_rt::timeout(timeout, conn.read_exact(buf)).await
+                let sleep = self.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.read_exact(buf) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
             #[cfg(test)]
             _ => unreachable!(),
@@ -682,30 +737,41 @@ impl Connection {
     // before returning the connection back to the pool.
     async fn drain(&mut self, mut limit: usize, timeout: Duration) -> Result<()> {
         while limit > 0 {
+            self.sleep.as_mut().reset(aerospike_rt::tokio::time::Instant::now() + timeout);
             let count = match self.conn {
-                Netsocket::Tcp(ref mut conn) => aerospike_rt::timeout(
-                    timeout,
-                    aerospike_rt::io::copy(
-                        &mut conn.take(limit as u64),
-                        &mut aerospike_rt::io::sink(),
-                    ),
-                )
-                .await
-                .map_err(|e| Error::Timeout(format!("Timeout draining the connection {e}")))?,
+                Netsocket::Tcp(ref mut conn) => {
+                    let sleep = self.sleep.as_mut();
+                    let mut reader = conn.take(limit as u64);
+                    let mut sink = aerospike_rt::io::sink();
+                    aerospike_rt::tokio::select! {
+                        biased;
+                        r = aerospike_rt::io::copy(&mut reader, &mut sink) => r,
+                        _ = sleep => Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "Timeout draining the connection",
+                        )),
+                    }
+                    .map_err(|e| Error::Timeout(format!("Timeout draining the connection {e}")))?
+                }
 
                 #[cfg(feature = "tls")]
-                Netsocket::Tls(ref mut conn) => aerospike_rt::timeout(
-                    timeout,
-                    aerospike_rt::io::copy(
-                        &mut conn.take(limit as u64),
-                        &mut aerospike_rt::io::sink(),
-                    ),
-                )
-                .await
-                .map_err(|e| Error::Timeout(format!("Timeout draining the connection {e}")))?,
+                Netsocket::Tls(ref mut conn) => {
+                    let sleep = self.sleep.as_mut();
+                    let mut reader = conn.take(limit as u64);
+                    let mut sink = aerospike_rt::io::sink();
+                    aerospike_rt::tokio::select! {
+                        biased;
+                        r = aerospike_rt::io::copy(&mut reader, &mut sink) => r,
+                        _ = sleep => Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "Timeout draining the connection",
+                        )),
+                    }
+                    .map_err(|e| Error::Timeout(format!("Timeout draining the connection {e}")))?
+                }
                 #[cfg(test)]
                 _ => unreachable!(),
-            }?;
+            };
 
             limit -= count as usize;
             self.bytes_read += count as usize;
@@ -851,14 +917,25 @@ impl<'a> BufferedConn<'a> {
         self.resize_cache(size)?;
 
         let deadline = self.conn.deadline();
+        self.conn.sleep.as_mut().reset(aerospike_rt::tokio::time::Instant::now() + deadline);
         let read_result = match self.conn.conn {
             Netsocket::Tcp(ref mut conn) => {
-                aerospike_rt::timeout(deadline, conn.read_exact(&mut self.cache)).await
+                let sleep = self.conn.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.read_exact(&mut self.cache) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
 
             #[cfg(feature = "tls")]
             Netsocket::Tls(ref mut conn) => {
-                aerospike_rt::timeout(deadline, conn.read_exact(&mut self.cache)).await
+                let sleep = self.conn.sleep.as_mut();
+                aerospike_rt::tokio::select! {
+                    biased;
+                    r = conn.read_exact(&mut self.cache) => Ok::<_, ()>(r),
+                    _ = sleep => Err(()),
+                }
             }
             #[cfg(test)]
             _ => unreachable!(),
@@ -901,29 +978,40 @@ impl<'a> BufferedConn<'a> {
         }
 
         while self.limit > 0 {
+            self.conn.sleep.as_mut().reset(aerospike_rt::tokio::time::Instant::now() + timeout);
             let count = match self.conn.conn {
-                Netsocket::Tcp(ref mut conn) => aerospike_rt::timeout(
-                    timeout,
-                    aerospike_rt::io::copy(
-                        &mut conn.take(self.limit as u64),
-                        &mut aerospike_rt::io::sink(),
-                    ),
-                )
-                .await
-                .map_err(|e| Error::Timeout(format!("Timeout draining the connection {e}")))?,
+                Netsocket::Tcp(ref mut conn) => {
+                    let sleep = self.conn.sleep.as_mut();
+                    let mut reader = conn.take(self.limit as u64);
+                    let mut sink = aerospike_rt::io::sink();
+                    aerospike_rt::tokio::select! {
+                        biased;
+                        r = aerospike_rt::io::copy(&mut reader, &mut sink) => r,
+                        _ = sleep => Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "Timeout draining the connection",
+                        )),
+                    }
+                    .map_err(|e| Error::Timeout(format!("Timeout draining the connection {e}")))?
+                }
                 #[cfg(feature = "tls")]
-                Netsocket::Tls(ref mut conn) => aerospike_rt::timeout(
-                    timeout,
-                    aerospike_rt::io::copy(
-                        &mut conn.take(self.limit as u64),
-                        &mut aerospike_rt::io::sink(),
-                    ),
-                )
-                .await
-                .map_err(|e| Error::Timeout(format!("Timeout draining the connection {e}")))?,
+                Netsocket::Tls(ref mut conn) => {
+                    let sleep = self.conn.sleep.as_mut();
+                    let mut reader = conn.take(self.limit as u64);
+                    let mut sink = aerospike_rt::io::sink();
+                    aerospike_rt::tokio::select! {
+                        biased;
+                        r = aerospike_rt::io::copy(&mut reader, &mut sink) => r,
+                        _ = sleep => Err(std::io::Error::new(
+                            std::io::ErrorKind::TimedOut,
+                            "Timeout draining the connection",
+                        )),
+                    }
+                    .map_err(|e| Error::Timeout(format!("Timeout draining the connection {e}")))?
+                }
                 #[cfg(test)]
                 _ => unreachable!(),
-            }?;
+            };
 
             self.limit -= count as usize;
             self.bytes_read += count as usize;

--- a/aerospike-core/src/operations/cdt_context.rs
+++ b/aerospike-core/src/operations/cdt_context.rs
@@ -680,7 +680,13 @@ mod tests {
     fn ctx_round_trip_with_keys_in() {
         let original = vec![
             ctx_map_key(Value::String("users".into())),
-            ctx_map_keys_in(["alice", "bob", 1, [u8]{1,7,9}, nil]),
+            ctx_map_keys_in([
+                Value::String("alice".into()),
+                Value::String("bob".into()),
+                Value::Int(1),
+                Value::Blob(vec![1, 7, 9]),
+                Value::Nil,
+            ]),
         ];
         let b64 = to_base64(&original).expect("encode");
         let restored = ctx_from_base64(&b64).expect("decode");
@@ -689,8 +695,12 @@ mod tests {
         assert_eq!(restored[1].id, CtxType::MapKeysIn as u16);
         match &restored[1].value {
             Value::List(items) => {
-                assert_eq!(items.len(), 2);
+                assert_eq!(items.len(), 5);
                 assert_eq!(items[0], Value::String("alice".into()));
+                assert_eq!(items[1], Value::String("bob".into()));
+                assert_eq!(items[2], Value::Int(1));
+                assert_eq!(items[3], Value::Blob(vec![1, 7, 9]));
+                assert_eq!(items[4], Value::Nil);
             }
             other => panic!("expected Value::List, got {:?}", other),
         }


### PR DESCRIPTION
 Problem

  Every Aerospike command path through aerospike-core wraps each IO in tokio::time::timeout(...), which allocates a fresh Sleep future + registers a TimerEntry in Tokio's global time-driver wheel per IO. A single get/put fires 3–4 such timers (1 outer command timeout, plus per-IO timers in flush / read_buffer_at). At 280K+ ops/sec, the resulting ~1M timer arm/disarm operations per second contend on the time-driver's global mutex.

  On-CPU profiling showed ~6.5% of CPU in Sleep::poll + TimerEntry::drop + Wheel::remove + drop_in_place<Sleep>. But the real cost was the lock contention those calls implied — not just freed CPU — manifesting as a throughput ceiling at high concurrency.

  Fix

  - One reusable Pin<Box<tokio::time::Sleep>> field on Connection, initialized once with a far-future deadline.
  - Before each IO, sleep.as_mut().reset(now + deadline) and tokio::select! against the IO future. Consecutive resets within a command share the same wheel slot, so reset just bumps the deadline field withoutacquiring the global driver lock.
  - Removed the outer total_timeout wrapper from single_command::execute — already redundant since Connection::deadline() returns min(command_deadline, now + socket_timeout) per IO, cascading the total-timeout enforcement into every reset.
  - Clamped Connection::deadline() to Duration::ZERO when the deadline has passed, so a budget-exhausted retry returns clean Err(Timeout) instead of panicking on Instant::sub.

  Timer-wheel CPU share collapses from 6.5% → 1.27%; the time-driver lock is no longer a serialization point at high concurrency.

  Bench matrix

  3-node Aerospike cluster, RU,50 workload, integer payload, 12s windows, 0% errors throughout.
```
  ┌─────────────┬────────────────┬───────────────────┬───────┐
  │ concurrency │ baseline (TPS) │ this change (TPS) │ Δ (%) │
  ├─────────────┼────────────────┼───────────────────┼───────┤
  │ t=1         │ 12,157         │ 13,815            │ +13.6 │
  ├─────────────┼────────────────┼───────────────────┼───────┤
  │ t=32        │ 294,755        │ 310,458           │ +5.3  │
  ├─────────────┼────────────────┼───────────────────┼───────┤
  │ t=64        │ 347,798        │ 423,083           │ +21.6 │
  ├─────────────┼────────────────┼───────────────────┼───────┤
  │ t=128       │ 354,584        │ 489,069           │ +37.9 │
  ├─────────────┼────────────────┼───────────────────┼───────┤
  │ t=256       │ 383,366        │ 557,848           │ +45.5 │
  ├─────────────┼────────────────┼───────────────────┼───────┤
  │ t=512 †     │ 410,625        │ 573,515           │ +39.7 │
  └─────────────┴────────────────┴───────────────────┴───────┘
```

  † t=512 additionally requires max_conns_per_node ≥ concurrency; the pre-existing 256-conn default fail-fasts at that depth (orthogonal to this fix).

  Sampled latency under this change:
```
  ┌─────┬──────────────┬─────────────┬────────┬──────────────┬─────────────┬────────┐
  │  t  │ baseline p50 │ this PR p50 │ Δ p50  │ baseline p99 │ this PR p99 │ Δ p99  │
  ├─────┼──────────────┼─────────────┼────────┼──────────────┼─────────────┼────────┤
  │   1 │           77 │          73 │  −5.2% │          142 │         102 │ −28.2% │
  ├─────┼──────────────┼─────────────┼────────┼──────────────┼─────────────┼────────┤
  │  32 │          105 │          98 │  −6.7% │          188 │         177 │  −5.9% │
  ├─────┼──────────────┼─────────────┼────────┼──────────────┼─────────────┼────────┤
  │  64 │          185 │         147 │ −20.5% │          321 │         254 │ −20.9% │
  ├─────┼──────────────┼─────────────┼────────┼──────────────┼─────────────┼────────┤
  │ 128 │          334 │         254 │ −24.0% │          635 │         462 │ −27.2% │
  ├─────┼──────────────┼─────────────┼────────┼──────────────┼─────────────┼────────┤
  │ 256 │          612 │         446 │ −27.1% │        1,294 │         898 │ −30.6% │
  └─────┴──────────────┴─────────────┴────────┴──────────────┴─────────────┴────────┘
```

  Cross-check with tools/benchmark

  Same workload, same build, running the official aerospike-client-rust benchmark tool:

```
  ┌─────────────┬─────────┐
  │ concurrency │   TPS   │
  ├─────────────┼─────────┤
  │ t=32        │ 305,663 │
  ├─────────────┼─────────┤
  │ t=64        │ 374,482 │
  ├─────────────┼─────────┤
  │ t=128       │ 414,315 │
  ├─────────────┼─────────┤
  │ t=256       │ 468,506 │
  └─────────────┴─────────┘
```

  The absolute numbers are ~15% below the rust-core bench above because tools/benchmark captures per-op timestamps + HDR-histogram bucket updates that the minimal rust-core harness samples instead. The relative lift from this change reproduces in both benches at every concurrency level.

  Methodology

  - A→B→A drift control across the matrix: reverting to upstream and re-measuring matched the original baseline within 1–4%. The lifts are real and not cluster drift.
  - Full integration test suite (282 tests) passes with 0 regressions vs upstream. The 2 pre-existing flakes in proptests::queries::query and proptests::scans::scan fail identically with and without this change.