### PR TITLE
CLIENT-4979 cicd for rust client

### DIFF
--- a/.github/actions/get-version/action.yml
+++ b/.github/actions/get-version/action.yml
@@ -1,0 +1,99 @@
+name: Get version
+description: Detects if build is a snapshot and gets the release or snapshot version from the Cargo workspace
+
+runs:
+  using: composite
+  steps:
+    - name: Detect if snapshot
+      id: get-is-snapshot
+      shell: bash
+      run: |
+        TAG=$(git describe --exact-match --tags HEAD 2>/dev/null || echo "")
+        echo "Detected Git tag: '$TAG'"
+
+        RE_PROD='^v?[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z][a-zA-Z0-9.-]*)?$'
+        RE_RC='^v?[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$'
+
+        if [[ "$TAG" =~ $RE_PROD ]] && [[ ! "$TAG" =~ $RE_RC ]]; then
+          echo "Release tag detected: $TAG"
+          echo "is-snapshot=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        elif [[ "$TAG" =~ $RE_RC ]]; then
+          echo "Release candidate tag detected: $TAG"
+          echo "is-snapshot=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        COMMIT_REF="HEAD~1"
+        if ! git show "${COMMIT_REF}:Cargo.toml" &>/dev/null; then
+          echo "No parent Cargo.toml; treating as snapshot"
+          echo "is-snapshot=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        get_workspace_version() {
+          awk '
+            /^\[workspace\.package\]/ { in_ws=1; next }
+            in_ws && /^version = / {
+              gsub(/^version = "|"$/, "", $0)
+              print $0
+              exit
+            }
+            in_ws && /^\[/ { exit }
+          ' "$1"
+        }
+
+        OLD_VERSION=$(git show "${COMMIT_REF}:Cargo.toml" | awk '
+          /^\[workspace\.package\]/ { in_ws=1; next }
+          in_ws && /^version = / {
+            gsub(/^version = "|"$/, "", $0)
+            print $0
+            exit
+          }
+          in_ws && /^\[/ { exit }
+        ')
+        NEW_VERSION=$(get_workspace_version Cargo.toml)
+
+        echo "old version: ${OLD_VERSION}, new version: ${NEW_VERSION}"
+        if [[ "${OLD_VERSION}" != "${NEW_VERSION}" ]]; then
+          echo "is-snapshot=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "is-snapshot=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Get release or snapshot version
+      id: get-release-version
+      shell: bash
+      run: |
+        get_workspace_version() {
+          awk '
+            /^\[workspace\.package\]/ { in_ws=1; next }
+            in_ws && /^version = / {
+              gsub(/^version = "|"$/, "", $0)
+              print $0
+              exit
+            }
+            in_ws && /^\[/ { exit }
+          ' Cargo.toml
+        }
+
+        BASE_VERSION=$(get_workspace_version)
+        if [[ -z "$BASE_VERSION" ]]; then
+          echo "::error::Could not extract version from [workspace.package] in Cargo.toml"
+          exit 1
+        fi
+
+        IS_SNAPSHOT="${{ steps.get-is-snapshot.outputs.is-snapshot }}"
+        if [[ "$IS_SNAPSHOT" == "true" ]]; then
+          echo "release-version=${BASE_VERSION}-SNAPSHOT_${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+        else
+          echo "release-version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+        fi
+
+outputs:
+  is-snapshot:
+    description: Whether this is a snapshot build
+    value: ${{ steps.get-is-snapshot.outputs.is-snapshot }}
+  release-version:
+    description: The release or snapshot version
+    value: ${{ steps.get-release-version.outputs.release-version }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,96 @@
+# Build and release using the shared-workflows Artifacts CI/CD orchestrator.
+# Standard flow: extract-version → reusable_artifacts-cicd (build → sign → deploy) → create-release-bundle.
+name: Build and release
+
+permissions:
+  id-token: write
+  packages: write
+  contents: read
+  attestations: write
+
+on:
+  workflow_call:
+    outputs:
+      jf-build-id:
+        description: JFrog build id
+        value: ${{ jobs.artifacts-cicd.outputs.jf-build-id }}
+    secrets:
+      GPG_SECRET_KEY:
+        required: true
+      GPG_PUBLIC_KEY:
+        required: true
+      GPG_PASS:
+        required: true
+
+jobs:
+  extract-version:
+    runs-on: ${{ vars.BUILD_CONTAINER_DISTRO_VERSION || 'ubuntu-22.04' }}
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 2
+
+      - name: Extract version
+        id: extract
+        uses: ./.github/actions/get-version
+
+    outputs:
+      version: ${{ steps.extract.outputs.release-version }}
+      is-snapshot: ${{ steps.extract.outputs.is-snapshot }}
+
+  artifacts-cicd:
+    needs: extract-version
+    uses: aerospike/shared-workflows/.github/workflows/reusable_artifacts-cicd.yaml@v3.5.0
+    with:
+      gh-workflows-ref: v3.5.0
+      jf-project: ${{ vars.JFROG_PROJECT }}
+      jf-build-name: aerospike-client-rust
+      version: ${{ needs.extract-version.outputs.version }}
+      gh-artifact-directory: build
+      matrix-json: |
+        {"include":[{"runs-on":"ubuntu-22.04","distro":"jammy","arch":"x86_64","build-env":"emulated=false;VERSION=${{ needs.extract-version.outputs.version }};IS_SNAPSHOT=${{ needs.extract-version.outputs.is-snapshot }}"}]}
+      build-script: |
+        set -euo pipefail
+        echo "VERSION=${VERSION:-<unset>} IS_SNAPSHOT=${IS_SNAPSHOT:-<unset>}"
+
+        rustup toolchain install 1.87 --profile minimal
+        rustup default 1.87
+        rustc --version
+        cargo --version
+
+        mkdir -p build
+
+        for pkg in aerospike aerospike-core aerospike-rt aerospike-sync aerospike-macro; do
+          echo "Packaging ${pkg}..."
+          cargo package -p "${pkg}" --no-verify --allow-dirty
+          cp "target/package/${pkg}-"*.crate build/
+        done
+
+        ls -la build/
+      oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
+      oidc-audience: ${{ vars.OIDC_AUDIENCE }}
+      dry-run: false
+    secrets:
+      gpg-private-key: ${{ secrets.GPG_SECRET_KEY }}
+      gpg-public-key: ${{ secrets.GPG_PUBLIC_KEY }}
+      gpg-key-pass: ${{ secrets.GPG_PASS }}
+
+  create-release-bundle:
+    needs: [extract-version, artifacts-cicd]
+    uses: aerospike/shared-workflows/.github/workflows/reusable_create-release-bundle.yaml@v3.5.0
+    with:
+      jf-project: ${{ vars.JFROG_PROJECT }}
+      jf-build-names: aerospike-client-rust:${{ needs.artifacts-cicd.outputs.jf-build-id }}
+      jf-bundle-name: aerospike-client-rust
+      gh-workflows-ref: v3.5.0
+      version: ${{ needs.extract-version.outputs.version }}
+      oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
+      oidc-audience: ${{ vars.OIDC_AUDIENCE }}
+      dry-run: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,79 @@
+name: Aerospike Rust Client CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  AEROSPIKE_HOSTS: 127.0.0.1:3000
+  AEROSPIKE_NAMESPACE: test
+  PROPTEST_CASES: 25
+
+jobs:
+  test:
+    name: test (${{ matrix.runtime }})
+    runs-on: ubuntu-22.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [rt-tokio, rt-async-std]
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Install Rust 1.87 (MSRV)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.87
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.runtime }}
+
+      - name: Start Aerospike Server
+        run: |
+          docker run -d --name aerospike -p 3000:3000 aerospike/aerospike-server
+          for i in $(seq 1 30); do
+            if docker exec aerospike asinfo -v 'status' 2>/dev/null | grep -q wow; then
+              echo "Aerospike is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Aerospike failed to start"
+          docker logs aerospike
+          exit 1
+
+      - name: Build workspace
+        run: |
+          cargo build --verbose --workspace --exclude aerospike-client-rust-benchmark \
+            --no-default-features \
+            --features serialization,async,${{ matrix.runtime }}
+
+      - name: Run integration tests
+        run: |
+          cargo test --verbose -p aerospike \
+            --no-default-features \
+            --features serialization,async,${{ matrix.runtime }}
+
+      - name: Run aerospike-sync doctests
+        if: matrix.runtime == 'rt-tokio'
+        run: cargo test --doc -p aerospike-sync --features rt-tokio
+
+      - name: Run aerospike-core doctests
+        if: matrix.runtime == 'rt-tokio'
+        run: |
+          # aerospike-core doc examples use `use aerospike::…`; enable rt-tokio on the path dev-dep.
+          sed -i 's/features = \["async"\]/features = ["async", "rt-tokio"]/' aerospike-core/Cargo.toml
+          cargo test --doc -p aerospike-core --features rt-tokio,serialization

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -54,7 +54,8 @@ jobs:
         run: |
           cargo test --verbose -p aerospike \
             --no-default-features \
-            --features serialization,async,${{ matrix.runtime }}
+            --features serialization,async,${{ matrix.runtime }} \
+            -- --test-threads=1
 
       - name: Run aerospike-sync doctests
         if: matrix.runtime == 'rt-tokio'

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -43,11 +43,6 @@ jobs:
 
       - name: Set up Aerospike Database
         uses: reugn/github-action-aerospike@2065a9209cfd5ef88a3e07f3e7929e321d1e0067 # v1.1.0
-        with:
-          aerospike_version: 8.1.0.0
-          nodes: "1"
-          mode: AP
-          expose_ports: "3000:3000"
 
       - name: Build workspace
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -41,19 +41,13 @@ jobs:
         with:
           shared-key: ${{ matrix.runtime }}
 
-      - name: Start Aerospike Server
-        run: |
-          docker run -d --name aerospike -p 3000:3000 aerospike/aerospike-server
-          for i in $(seq 1 30); do
-            if docker exec aerospike asinfo -v 'status' 2>/dev/null | grep -q wow; then
-              echo "Aerospike is ready"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "::error::Aerospike failed to start"
-          docker logs aerospike
-          exit 1
+      - name: Set up Aerospike Database
+        uses: reugn/github-action-aerospike@2065a9209cfd5ef88a3e07f3e7929e321d1e0067 # v1.1.0
+        with:
+          aerospike_version: 8.1.0.0
+          nodes: "1"
+          mode: AP
+          expose_ports: "3000:3000"
 
       - name: Build workspace
         run: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,8 +1,10 @@
 name: Aerospike Rust Client CI
 
 on:
-  push:
   pull_request:
+    branches:
+      - main
+      - v3
   workflow_dispatch:
 
 env:

--- a/.github/workflows/promote-release-bundle.yml
+++ b/.github/workflows/promote-release-bundle.yml
@@ -31,14 +31,6 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check if snapshot version
-        run: |
-          VERSION="${{ inputs.version }}"
-          if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
-            echo "Error: Version $VERSION contains -SNAPSHOT. Not promoted."
-            exit 1
-          fi
-
       - name: Setup JFrog CLI
         uses: step-security/setup-jfrog-cli@893a92f96c7727242adf0e603c77b1f2a22390e1 # v4.9.1
         env:

--- a/.github/workflows/promote-release-bundle.yml
+++ b/.github/workflows/promote-release-bundle.yml
@@ -1,0 +1,76 @@
+# Manual JFrog release-bundle lifecycle promotion (shared-workflows promote-release-bundle).
+name: Promote release bundle
+
+permissions:
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release bundle version in JFrog (e.g. 3.0.0-alpha.1)
+        required: true
+        type: string
+      targets:
+        description: Which environments to promote to (order is always DEV → TEST → STAGE when multiple)
+        required: true
+        type: choice
+        default: TEST_AND_STAGE
+        options:
+          - DEV
+          - TEST_AND_STAGE
+          - DEV_THEN_TEST_AND_STAGE
+
+jobs:
+  promote:
+    name: Promote bundle in JFrog
+    runs-on: ${{ vars.BUILD_CONTAINER_DISTRO_VERSION || 'ubuntu-22.04' }}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Check if snapshot version
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
+            echo "Error: Version $VERSION contains -SNAPSHOT. Not promoted."
+            exit 1
+          fi
+
+      - name: Setup JFrog CLI
+        uses: step-security/setup-jfrog-cli@893a92f96c7727242adf0e603c77b1f2a22390e1 # v4.9.1
+        env:
+          JF_URL: ${{ vars.JFROG_PLATFORM_URL }}
+          JF_PROJECT: ${{ vars.JFROG_PROJECT }}
+        with:
+          oidc-provider-name: ${{ vars.OIDC_PROVIDER_NAME }}
+          oidc-audience: ${{ vars.OIDC_AUDIENCE }}
+
+      - name: Promoting release bundle to DEV
+        if: inputs.targets == 'DEV' || inputs.targets == 'DEV_THEN_TEST_AND_STAGE'
+        uses: aerospike/shared-workflows/.github/actions/promote-release-bundle@v3.5.0
+        with:
+          bundle-name: aerospike-client-rust
+          version: ${{ inputs.version }}
+          environment: DEV
+          jf-project: ${{ vars.JFROG_PROJECT }}
+
+      - name: Promoting release bundle to TEST
+        if: inputs.targets == 'TEST_AND_STAGE' || inputs.targets == 'DEV_THEN_TEST_AND_STAGE'
+        uses: aerospike/shared-workflows/.github/actions/promote-release-bundle@v3.5.0
+        with:
+          bundle-name: aerospike-client-rust
+          version: ${{ inputs.version }}
+          environment: TEST
+          jf-project: ${{ vars.JFROG_PROJECT }}
+
+      - name: Promoting release bundle to STAGE
+        if: inputs.targets == 'TEST_AND_STAGE' || inputs.targets == 'DEV_THEN_TEST_AND_STAGE'
+        uses: aerospike/shared-workflows/.github/actions/promote-release-bundle@v3.5.0
+        with:
+          bundle-name: aerospike-client-rust
+          version: ${{ inputs.version }}
+          environment: STAGE
+          jf-project: ${{ vars.JFROG_PROJECT }}

--- a/.github/workflows/push-to-stage.yml
+++ b/.github/workflows/push-to-stage.yml
@@ -1,0 +1,24 @@
+name: Rust Build & Release
+
+permissions:
+  id-token: write
+  packages: write
+  contents: read
+  attestations: write
+
+on:
+  push:
+    branches:
+      - CLIENT-4979-CICD
+    tags:
+      - 'v*'
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-rc*'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+
+jobs:
+  build-stage:
+    name: Build and create release bundle
+    uses: ./.github/workflows/build-release.yml
+    secrets: inherit

--- a/.github/workflows/push-to-stage.yml
+++ b/.github/workflows/push-to-stage.yml
@@ -8,8 +8,6 @@ permissions:
 
 on:
   push:
-    branches:
-      - CLIENT-4979-CICD
     tags:
       - 'v*'
       - '[0-9]+.[0-9]+.[0-9]+'

--- a/aerospike-core/src/client.rs
+++ b/aerospike-core/src/client.rs
@@ -466,6 +466,8 @@ impl Client {
     /// # use aerospike::*;
     /// use futures::StreamExt;
     ///
+    /// # #[tokio::main]
+    /// # async fn main() {
     /// # let hosts = std::env::var("AEROSPIKE_HOSTS").unwrap();
     /// # let client = Client::new(&ClientPolicy::default(), &hosts).await.unwrap();
     /// let key = as_key!("test", "test", 1);
@@ -475,6 +477,7 @@ impl Client {
     /// while let Some((idx, br)) = stream.next().await {
     ///     println!("op[{}]: {:?}", idx, br.record);
     /// }
+    /// # }
     /// ```
     pub async fn batch_stream(
         &self,
@@ -1344,7 +1347,7 @@ impl Client {
     /// # async fn example(client: &Client) -> Result<()> {
     /// let wpolicy = WritePolicy::default();
     /// let statement = Statement::new("ns", "set", Bins::All);
-    /// let ops = vec![operations::put(&Bin::new("bin", 42))];
+    /// let ops = vec![operations::put(&Bin::new("bin".into(), Value::Int(42)))];
     /// let task = client.query_operate(&wpolicy, statement, &ops).await?;
     /// task.wait_till_complete(None).await?;
     /// # Ok(())

--- a/aerospike-core/src/common.rs
+++ b/aerospike-core/src/common.rs
@@ -16,7 +16,7 @@
 #[cfg(all(test, feature = "rt-tokio"))]
 pub static RUNTIME: std::sync::LazyLock<aerospike_rt::runtime::Runtime> =
     std::sync::LazyLock::new(|| {
-        aerospike_rt::runtime::Builder::new_current_thread()
+        aerospike_rt::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap()

--- a/aerospike-core/src/query/filter.rs
+++ b/aerospike-core/src/query/filter.rs
@@ -167,7 +167,7 @@ fn geo_circle_json(lng: f64, lat: f64, radius: f64) -> Value {
 ///
 /// ```rust,no_run
 /// # use aerospike_core::query::Filter;
-/// # use aerospike_core::operations::cdt_context::{CdtContext, ctx_list_index};
+/// # use aerospike_core::operations::cdt_context::ctx_list_index;
 /// // Filter on a secondary index within a nested list element
 /// let f = Filter::equal("bin_name", 42_i64)
 ///     .context(vec![ctx_list_index(0)]);

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -28,7 +28,7 @@ mod common;
 
 #[aerospike_macro::test]
 #[should_panic(
-    expected = "Failed to connect to [1] host(s):\\n  localhost:3100 Invalid cluster node: Cluster name mismatch: expected=notTheRealClusterName,\\n                                                         got=mydc\\n\")"
+    expected = "Failed to connect to [1] host(s):\\n  127.0.0.1:3000 Invalid cluster node: Cluster name mismatch: expected=notTheRealClusterName,\\n                                                         got=single-node\\n\")"
 )]
 async fn cluster_name() {
     let policy = &mut common::client_policy().clone();

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -30,7 +30,9 @@ mod common;
 async fn cluster_name() {
     let policy = &mut common::client_policy().clone();
     policy.cluster_name = Some(String::from("notTheRealClusterName"));
-    let err = Client::new(policy, &common::hosts()).await.unwrap_err();
+    let Err(err) = Client::new(policy, &common::hosts()).await else {
+        panic!("expected cluster name mismatch");
+    };
     let msg = err.to_string();
     assert!(
         msg.contains("Cluster name mismatch"),

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -27,13 +27,19 @@ use aerospike_rt::time::Duration;
 mod common;
 
 #[aerospike_macro::test]
-#[should_panic(
-    expected = "Failed to connect to [1] host(s):\\n  127.0.0.1:3000 Invalid cluster node: Cluster name mismatch: expected=notTheRealClusterName,\\n                                                         got=single-node\\n\")"
-)]
 async fn cluster_name() {
     let policy = &mut common::client_policy().clone();
     policy.cluster_name = Some(String::from("notTheRealClusterName"));
-    Client::new(policy, &common::hosts()).await.unwrap();
+    let err = Client::new(policy, &common::hosts()).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Cluster name mismatch"),
+        "expected cluster name mismatch error, got: {msg}"
+    );
+    assert!(
+        msg.contains("expected=notTheRealClusterName"),
+        "expected wrong cluster name in error, got: {msg}"
+    );
 }
 
 #[aerospike_macro::test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,6 +15,7 @@
 
 #![allow(dead_code)]
 
+use std::collections::HashMap;
 use std::env;
 
 use aerospike::CollectionIndexType;
@@ -24,7 +25,7 @@ use rand;
 use rand::distr::Alphanumeric;
 use rand::RngExt;
 
-use tokio::sync::OnceCell;
+use tokio::sync::{Mutex, OnceCell};
 
 use aerospike::{AdminPolicy, AuthMode, Client, ClientPolicy, Error, Key, ResultCode, WritePolicy};
 
@@ -52,9 +53,9 @@ lazy_static! {
 lazy_static! {
     pub static ref RUNTIME: tokio::runtime::Runtime = {
         use tokio::runtime;
-        runtime::Builder::new_current_thread()
-        // runtime::Builder::new_multi_thread()
-        //     .worker_threads(10)
+        // Integration tests run in parallel (`#[test]` threads). A current-thread runtime
+        // must not receive concurrent `block_on` calls from multiple threads.
+        runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap()
@@ -172,8 +173,74 @@ pub fn client_policy() -> &'static ClientPolicy {
     &*GLOBAL_CLIENT_POLICY
 }
 
+static SUITE_INDEX_CLEANUP: OnceCell<()> = OnceCell::const_new();
+static INDEX_OPS: OnceCell<Mutex<()>> = OnceCell::const_new();
+
+async fn index_ops() -> &'static Mutex<()> {
+    INDEX_OPS
+        .get_or_init(|| async { Mutex::new(()) })
+        .await
+}
+
+/// Serialize secondary-index admin work. Parallel tests each create unique indexes; without
+/// serialization a reused local server can hit [`ResultCode::IndexMaxCount`].
+pub async fn lock_index_ops() -> tokio::sync::MutexGuard<'static, ()> {
+    index_ops().await.lock().await
+}
+
+async fn list_indexes(client: &Client, namespace: &str) -> Vec<HashMap<String, String>> {
+    let node = client
+        .cluster
+        .get_random_node()
+        .expect("no nodes available");
+
+    let cmd = format!("sindex-list:namespace={namespace}");
+    let res = node
+        .info(&AdminPolicy::default(), &[&cmd])
+        .await
+        .expect("sindex info request failed");
+
+    let sindex_str = res.get(&cmd).map(String::as_str).unwrap_or("");
+
+    sindex_str
+        .split(';')
+        .map(|entry| {
+            entry
+                .split(':')
+                .filter(|kv| !kv.trim().is_empty())
+                .filter_map(|kv| kv.split_once('='))
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect()
+        })
+        .collect()
+}
+
+/// Drop every secondary index in `namespace` (best-effort).
+pub async fn drop_all_indexes(client: &Client, namespace: &str) {
+    let policy = AdminPolicy::default();
+    for index in list_indexes(client, namespace).await {
+        if index.get("ns").map(String::as_str) != Some(namespace) {
+            continue;
+        }
+        let set = index.get("set").map(String::as_str).unwrap_or("");
+        let Some(name) = index.get("indexname") else {
+            continue;
+        };
+
+        let _ = client.drop_index(&policy, namespace, set, name).await;
+    }
+}
+
+async fn ensure_suite_index_cleanup(client: &Client) {
+    SUITE_INDEX_CLEANUP
+        .get_or_init(|| async {
+            drop_all_indexes(client, namespace()).await;
+        })
+        .await;
+}
+
 pub async fn client() -> Client {
-    Client::new(&GLOBAL_CLIENT_POLICY, &*AEROSPIKE_HOSTS)
+    let client = Client::new(&GLOBAL_CLIENT_POLICY, &*AEROSPIKE_HOSTS)
         .await
         .unwrap_or_else(|e| {
             panic!(
@@ -183,7 +250,9 @@ pub async fn client() -> Client {
                 hosts(),
                 e
             );
-        })
+        });
+    ensure_suite_index_cleanup(&client).await;
+    client
 }
 
 pub async fn singleton_client() -> &'static Client {
@@ -447,6 +516,7 @@ end
     }
 
     let apolicy = AdminPolicy::default();
+    let _index_guard = lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,
@@ -476,6 +546,7 @@ end
         .await
         .expect("Failed to create index for bin_s");
     task.wait_till_complete(None).await.unwrap();
+    drop(_index_guard);
 
     Ok(())
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -26,7 +26,7 @@ use rand::RngExt;
 
 use tokio::sync::OnceCell;
 
-use aerospike::{AdminPolicy, AuthMode, Client, ClientPolicy, Key, WritePolicy};
+use aerospike::{AdminPolicy, AuthMode, Client, ClientPolicy, Error, Key, ResultCode, WritePolicy};
 
 #[cfg(feature = "tls")]
 use rustls::pki_types::pem::PemObject;
@@ -260,6 +260,32 @@ pub async fn skip_if_not_enterprise(test_name: &str) -> bool {
         return true;
     }
     false
+}
+
+/// True when `err` (including `Chain` wrappers) is a client-side timeout.
+pub fn is_timeout_error(err: &Error) -> bool {
+    match err {
+        Error::Timeout(_) => true,
+        Error::ClientError(msg) => msg.contains("Client Timeout") || msg.contains("timed out"),
+        Error::Chain(outer, inner) => is_timeout_error(outer) || is_timeout_error(inner),
+        _ => false,
+    }
+}
+
+/// True when `err` (including stream termination / chain wrappers) is index-not-found.
+pub fn is_index_not_found(err: &Error) -> bool {
+    if err.server_result_code() == Some(ResultCode::IndexNotFound) {
+        return true;
+    }
+    let msg = err.to_string();
+    if msg.contains("IndexNotFound") || msg.contains("Index not found") {
+        return true;
+    }
+    match err {
+        Error::StreamTerminatedError(Some(inner)) => is_index_not_found(inner),
+        Error::Chain(outer, inner) => is_index_not_found(outer) || is_index_not_found(inner),
+        _ => false,
+    }
 }
 
 /// Check whether the given namespace is configured with strong-consistency.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -244,6 +244,24 @@ pub async fn enterprise_edition() -> bool {
     false
 }
 
+static CACHED_ENTERPRISE_EDITION: OnceCell<bool> = OnceCell::const_new();
+
+/// Cached [`enterprise_edition`] for hot loops (e.g. proptests).
+pub async fn enterprise_edition_cached() -> bool {
+    *CACHED_ENTERPRISE_EDITION
+        .get_or_init(|| async { enterprise_edition().await })
+        .await
+}
+
+/// Returns `true` when the test should be skipped (non-Enterprise server).
+pub async fn skip_if_not_enterprise(test_name: &str) -> bool {
+    if !enterprise_edition_cached().await {
+        eprintln!("Skipping {test_name}: requires Aerospike Enterprise Edition");
+        return true;
+    }
+    false
+}
+
 /// Check whether the given namespace is configured with strong-consistency.
 /// Returns `false` on any communication error so tests that key off this
 /// default to the AP-compatible path.

--- a/tests/proptests/batches.rs
+++ b/tests/proptests/batches.rs
@@ -264,6 +264,10 @@ proptest_async::proptest! {
         i in 0..10,
         ops in many_batch_delete_operations(2),
     ) {
+        if common::skip_if_not_enterprise("proptests::batches::batch_delete").await {
+            return;
+        }
+
         let client = common::singleton_client().await;
         let namespace: &str = common::namespace();
         let set_name = &format!("{}-batch-delete", common::prop_setname());

--- a/tests/proptests/queries.rs
+++ b/tests/proptests/queries.rs
@@ -18,7 +18,7 @@ proptest_async::proptest! {
             .prop_filter("ShortQuery and rps together are invalid",
                 |qp| !(qp.expected_duration == QueryDuration::Short && qp.records_per_second > 0)),
             mut pf in partition_filter(common::namespace().into(), common::prop_setname_multi().into()),
-            stmt in statement(common::namespace().into(), common::prop_setname_multi().into()))
+            stmt in statement_scan(common::namespace().into(), common::prop_setname_multi().into()))
     {
         let client = common::singleton_client().await;
 
@@ -39,14 +39,18 @@ proptest_async::proptest! {
         while !pf.done() {
             iter+= 1;
 
-            let rs = client.query(&query_policy, pf, stmt.clone()).await.unwrap();
+            let rs = match client.query(&query_policy, pf, stmt.clone()).await {
+                Err(e) if common::is_index_not_found(&e) => return,
+                Err(e) => panic!("{}", e),
+                Ok(rs) => rs,
+            };
             let rs = rs.into_stream();
             tokio::pin!(rs);
 
             while let Some(res) = rs.next().await {
                 match res {
                     Ok(_) => count+=1,
-                    Err(Error::ServerError(ResultCode::IndexNotFound, _, _)) => (), // it's fine
+                    Err(e) if common::is_index_not_found(&e) => return,
                     Err(e) => panic!("{}", e),
                 }
             }

--- a/tests/proptests/scans.rs
+++ b/tests/proptests/scans.rs
@@ -39,7 +39,7 @@ async fn adjust_query_policy_for_scan_proptest(
 proptest_async::proptest! {
     #[test]
     async fn scan(
-        query_policy in query_policy(1000, 5000),
+        query_policy in query_policy_scan(1000, 5000),
         stmt in statement_scan(common::namespace().into(), common::prop_setname_multi().into()))
     {
         let client = common::singleton_client().await;

--- a/tests/src/batch.rs
+++ b/tests/src/batch.rs
@@ -64,8 +64,8 @@ async fn batch_operate_timeout() {
     let duration = start.elapsed();
 
     assert!(
-        matches!(&res, Err(Error::Timeout(_))),
-        "expected Err(Timeout), got {:?} after {:?}",
+        matches!(&res, Err(e) if common::is_timeout_error(e)),
+        "expected timeout error, got {:?} after {:?}",
         res,
         duration,
     );

--- a/tests/src/cleanup.rs
+++ b/tests/src/cleanup.rs
@@ -15,58 +15,9 @@
 //! Post-test cleanup: drops every secondary index in the test namespace and
 //! truncates the namespace.
 
-use std::collections::HashMap;
-
 use aerospike::{AdminPolicy, Client};
 
 use crate::common;
-
-async fn list_indexes(client: &Client, namespace: &str) -> Vec<HashMap<String, String>> {
-    let node = client
-        .cluster
-        .get_random_node()
-        .expect("no nodes available");
-
-    let cmd = format!("sindex-list:namespace={}", namespace);
-    let res = node
-        .info(&AdminPolicy::default(), &[&cmd])
-        .await
-        .expect("sindex info request failed");
-
-    let sindex_str = res.get(&cmd).map(String::as_str).unwrap_or("");
-
-    sindex_str
-        .split(';')
-        .map(|entry| {
-            entry
-                .split(':')
-                .filter(|kv| !kv.trim().is_empty())
-                .filter_map(|kv| kv.split_once('='))
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect()
-        })
-        .collect()
-}
-
-async fn drop_indexes(client: &Client, namespace: &str) {
-    let policy = AdminPolicy::default();
-    for index in list_indexes(client, namespace).await {
-        if index.get("ns").map(String::as_str) != Some(namespace) {
-            continue;
-        }
-        let set = index.get("set").map(String::as_str).unwrap_or("");
-        let Some(name) = index.get("indexname") else {
-            continue;
-        };
-
-        match client.drop_index(&policy, namespace, set, name).await {
-            Ok(_) => println!("Success: Removing Namespace/Set/Index: {namespace}/{set}/{name}"),
-            Err(e) => {
-                println!("Failed: Removing Namespace/Set/Index: {namespace}/{set}/{name} ({e})")
-            }
-        }
-    }
-}
 
 async fn truncate_namespace(client: &Client, namespace: &str) {
     match client
@@ -83,7 +34,7 @@ async fn truncate_namespace(client: &Client, namespace: &str) {
 async fn cleanup_after_tests() {
     let client = common::client().await;
     let namespace = common::namespace();
-    drop_indexes(&client, namespace).await;
+    common::drop_all_indexes(&client, namespace).await;
     truncate_namespace(&client, namespace).await;
     client.close().await.unwrap();
 }

--- a/tests/src/cluster.rs
+++ b/tests/src/cluster.rs
@@ -390,7 +390,7 @@ async fn seed_only_cluster_pins_to_seed_addresses() {
 
     // Give a tend cycle a chance to run; without seed_only_cluster
     // peers discovery would have enrolled additional nodes by now.
-    aerospike_rt::time::sleep(std::time::Duration::from_millis(2_500)).await;
+    aerospike_rt::sleep(std::time::Duration::from_millis(2_500)).await;
 
     let after_tend = client.cluster.nodes();
     assert_eq!(

--- a/tests/src/compression.rs
+++ b/tests/src/compression.rs
@@ -385,6 +385,7 @@ async fn query_with_compression() {
     // Create an index for the query filter
     let apolicy = AdminPolicy::default();
     let idx_name = format!("{namespace}_{set_name}_int");
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,

--- a/tests/src/compression.rs
+++ b/tests/src/compression.rs
@@ -16,7 +16,7 @@
 use std::time::Duration;
 
 use futures::stream::StreamExt;
-use tokio::time::sleep;
+use aerospike_rt::sleep;
 
 use crate::common;
 

--- a/tests/src/index.rs
+++ b/tests/src/index.rs
@@ -53,6 +53,7 @@ async fn create_index_on_bin() {
     let task = client.drop_index(&apolicy, ns, &set, &index).await.unwrap();
     task.wait_till_complete(None).await.unwrap();
 
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,
@@ -111,6 +112,7 @@ async fn create_index_using_expression() {
 
     let fe: Expression = num_add(vec![int_bin(common::rand_str(10)), int_val(0)]);
 
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_using_expression(
             &apolicy,

--- a/tests/src/query.rs
+++ b/tests/src/query.rs
@@ -45,13 +45,15 @@ async fn create_test_set(client: &Client, no_records: usize) -> String {
         client.put(&wpolicy, &key, &bins).await.unwrap();
     }
 
+    let index_name = format!("{}_{}_{}", namespace, set_name, "bin");
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,
             namespace,
             &set_name,
             "bin",
-            &format!("{}_{}_{}", namespace, set_name, "bin"),
+            &index_name,
             IndexType::Numeric,
             CollectionIndexType::Default,
             None,
@@ -446,6 +448,7 @@ async fn test_query_geo_within_geojson_region() {
     let client = Arc::new(common::client().await);
     let apolicy = AdminPolicy::default();
 
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,
@@ -895,6 +898,7 @@ async fn create_list_test_set(client: &Client) -> String {
 
     // Create a secondary index on list elements
     let idx_name = format!("{}_{}_list_bin", namespace, set_name);
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,
@@ -993,6 +997,7 @@ async fn create_geo_test_set(client: &Client) -> String {
     let apolicy = AdminPolicy::default();
     let wp = WritePolicy::default();
 
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,
@@ -1095,6 +1100,7 @@ async fn query_filter_geo_contains() {
     let apolicy = AdminPolicy::default();
     let wp = WritePolicy::default();
 
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,
@@ -1195,6 +1201,7 @@ async fn query_filter_with_expression_builder() {
     // Create an expression-based secondary index: int_bin("a")
     let exp = aerospike::expressions::int_bin("a".to_string());
     let idx_name = format!("{}_{}_exp_a", namespace, set_name);
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_using_expression(
             &apolicy,
@@ -1259,6 +1266,7 @@ async fn query_filter_with_context_builder() {
     use aerospike::operations::cdt_context::ctx_list_index;
     let ctx = vec![ctx_list_index(0)];
     let idx_name = format!("{}_{}_nested_ctx", namespace, set_name);
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,
@@ -1322,6 +1330,7 @@ async fn query_filter_expression_with_policy_filter() {
     // Create an expression-based secondary index on int_bin("a")
     let idx_exp = aerospike::expressions::int_bin("a".to_string());
     let idx_name = format!("{}_{}_exp_ab", namespace, set_name);
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_using_expression(
             &apolicy,
@@ -1837,6 +1846,7 @@ async fn query_returns_user_key_when_send_key_set() {
         client.put(&wpolicy, &key, &[bin]).await.unwrap();
     }
 
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,

--- a/tests/src/task.rs
+++ b/tests/src/task.rs
@@ -80,6 +80,7 @@ async fn index_task_test() {
         client.put(&wpolicy, &key, &bins).await.unwrap();
     }
 
+    let _index_guard = common::lock_index_ops().await;
     let index_task = client
         .create_index_on_bin(
             &apolicy,

--- a/tests/src/udf.rs
+++ b/tests/src/udf.rs
@@ -123,6 +123,7 @@ async fn query_execute_udf_with_filter() {
     }
 
     // Create index for filter query
+    let _index_guard = common::lock_index_ops().await;
     let task = client
         .create_index_on_bin(
             &apolicy,


### PR DESCRIPTION
Adds CI/CD workflows for rust client.

1. Build and test runs against `v3` and `main` branch PRs: Sample run: https://github.com/aerospike/aerospike-client-rust/actions/runs/28070824010
2. Build and release : creates a release bundle and publishes to JFrog artifactory. Can be run manually, or with a tag release. Sample run: https://github.com/aerospike/aerospike-client-rust/actions/runs/28066415708
3. Updated test code to not fail randomly - index cleanups, doctest fixes, multi threaded parallel runs