### PR TITLE
CLIENT-4751: included different timeout used across different ops

### DIFF
--- a/aerospike-core/src/cluster/mod.rs
+++ b/aerospike-core/src/cluster/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 Aerospike, Inc.
+// Copyright 2015-2026 Aerospike, Inc.
 //
 // Portions may be licensed to Aerospike, Inc. under one or more contributor
 // license agreements.
@@ -47,6 +47,8 @@ use futures::channel::mpsc::{Receiver, Sender, TryRecvError};
 use hazarc::AtomicArc;
 
 static CLIENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const INIT_STABILIZE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Per-namespace partition data.
 /// Contains replicated node arrays, SC mode flag, and regime tracking.
@@ -523,15 +525,7 @@ impl Cluster {
     }
 
     async fn wait_till_stabilized(cluster: Arc<Cluster>) -> Result<()> {
-        let timeout = {
-            let timeout = cluster.client_policy.load().timeout;
-            if timeout > 0 {
-                Duration::from_millis(u64::from(timeout))
-            } else {
-                Duration::from_secs(3)
-            }
-        };
-        let deadline = Instant::now() + timeout;
+        let deadline = Instant::now() + INIT_STABILIZE_TIMEOUT;
         let sleep_between_tend = Duration::from_millis(1);
 
         let handle = aerospike_rt::spawn(async move {

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2024 Aerospike, Inc.
+// Copyright 2015-2026 Aerospike, Inc.
 //
 // Portions may be licensed to Aerospike, Inc. under one or more contributor
 // license agreements.
@@ -547,18 +547,28 @@ impl Node {
     }
 
     // Get a connection to the node from the connection pool
-    pub async fn get_connection(&self, hint: u8) -> Result<PooledConnection> {
+    pub async fn get_connection(
+        &self,
+        hint: u8,
+        connect_timeout_ms: u32,
+        socket_timeout_ms: u32,
+    ) -> Result<PooledConnection> {
         if !self.is_active() {
             return Err(Error::InvalidNode(format!(
                 "Cannot get a connection for node. The node `{self}` is inactive"
             )));
         }
 
-        if let Ok(conn) = self.connection_pool.get(hint) {
+        if let Ok(mut conn) = self.connection_pool.get(hint) {
+            if let Some(c) = conn.conn.as_mut() {
+                c.set_socket_timeout(None, socket_timeout_ms);
+            }
             return Ok(conn);
         }
 
-        self.connection_pool.make_conn(usize::from(hint)).await
+        self.connection_pool
+            .make_conn(usize::from(hint), connect_timeout_ms, socket_timeout_ms)
+            .await
     }
 
     // Put a connection to the node back in the connection pool
@@ -621,7 +631,7 @@ impl Node {
         policy: &AdminPolicy,
         commands: &[&str],
     ) -> Result<HashMap<String, String>> {
-        let mut conn = self.get_connection(0).await?;
+        let mut conn = self.get_connection(0, 0, policy.timeout()).await?;
         let res = Message::info(policy, &mut conn, commands).await;
 
         if let Err(e) = res {
@@ -647,10 +657,13 @@ impl Node {
             // Open lazily. The first call after Node::new pays the
             // TCP-handshake + LOGIN here; subsequent calls reuse the
             // already-authenticated socket.
-            let conn = Connection::new(
+            let (conn, _) = Connection::new_with_session(
                 &self.host,
                 &self.client_policy,
                 self.client_policy.hashed_pass().as_ref(),
+                None,
+                self.client_policy.timeout,
+                self.client_policy.timeout,
             )
             .await
             .map_err(|e| e.chain_error("Failed to open tend connection"))?;
@@ -913,7 +926,10 @@ impl Node {
                     .min_conns_per_node
                     .saturating_sub(self.connection_pool.total_reserved());
                 for _ in 0..to_fill {
-                    self.connection_pool.make_conn(count).await?;
+                    let connect = client_policy.timeout;
+                    self.connection_pool
+                        .make_conn(count, connect, connect)
+                        .await?;
                     count += 1;
                 }
             }
@@ -978,7 +994,7 @@ mod node_tests {
         let node = test_node();
         let pconn = node
             .connection_pool
-            .make_conn(0)
+            .make_conn(0, 1000, 1000)
             .await
             .expect("make_conn uses test Connection");
         node.put_connection(pconn);
@@ -993,7 +1009,7 @@ mod node_tests {
         node.close();
         assert!(!node.is_active());
 
-        let err = node.get_connection(0).await.unwrap_err();
+        let err = node.get_connection(0, 0, 30_000).await.unwrap_err();
         match err {
             Error::InvalidNode(msg) => assert!(msg.contains("inactive"), "unexpected: {}", msg),
             other => panic!("expected InvalidNode, got {:?}", other),
@@ -1009,7 +1025,7 @@ mod node_tests {
     async fn put_connection_does_not_return_conn_to_pool_when_inactive() {
         let node = create_node_with_connection().await;
         let pconn = node
-            .get_connection(0)
+            .get_connection(0, 0, 30_000)
             .await
             .expect("active node with one mock conn in pool");
         assert_eq!(node.connection_pool.num_conns(), 0);
@@ -1030,7 +1046,7 @@ mod node_tests {
         let arc = Arc::new(create_node_with_connection().await);
         let queue_witness = {
             let pconn = arc
-                .get_connection(0)
+                .get_connection(0, 0, 30_000)
                 .await
                 .expect("pool should have one connection");
             let q = pconn.queue.clone();
@@ -1076,10 +1092,10 @@ mod node_tests {
         let node = Node::new(policy, nv);
 
         // Trigger 4 pool misses with distinct hints — each should land on its own queue.
-        let _c0 = node.get_connection(0).await.expect("hint=0");
-        let _c1 = node.get_connection(1).await.expect("hint=1");
-        let _c2 = node.get_connection(2).await.expect("hint=2");
-        let _c3 = node.get_connection(3).await.expect("hint=3");
+        let _c0 = node.get_connection(0, 0, 30_000).await.expect("hint=0");
+        let _c1 = node.get_connection(1, 0, 30_000).await.expect("hint=1");
+        let _c2 = node.get_connection(2, 0, 30_000).await.expect("hint=2");
+        let _c3 = node.get_connection(3, 0, 30_000).await.expect("hint=3");
 
         let queues = node.connection_pool.queues();
         for i in 0..4 {
@@ -1113,7 +1129,7 @@ mod node_tests {
         for i in 0..5 {
             let pconn = node
                 .connection_pool
-                .make_conn(i)
+                .make_conn(i, 1000, 1000)
                 .await
                 .expect("make_conn failed");
             in_flight.push(pconn);

--- a/aerospike-core/src/cluster/node_validator.rs
+++ b/aerospike-core/src/cluster/node_validator.rs
@@ -116,8 +116,16 @@ impl NodeValidator {
     }
 
     async fn validate_alias(&mut self, cluster: &Cluster, alias: &Host) -> Result<()> {
-        let mut conn =
-            Connection::new(alias, &self.client_policy, cluster.hashed_pass().as_ref()).await?;
+        let mut conn = Connection::new_with_session(
+            alias,
+            &self.client_policy,
+            cluster.hashed_pass().as_ref(),
+            None,
+            self.client_policy.timeout,
+            self.client_policy.timeout,
+        )
+        .await?
+        .0;
         let admin_policy = AdminPolicy {
             timeout: self.client_policy.timeout,
         };
@@ -281,10 +289,13 @@ impl NodeValidator {
                     &candidate.tls_name.clone().unwrap_or_default(),
                     candidate.port,
                 );
-                if let Ok(mut probe) = Connection::new(
+                if let Ok((mut probe, _)) = Connection::new_with_session(
                     &real_alias,
                     &self.client_policy,
                     cluster.hashed_pass().as_ref(),
+                    None,
+                    self.client_policy.timeout,
+                    self.client_policy.timeout,
                 )
                 .await
                 {

--- a/aerospike-core/src/commands/admin_command.rs
+++ b/aerospike-core/src/commands/admin_command.rs
@@ -571,7 +571,7 @@ impl AdminCommand {
         roles: &[&str],
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -589,7 +589,7 @@ impl AdminCommand {
         user: &str,
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -606,7 +606,7 @@ impl AdminCommand {
         password: &str,
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -624,7 +624,7 @@ impl AdminCommand {
         password: &str,
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -663,7 +663,7 @@ impl AdminCommand {
         write_quota: u32,
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         let mut field_count = 1;
         if !privileges.is_empty() {
@@ -712,7 +712,7 @@ impl AdminCommand {
         role_name: &str,
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -729,7 +729,7 @@ impl AdminCommand {
         privileges: &[Privilege],
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -747,7 +747,7 @@ impl AdminCommand {
         privileges: &[Privilege],
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -765,7 +765,7 @@ impl AdminCommand {
         allowlist: &[&str],
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -784,7 +784,7 @@ impl AdminCommand {
         write_quota: u32,
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -803,7 +803,7 @@ impl AdminCommand {
         roles: &[&str],
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -821,7 +821,7 @@ impl AdminCommand {
         roles: &[&str],
     ) -> Result<()> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -838,7 +838,7 @@ impl AdminCommand {
         user: Option<&str>,
     ) -> Result<Vec<User>> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();
@@ -859,7 +859,7 @@ impl AdminCommand {
         role: Option<&str>,
     ) -> Result<Vec<Role>> {
         let node = cluster.get_random_node()?;
-        let mut conn = node.get_connection(0).await?;
+        let mut conn = node.get_connection(0, 0, policy.timeout()).await?;
 
         conn.buffer.resize_buffer(1024)?;
         conn.buffer.reset_offset();

--- a/aerospike-core/src/commands/batch_operate_command.rs
+++ b/aerospike-core/src/commands/batch_operate_command.rs
@@ -178,7 +178,10 @@ impl BatchOperateCommand {
             return Ok(Some(err));
         }
 
-        let mut conn = match node.get_connection(0).await {
+        let mut conn = match node
+            .get_connection(0, policy.connect_timeout(), policy.socket_timeout())
+            .await
+        {
             Ok(conn) => conn,
             Err(err) => {
                 warn!("Node {node}: {err}");

--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -213,7 +213,14 @@ impl<'a> SingleCommand<'a> {
                 continue;
             }
 
-            let mut conn = match node.get_connection(cmd.hint()).await {
+            let mut conn = match node
+                .get_connection(
+                    cmd.hint(),
+                    policy.connect_timeout(),
+                    policy.socket_timeout(),
+                )
+                .await
+            {
                 Ok(conn) => conn,
                 Err(err) => {
                     warn!("Node {node}: {err}");

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -142,9 +142,16 @@ impl Connection {
         policy: &ClientPolicy,
         hashed_pass: Option<&String>,
     ) -> Result<Self> {
-        Self::new_with_session(host, policy, hashed_pass, None)
-            .await
-            .map(|(conn, _session)| conn)
+        Self::new_with_session(
+            host,
+            policy,
+            hashed_pass,
+            None,
+            policy.timeout,
+            policy.timeout,
+        )
+        .await
+        .map(|(conn, _session)| conn)
     }
 
     /// Like [`new`](Self::new) but optionally reuses a previously-issued
@@ -157,10 +164,15 @@ impl Connection {
         policy: &ClientPolicy,
         hashed_pass: Option<&String>,
         session: Option<&crate::commands::admin_command::SessionInfo>,
+        connect_timeout_ms: u32,
+        socket_timeout_ms: u32,
     ) -> Result<(Self, Option<crate::commands::admin_command::SessionInfo>)> {
         let addr = host.address();
+        let effective_connect =
+            ClientPolicy::effective_connect_timeout_ms(connect_timeout_ms, socket_timeout_ms);
+        let connect_duration = Duration::from_millis(u64::from(effective_connect));
         let stream =
-            aerospike_rt::timeout(policy.timeout(), TcpStream::connect(addr.clone())).await;
+            aerospike_rt::timeout(connect_duration, TcpStream::connect(addr.clone())).await;
         if stream.is_err() {
             return Err(Error::Connection(
                 "Could not open network connection".to_string(),
@@ -176,12 +188,18 @@ impl Connection {
             None
         };
 
+        let post_connect_socket = if socket_timeout_ms > 0 {
+            socket_timeout_ms
+        } else {
+            effective_connect
+        };
+
         let mut conn = Connection {
             addr,
             buffer: Buffer::new(policy.buffer_reclaim_threshold),
             bytes_read: 0,
             conn: stream,
-            socket_timeout: policy.timeout().as_millis() as u32,
+            socket_timeout: effective_connect,
             timeout_delay: 0,
             deadline: None,
             idle_timeout,
@@ -204,7 +222,12 @@ impl Connection {
             _ => false,
         };
         if !used_session {
+            let login_ms = policy.login_timeout().as_millis() as u32;
+            conn.set_socket_timeout(None, login_ms);
             new_session = conn.authenticate(&policy.auth_mode, hashed_pass).await?;
+            conn.set_socket_timeout(None, post_connect_socket);
+        } else {
+            conn.set_socket_timeout(None, post_connect_socket);
         }
         conn.refresh();
         Ok((conn, new_session))
@@ -221,8 +244,10 @@ impl Connection {
         policy: &ClientPolicy,
         hashed_pass: Option<&String>,
         _session: Option<&crate::commands::admin_command::SessionInfo>,
+        connect_timeout_ms: u32,
+        socket_timeout_ms: u32,
     ) -> Result<(Self, Option<crate::commands::admin_command::SessionInfo>)> {
-        Self::new(host, policy, hashed_pass)
+        Self::new(host, policy, hashed_pass, connect_timeout_ms, socket_timeout_ms)
             .await
             .map(|c| (c, None))
     }
@@ -232,6 +257,8 @@ impl Connection {
         host: &Host,
         policy: &ClientPolicy,
         _hashed_pass: Option<&String>,
+        connect_timeout_ms: u32,
+        socket_timeout_ms: u32,
     ) -> Result<Self> {
         let addr = host.address();
         let stream = Netsocket::TestDummy;
@@ -247,7 +274,10 @@ impl Connection {
             buffer: Buffer::new(policy.buffer_reclaim_threshold),
             bytes_read: 0,
             conn: stream,
-            socket_timeout: policy.timeout().as_millis() as u32,
+            socket_timeout: ClientPolicy::effective_connect_timeout_ms(
+                connect_timeout_ms,
+                socket_timeout_ms,
+            ),
             timeout_delay: 0,
             deadline: None,
             idle_timeout: idle_timeout,

--- a/aerospike-core/src/net/connection_pool.rs
+++ b/aerospike-core/src/net/connection_pool.rs
@@ -1,4 +1,4 @@
-// Copyright 2015-2018 Aerospike, Inc.
+// Copyright 2015-2026 Aerospike, Inc.
 //
 // Portions may be licensed to Aerospike, Inc. under one or more contributor
 // license agreements.
@@ -102,7 +102,11 @@ impl Queue {
     /// already holds a non-expired session, the new connection
     /// authenticates via AUTHENTICATE with that token; otherwise it does a
     /// full LOGIN and stores the resulting session for the next caller.
-    pub async fn make_conn(&self) -> Result<Connection> {
+    pub async fn make_conn(
+        &self,
+        connect_timeout_ms: u32,
+        socket_timeout_ms: u32,
+    ) -> Result<Connection> {
         // Snapshot the current session under the lock, then drop the guard
         // before any await so the mutex doesn't get held across .await
         // points (it's a std::sync::Mutex, not async-aware).
@@ -115,19 +119,18 @@ impl Queue {
             guard.as_ref().filter(|s| !s.is_expired()).cloned()
         };
 
-        let result = aerospike_rt::timeout(
-            self.0.policy.timeout(),
-            Connection::new_with_session(
-                &self.0.host,
-                &self.0.policy,
-                self.0.hashed_pass.as_ref(),
-                cached_session.as_ref(),
-            ),
+        let result = Connection::new_with_session(
+            &self.0.host,
+            &self.0.policy,
+            self.0.hashed_pass.as_ref(),
+            cached_session.as_ref(),
+            connect_timeout_ms,
+            socket_timeout_ms,
         )
         .await;
 
         match result {
-            Ok(Ok((conn, fresh_session))) => {
+            Ok((conn, fresh_session)) => {
                 if let Some(s) = fresh_session {
                     let mut guard = self
                         .0
@@ -315,7 +318,12 @@ impl ConnectionPool {
 
     /// If there is a pool with capacity to hold more connections, create a connection
     /// for that queue and return it to the user.
-    pub async fn make_conn(&self, hint: usize) -> Result<PooledConnection> {
+    pub async fn make_conn(
+        &self,
+        hint: usize,
+        connect_timeout_ms: u32,
+        socket_timeout_ms: u32,
+    ) -> Result<PooledConnection> {
         let num_queues = usize::from(self.num_queues);
         let mut attempts = self.num_queues;
         let mut i = hint % num_queues;
@@ -326,7 +334,7 @@ impl ConnectionPool {
                 i = 0;
             }
             if queue.reserve_capacity() {
-                match queue.make_conn().await {
+                match queue.make_conn(connect_timeout_ms, socket_timeout_ms).await {
                     Ok(conn) => {
                         return Ok(PooledConnection {
                             queue: queue.clone(),
@@ -484,9 +492,15 @@ mod tests {
         ($pool:ident, $hint:tt) => {{
             match $pool.get($hint) {
                 Ok(c) => Ok(c),
-                Err(_) => $pool.make_conn($hint).await,
+                Err(_) => $pool.make_conn($hint, 0, 30_000).await,
             }
         }};
+    }
+
+    async fn test_connection(host: &Host, policy: &ClientPolicy) -> Connection {
+        Connection::new(host, policy, None, 1000, 30_000)
+            .await
+            .expect("creating dummy connection failed")
     }
 
     #[aerospike_macro::test]
@@ -499,30 +513,22 @@ mod tests {
         assert_eq!(q.reserved(), 0);
         assert_eq!(q.get().is_err(), true);
 
-        let c = Connection::new(&host, &policy, None)
-            .await
-            .expect("creating dummy connection failed");
+        let c = test_connection(&host, &policy).await;
         put_back_with_reserve!(q, c);
         assert_eq!(q.reserved(), 1);
         assert_eq!(q.num_conns(), 1);
 
-        let c = Connection::new(&host, &policy, None)
-            .await
-            .expect("creating dummy connection failed");
+        let c = test_connection(&host, &policy).await;
         put_back_with_reserve!(q, c);
         assert_eq!(q.reserved(), 2);
         assert_eq!(q.num_conns(), 2);
 
-        let c = Connection::new(&host, &policy, None)
-            .await
-            .expect("creating dummy connection failed");
+        let c = test_connection(&host, &policy).await;
         put_back_with_reserve!(q, c);
         assert_eq!(q.reserved(), 3);
         assert_eq!(q.num_conns(), 3);
 
-        let c = Connection::new(&host, &policy, None)
-            .await
-            .expect("creating dummy connection failed");
+        let c = test_connection(&host, &policy).await;
         put_back_with_reserve!(q, c);
         assert_eq!(q.num_conns(), 3);
         assert_eq!(q.reserved(), 3);
@@ -570,7 +576,7 @@ mod tests {
         assert_eq!(get_or_make!(p, 0).is_err(), false);
         assert_eq!(p.num_conns(), 1);
 
-        assert_eq!(p.make_conn(0).await.is_err(), false);
+        assert_eq!(p.make_conn(0, 1000, 30_000).await.is_err(), false);
         assert_eq!(p.num_conns(), 2);
 
         assert_eq!(p.get(0).is_err(), false);
@@ -614,7 +620,7 @@ mod tests {
         assert_eq!(p.queues[1].reserved(), 0);
         assert_eq!(p.queues[1].num_conns(), 0);
 
-        assert_eq!(p.make_conn(1).await.is_err(), false);
+        assert_eq!(p.make_conn(1, 1000, 30_000).await.is_err(), false);
         assert_eq!(p.num_conns(), 2);
         assert_eq!(p.queues[0].reserved(), 1);
         assert_eq!(p.queues[0].num_conns(), 1);
@@ -651,21 +657,21 @@ mod tests {
 
         // test for capacity planning
 
-        assert_eq!(p.make_conn(1).await.is_err(), false);
+        assert_eq!(p.make_conn(1, 1000, 30_000).await.is_err(), false);
         assert_eq!(p.num_conns(), 1);
         assert_eq!(p.queues[0].reserved(), 0);
         assert_eq!(p.queues[0].num_conns(), 0);
         assert_eq!(p.queues[1].reserved(), 1);
         assert_eq!(p.queues[1].num_conns(), 1);
 
-        assert_eq!(p.make_conn(1).await.is_err(), false);
+        assert_eq!(p.make_conn(1, 1000, 30_000).await.is_err(), false);
         assert_eq!(p.num_conns(), 2);
         assert_eq!(p.queues[0].reserved(), 1);
         assert_eq!(p.queues[0].num_conns(), 1);
         assert_eq!(p.queues[1].reserved(), 1);
         assert_eq!(p.queues[1].num_conns(), 1);
 
-        assert_eq!(p.make_conn(1).await.is_err(), false);
+        assert_eq!(p.make_conn(1, 1000, 30_000).await.is_err(), false);
         assert_eq!(p.num_conns(), 3);
         assert_eq!(p.queues[0].reserved(), 2);
         assert_eq!(p.queues[0].num_conns(), 2);
@@ -673,7 +679,7 @@ mod tests {
         assert_eq!(p.queues[1].num_conns(), 1);
 
         // can't make more, all queues are full
-        assert_eq!(p.make_conn(1).await.is_err(), true);
+        assert_eq!(p.make_conn(1, 1000, 30_000).await.is_err(), true);
         assert_eq!(p.num_conns(), 3);
         assert_eq!(p.queues[0].reserved(), 2);
         assert_eq!(p.queues[0].num_conns(), 2);
@@ -683,7 +689,7 @@ mod tests {
         // can't make more, all queues are full
         let mut c = p.get(0).unwrap();
         // we are at capacity, no more connections can be created
-        assert_eq!(p.make_conn(1).await.is_err(), true);
+        assert_eq!(p.make_conn(1, 1000, 30_000).await.is_err(), true);
         // but there is one connection in flight
         assert_eq!(p.num_conns(), 2);
         assert_eq!(p.queues[0].reserved(), 2);
@@ -703,7 +709,7 @@ mod tests {
         // can't make more, all queues are full
         let mut c = p.get(1).unwrap();
         // we are at capacity, no more connections can be created
-        assert_eq!(p.make_conn(1).await.is_err(), true);
+        assert_eq!(p.make_conn(1, 1000, 30_000).await.is_err(), true);
         // but there is one connection in flight
         assert_eq!(p.num_conns(), 2);
         assert_eq!(p.queues[0].reserved(), 2);
@@ -729,9 +735,7 @@ mod tests {
         };
 
         let q = Queue::with_capacity(3, host.clone(), policy.clone());
-        let c = Connection::new(&host, &policy, None)
-            .await
-            .expect("creating dummy connection failed");
+        let c = test_connection(&host, &policy).await;
         put_back_with_reserve!(q, c);
         assert_eq!(q.reserved(), 1);
         assert_eq!(q.num_conns(), 1);
@@ -755,20 +759,14 @@ mod tests {
 
         let q = Queue::with_capacity(2, host.clone(), policy.clone());
 
-        let c1 = Connection::new(&host, &policy, None)
-            .await
-            .expect("creating dummy connection failed");
+        let c1 = test_connection(&host, &policy).await;
         put_back_with_reserve!(q, c1);
-        let c2 = Connection::new(&host, &policy, None)
-            .await
-            .expect("creating dummy connection failed");
+        let c2 = test_connection(&host, &policy).await;
         put_back_with_reserve!(q, c2);
         assert_eq!(q.reserved(), 2);
         assert_eq!(q.num_conns(), 2);
 
-        let overflow = Connection::new(&host, &policy, None)
-            .await
-            .expect("creating dummy connection failed");
+        let overflow = test_connection(&host, &policy).await;
         assert!(
             !q.reserve_capacity(),
             "queue is at capacity, reserve should fail"
@@ -806,10 +804,10 @@ mod tests {
 
         // make_conn returns a PooledConnection; dropping it returns the
         // connection to the pool. We need to hold them to keep them "in-flight".
-        let _c1 = p.make_conn(0).await.expect("make_conn failed");
+        let _c1 = p.make_conn(0, 1000, 30_000).await.expect("make_conn failed");
         assert_eq!(p.total_reserved(), 1);
 
-        let _c2 = p.make_conn(0).await.expect("make_conn failed");
+        let _c2 = p.make_conn(0, 1000, 30_000).await.expect("make_conn failed");
         assert_eq!(p.total_reserved(), 2);
 
         // Both are held as in-flight PooledConnections, so the queue is empty
@@ -838,7 +836,7 @@ mod tests {
         let p = ConnectionPool::new(host.clone(), policy.clone());
 
         for round in 0..10 {
-            let mut c = p.make_conn(0).await.expect("make_conn failed");
+            let mut c = p.make_conn(0, 1000, 30_000).await.expect("make_conn failed");
             c.invalidate(); // state → Closed
             drop(c); // Drop: Closed arm → reduce_capacity()
             assert_eq!(
@@ -849,7 +847,7 @@ mod tests {
         }
         // Pool must still accept new connections — no slots leaked.
         let _c = p
-            .make_conn(0)
+            .make_conn(0, 1000, 30_000)
             .await
             .expect("pool must have capacity after all connections were closed and dropped");
     }

--- a/aerospike-core/src/policy/admin_policy.rs
+++ b/aerospike-core/src/policy/admin_policy.rs
@@ -28,3 +28,19 @@ impl AdminPolicy {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AdminPolicy;
+
+    #[test]
+    fn zero_admin_timeout_uses_legacy_three_second_fallback() {
+        assert_eq!(AdminPolicy::default().timeout(), 3_000);
+    }
+
+    #[test]
+    fn explicit_admin_timeout_is_preserved() {
+        let p = AdminPolicy { timeout: 1_000 };
+        assert_eq!(p.timeout(), 1_000);
+    }
+}

--- a/aerospike-core/src/policy/client_policy.rs
+++ b/aerospike-core/src/policy/client_policy.rs
@@ -103,9 +103,17 @@ pub struct ClientPolicy {
     #[cfg(feature = "tls")]
     pub tls_config: Option<ClientConfig>,
 
-    /// Initial host connection timeout in milliseconds. The timeout when opening a connection
-    /// to the server host for the first time.
+    /// Cluster tend info call timeout in milliseconds. The timeout when opening a connection
+    /// to the server node for the first time and when polling each node for cluster status.
+    ///
+    /// Default: 1000
     pub timeout: u32,
+
+    /// Login timeout in milliseconds. Used when user authentication is enabled and a node
+    /// login is being performed.
+    ///
+    /// Default: 5000
+    pub login_timeout: u32,
 
     /// Connection idle timeout. Every time a connection is used, its idle
     /// deadline will be extended by this duration. When this deadline is reached,
@@ -237,7 +245,8 @@ impl Default for ClientPolicy {
     fn default() -> ClientPolicy {
         ClientPolicy {
             auth_mode: AuthMode::None,
-            timeout: 30_000,
+            timeout: 1_000,
+            login_timeout: 5_000,
             idle_timeout: 30_000,
             min_conns_per_node: 0,
             max_conns_per_node: 256,
@@ -294,11 +303,27 @@ impl ClientPolicy {
         "not-set"
     }
 
-    pub(crate) fn timeout(&self) -> Duration {
-        if self.timeout > 0 {
-            Duration::from_millis(u64::from(self.timeout))
+    /// Login timeout as a [`Duration`].
+    pub(crate) fn login_timeout(&self) -> Duration {
+        if self.login_timeout > 0 {
+            Duration::from_millis(u64::from(self.login_timeout))
         } else {
-            Duration::from_secs(30)
+            Duration::from_millis(5_000)
+        }
+    }
+
+    /// Effective connect timeout when opening a socket. Mirrors Java
+    /// `Node.getConnection`: use `connect_timeout` when &gt; 0, else `socket_timeout`.
+    pub(crate) fn effective_connect_timeout_ms(
+        connect_timeout_ms: u32,
+        socket_timeout_ms: u32,
+    ) -> u32 {
+        if connect_timeout_ms > 0 {
+            connect_timeout_ms
+        } else if socket_timeout_ms > 0 {
+            socket_timeout_ms
+        } else {
+            2_000
         }
     }
 
@@ -354,5 +379,38 @@ impl ClientPolicy {
             true => "service-clear-alt",
             false => "service-clear-std",
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ClientPolicy;
+
+    #[test]
+    fn default_client_policy_timeout_defaults() {
+        let p = ClientPolicy::default();
+        assert_eq!(p.timeout, 1_000, "tend/connect default");
+        assert_eq!(p.login_timeout, 5_000, "login default");
+    }
+
+    #[test]
+    fn effective_connect_timeout_uses_explicit_connect() {
+        assert_eq!(ClientPolicy::effective_connect_timeout_ms(5_000, 1_000), 5_000);
+    }
+
+    #[test]
+    fn effective_connect_timeout_falls_back_to_socket() {
+        assert_eq!(ClientPolicy::effective_connect_timeout_ms(0, 1_000), 1_000);
+    }
+
+    #[test]
+    fn effective_connect_timeout_java_hardcoded_when_both_zero() {
+        assert_eq!(ClientPolicy::effective_connect_timeout_ms(0, 0), 2_000);
+    }
+
+    #[test]
+    fn login_timeout_duration_default() {
+        let p = ClientPolicy::default();
+        assert_eq!(p.login_timeout().as_millis(), 5_000);
     }
 }

--- a/aerospike-core/src/policy/mod.rs
+++ b/aerospike-core/src/policy/mod.rs
@@ -73,6 +73,10 @@ pub trait Policy {
     /// Socket timeout for client.
     fn socket_timeout(&self) -> u32;
 
+    /// Socket connect timeout in milliseconds for command connections.
+    /// When zero, [`socket_timeout`](Self::socket_timeout) is used.
+    fn connect_timeout(&self) -> u32;
+
     /// Total transaction timeout for both client and server. The timeout is tracked on the client
     /// and also sent to the server along with the transaction in the wire protocol. The client
     /// will most likely timeout first, but the server has the capability to timeout the
@@ -141,6 +145,10 @@ where
 
     fn socket_timeout(&self) -> u32 {
         self.base().socket_timeout()
+    }
+
+    fn connect_timeout(&self) -> u32 {
+        self.base().connect_timeout()
     }
 
     fn total_timeout(&self) -> u32 {
@@ -214,6 +222,13 @@ pub struct BasePolicy {
     /// both `max_retries` and `total_timeout` are checked. If `max_retries` and `total_timeout` are not
     /// exceeded, the command is retried.
     pub socket_timeout: u32,
+
+    /// Socket connect timeout in milliseconds. If greater than zero, it is applied when
+    /// creating a connection plus optional user authentication. Otherwise,
+    /// [`socket_timeout`](Self::socket_timeout) is used.
+    ///
+    /// Default: 0
+    pub connect_timeout: u32,
 
     /// Total command timeout.
     /// This timeout is used to set the socket timeout and is also sent to the
@@ -352,6 +367,10 @@ impl Policy for BasePolicy {
         }
     }
 
+    fn connect_timeout(&self) -> u32 {
+        self.connect_timeout
+    }
+
     fn total_timeout(&self) -> u32 {
         self.total_timeout
     }
@@ -386,5 +405,47 @@ impl Policy for BasePolicy {
 
     fn compression_threshold(&self) -> usize {
         self.compression_threshold
+    }
+}
+
+#[cfg(test)]
+mod timeout_policy_tests {
+    use super::{BasePolicy, Policy, ReadPolicy};
+
+    #[test]
+    fn base_policy_default_connect_timeout_is_zero() {
+        let p = BasePolicy::default();
+        assert_eq!(p.connect_timeout, 0);
+        assert_eq!(p.connect_timeout(), 0);
+    }
+
+    #[test]
+    fn effective_socket_timeout_is_min_of_socket_and_total() {
+        let mut base = BasePolicy::default();
+        base.socket_timeout = 30_000;
+        base.total_timeout = 1_000;
+        let policy = ReadPolicy {
+            base_policy: base,
+            ..ReadPolicy::default()
+        };
+        assert_eq!(policy.socket_timeout(), 1_000);
+    }
+
+    #[test]
+    fn connect_timeout_is_independent_of_socket_total_cap() {
+        let mut base = BasePolicy::default();
+        base.connect_timeout = 5_000;
+        base.socket_timeout = 30_000;
+        base.total_timeout = 1_000;
+        assert_eq!(base.connect_timeout(), 5_000);
+        assert_eq!(base.socket_timeout(), 1_000);
+    }
+
+    #[test]
+    fn both_zero_socket_and_total_yields_zero_effective_socket() {
+        let mut base = BasePolicy::default();
+        base.socket_timeout = 0;
+        base.total_timeout = 0;
+        assert_eq!(base.socket_timeout(), 0);
     }
 }

--- a/aerospike-core/src/policy/read_policy.rs
+++ b/aerospike-core/src/policy/read_policy.rs
@@ -32,6 +32,7 @@ impl Default for BasePolicy {
     fn default() -> BasePolicy {
         BasePolicy {
             socket_timeout: 30000,
+            connect_timeout: 0,
             total_timeout: 1000,
             timeout_delay: 0,
             max_retries: 2,

--- a/aerospike-core/src/txn_monitor.rs
+++ b/aerospike-core/src/txn_monitor.rs
@@ -147,6 +147,7 @@ async fn add_write_keys(
 fn copy_timeout_policy(policy: &BasePolicy, txn: &Arc<Txn>) -> WritePolicy {
     let mut wp = WritePolicy::default();
     wp.base_policy.socket_timeout = policy.socket_timeout;
+    wp.base_policy.connect_timeout = policy.connect_timeout;
     wp.base_policy.total_timeout = policy.total_timeout;
     wp.base_policy.timeout_delay = policy.timeout_delay;
     wp.base_policy.max_retries = policy.max_retries;

--- a/aerospike-core/src/txn_roll.rs
+++ b/aerospike-core/src/txn_roll.rs
@@ -336,6 +336,7 @@ impl TxnRoll {
 fn write_policy_from_base(base: &BasePolicy) -> WritePolicy {
     let mut wp = WritePolicy::default();
     wp.base_policy.socket_timeout = base.socket_timeout;
+    wp.base_policy.connect_timeout = base.connect_timeout;
     wp.base_policy.total_timeout = base.total_timeout;
     wp.base_policy.timeout_delay = base.timeout_delay;
     wp.base_policy.max_retries = base.max_retries;

--- a/tests/proptests/policy.rs
+++ b/tests/proptests/policy.rs
@@ -164,6 +164,7 @@ pub fn base_policy(
                 filter_expression,
             )| BasePolicy {
                 socket_timeout,
+                connect_timeout: 0,
                 total_timeout,
                 timeout_delay,
                 max_retries,


### PR DESCRIPTION
### Out of Scope: `resetDeadline` parity for explicit `connect_timeout`

This PR intentionally does not implement Java's `resetDeadline` behavior for newly established pooled connections.

In Java, when `Policy.connectTimeout > 0`, the command `total_timeout` deadline is reset after connection establishment (including TCP connect, TLS handshake, and authentication), ensuring connection setup time does not consume the command SLA.

This is deferred because `BasePolicy.connect_timeout` defaults to `0`, so Java does not invoke `resetDeadline` in the default path, and steady-state traffic typically uses existing pooled connections. The focus of this PR is timeout separation (`ClientPolicy.timeout`/`login_timeout` vs. command timeouts), not full command deadline accounting parity.

The difference is only observable when users explicitly configure `connect_timeout > 0` together with a tight `total_timeout` (for example, TLS handshakes on pool misses).

This can be added later via a small follow-up change in `SingleCommand` and batch command paths as part of separate ticket
