### PR TITLE
CLIENT-4966: restore connection to  Ready state after authenticate on Ok path

### DIFF
--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -685,7 +685,12 @@ impl Connection {
     ) -> Result<Option<crate::commands::admin_command::SessionInfo>> {
         self.state = ConnectionState::Writing;
         match AdminCommand::authenticate(self, auth_mode, hashed_pass).await {
-            Ok(session) => Ok(session),
+            Ok(session) => {
+                // Restore Ready so PooledConnection::Drop puts the conn back
+                // in the pool instead of taking the non-recoverable close arm.
+                self.set_state(ConnectionState::Ready);
+                Ok(session)
+            }
             Err(err) => {
                 self.close();
                 Err(err)
@@ -705,7 +710,12 @@ impl Connection {
     ) -> Result<bool> {
         self.state = ConnectionState::Writing;
         match AdminCommand::authenticate_session(self, auth_mode, token).await {
-            Ok(ok) => Ok(ok),
+            Ok(ok) => {
+                // Restore Ready so PooledConnection::Drop puts the conn back
+                // in the pool instead of taking the non-recoverable close arm.
+                self.set_state(ConnectionState::Ready);
+                Ok(ok)
+            }
             Err(err) => {
                 self.close();
                 Err(err)

--- a/aerospike-core/src/net/connection_pool.rs
+++ b/aerospike-core/src/net/connection_pool.rs
@@ -515,7 +515,7 @@ impl DerefMut for PooledConnection {
 
 #[cfg(test)]
 mod tests {
-    use crate::net::Connection;
+    use crate::net::{Connection, ConnectionState};
 
     use super::{ClientPolicy, ConnectionPool, Host, Queue};
 
@@ -895,6 +895,81 @@ mod tests {
             2,
             "in-flight connections must count in total_reserved"
         );
+    }
+
+    // Pool's Drop contract: retain Ready conns, close non-Ready ones;
+    // asserted independently of the auth code path.
+
+    /// Non-Ready conn at drop must be closed and its slot released.
+    #[aerospike_macro::test]
+    async fn writing_state_at_drop_evicts_from_pool() {
+        let host = Host::new("some-url", 30000);
+        let policy = ClientPolicy {
+            max_conns_per_node: 8,
+            ..ClientPolicy::default()
+        };
+        let p = ConnectionPool::new(host.clone(), policy.clone(), None);
+
+        {
+            let mut pconn = p.make_conn(0).await.expect("make_conn failed");
+            assert_eq!(p.total_reserved(), 1);
+            pconn.set_state(ConnectionState::Writing);
+        }
+
+        assert_eq!(p.total_reserved(), 0, "non-Ready drop must free the slot");
+        assert_eq!(p.num_conns(), 0, "non-Ready conn must not reach the queue");
+    }
+
+    /// Ready conn at drop must be put back into the pool.
+    #[aerospike_macro::test]
+    async fn ready_state_at_drop_returns_connection_to_pool() {
+        let host = Host::new("some-url", 30000);
+        let policy = ClientPolicy {
+            max_conns_per_node: 8,
+            ..ClientPolicy::default()
+        };
+        let p = ConnectionPool::new(host.clone(), policy.clone(), None);
+
+        {
+            let pconn = p.make_conn(0).await.expect("make_conn failed");
+            assert_eq!(p.total_reserved(), 1);
+            drop(pconn);
+        }
+
+        assert_eq!(p.total_reserved(), 1, "Ready drop must keep the slot");
+        assert_eq!(p.num_conns(), 1, "Ready conn must be in the queue");
+    }
+
+    /// fill_min_conns fixpoint: non-Ready path leaves reserved at 0 (churn);
+    /// Ready path reaches `min` in one pass so next tend does nothing.
+    #[aerospike_macro::test]
+    async fn fill_min_conns_fixpoint_bug_vs_fixed() {
+        let host = Host::new("some-url", 30000);
+        let min = 32usize;
+        let policy = ClientPolicy {
+            min_conns_per_node: min,
+            max_conns_per_node: 128,
+            conn_pools_per_node: 4,
+            ..ClientPolicy::default()
+        };
+
+        // Non-Ready path: nothing accumulates.
+        let buggy = ConnectionPool::new(host.clone(), policy.clone(), None);
+        for i in 0..min {
+            let mut pconn = buggy.make_conn(i).await.expect("make_conn failed");
+            pconn.set_state(ConnectionState::Writing);
+        }
+        assert_eq!(buggy.total_reserved(), 0, "non-Ready loop never grows the pool");
+        assert_eq!(buggy.num_conns(), 0);
+
+        // Ready path: pool reaches min in one pass.
+        let fixed = ConnectionPool::new(host.clone(), policy.clone(), None);
+        for i in 0..min {
+            let pconn = fixed.make_conn(i).await.expect("make_conn failed");
+            drop(pconn);
+        }
+        assert_eq!(fixed.total_reserved(), min, "Ready loop reaches min");
+        assert_eq!(fixed.num_conns(), min);
     }
 
     // Tests the Drop/Closed path — Netsocket::TestDummy bypasses TCP so the


### PR DESCRIPTION
## Root Cause

`authenticate()` and `authenticate_with_session()` set the connection state to Writing on entry, but failed to restore it to `Ready` on the successful (`Ok`) path. As a result, newly created Connection instances remained in the Writing state.

When `fill_min_conns()` invoked `make_conn().await`?, the returned connections were dropped as temporaries. Because their state was still `Writing`, `PooledConnection::Drop` treated them as non-recoverable and closed them instead of returning them to the pool. Consequently, the pool's reserved connection count never increased, causing every subsequent tend cycle to recreate the full `min_conns_per_node` set indefinitely.

Three regression tests have been added to verify the pool's `Drop` contract and prevent this behavior from regressing.

Notably, this bug occurs regardless of whether authentication actually takes place. The connection state is set to `Writing` before the authentication mode is checked, so the incorrect state persists even when no authentication bytes are sent over the wire.

## Test Environment

* **Aerospike Enterprise Edition:** 8.1.2.3, 3-node cluster via aerolab
* **Client:** This branch, benchmark tool
* **`min_conns_per_node`:** 32
* **`conn_pools_per_node`:** 4
* **Workers (`-t`):** 8 (< `min_conns_per_node`)
* **Workload:** Mixed reads and writes
* **Duration:** 55 seconds
* **Observation Method:** `docker exec asinfo -v statistics` polled every second

## Results: Before vs. After the Fix

The benchmark was executed twice using identical code, commands, and cluster configuration: once on the unfixed branch and once after applying the fix.

* **Connection opens per second:** 36 → 1
* **Total connections opened (~44 s):** 1,061 → 35
* **Server-side live connection count:** Oscillating between 10 and 34 → Stable at 34
* **Operations per second:** ~9,700 → ~9,970
* **Errors:** 0 → 0
* **Timeouts:** 0 → 0
