### PR TITLE
top-k api

### DIFF
--- a/aerospike-core/src/client.rs
+++ b/aerospike-core/src/client.rs
@@ -2281,7 +2281,7 @@ impl Client {
         }
     }
 
-    /// `order_by`/`top_k` (Top-K) are foreground-only (§1, §7): background
+    /// `order_by`/`top_k` (Top-K) are foreground-only: background
     /// jobs (`query_operate`, `query_execute_udf`) don't produce a result
     /// stream for the client to merge into, so there's nothing for
     /// `TopKMerger` to do. Called by both background entry points before
@@ -2298,7 +2298,7 @@ impl Client {
         Ok(())
     }
 
-    /// Merges every node's already-bounded Top-K buffer (§6.2's
+    /// Merges every node's already-bounded Top-K buffer (via
     /// `TopKMerger`) into the final global Top-K and pushes the result into
     /// `recordset` as a single batch. Split out from
     /// [`Self::execute_top_k_query`] so the merge-and-push step itself is
@@ -3634,8 +3634,8 @@ mod top_k_execution_tests {
 
     #[test]
     fn order_by_without_top_k_merges_unbounded() {
-        // `top_k` is optional (§8 Phase 0); without it the merge still
-        // sorts but doesn't truncate.
+        // `top_k` is optional; without it the merge still sorts but
+        // doesn't truncate.
         let rs = empty_recordset();
         let mut stmt = Statement::new("ns", "set", Bins::All);
         stmt.set_order_by("score", OrderByType::Integer, Order::Asc);

--- a/aerospike-core/src/client.rs
+++ b/aerospike-core/src/client.rs
@@ -42,7 +42,7 @@ use crate::policy::{
     AdminPolicy, BatchPolicy, ClientPolicy, QueryPolicy, ReadPolicy, TxnRollPolicy,
     TxnVerifyPolicy, WritePolicy,
 };
-use crate::query::{PartitionFilter, PartitionTracker};
+use crate::query::{NodePartitions, PartitionFilter, PartitionTracker};
 #[cfg(feature = "lua")]
 use crate::query::ResultSet;
 use crate::task::{DropIndexTask, ExecuteTask, IndexTask, RegisterTask, UdfRemoveTask};
@@ -1516,15 +1516,33 @@ impl Client {
         let t_recordset = recordset.clone();
         let defer_recordset = recordset.clone();
         let cluster = self.cluster.clone();
+        // Top-K (`ORDER BY <bin> LIMIT k`) statements go through a
+        // dedicated executor: each node buffers its own already-bounded
+        // result instead of streaming record-by-record, and the client
+        // merges every node's buffer into the final global Top-K once the
+        // whole job completes (see `execute_top_k_query` and
+        // `query::top_k_merge::TopKMerger`).
+        let is_top_k = statement.order_by.is_some();
         aerospike_rt::spawn(async move {
-            Self::execute_query_timeout(
-                cluster,
-                &t_policy,
-                tracker.clone(),
-                statement.clone(),
-                t_recordset,
-            )
-            .await;
+            if is_top_k {
+                Self::execute_top_k_query_timeout(
+                    cluster,
+                    &t_policy,
+                    tracker.clone(),
+                    statement.clone(),
+                    t_recordset,
+                )
+                .await;
+            } else {
+                Self::execute_query_timeout(
+                    cluster,
+                    &t_policy,
+                    tracker.clone(),
+                    statement.clone(),
+                    t_recordset,
+                )
+                .await;
+            }
             defer_recordset.close();
         });
 
@@ -1751,6 +1769,7 @@ impl Client {
         // public API for backwards compatibility.
         statement.operations = Some(operations.to_vec());
         statement.validate()?;
+        Self::reject_top_k_on_background_query(&statement)?;
 
         let nodes = self.cluster.nodes();
         if nodes.is_empty() {
@@ -1818,6 +1837,7 @@ impl Client {
         function_name: &str,
         args: Option<&[Value]>,
     ) -> Result<ExecuteTask> {
+        Self::reject_top_k_on_background_query(&statement)?;
         statement.set_aggregate_function(package_name, function_name, args);
         statement.validate()?;
 
@@ -1937,6 +1957,7 @@ impl Client {
                                 recordset.clone(),
                                 node_partition,
                                 cluster,
+                                None,
                             )
                             .await
                             .execute()
@@ -2004,6 +2025,302 @@ impl Client {
             }
 
             recordset.reset_task_id();
+        }
+    }
+
+    async fn execute_top_k_query_timeout(
+        cluster: Arc<Cluster>,
+        policy: &QueryPolicy,
+        tracker: Arc<Mutex<PartitionTracker>>,
+        statement: Arc<Statement>,
+        recordset: Arc<Recordset>,
+    ) {
+        if policy.total_timeout() > 0 {
+            let rs_closer = recordset.clone();
+            if aerospike_rt::timeout(
+                Duration::from_millis(u64::from(policy.total_timeout())),
+                Self::execute_top_k_query(cluster, policy, tracker, statement, recordset),
+            )
+            .await
+            .is_err()
+            {
+                let _ = rs_closer
+                    .push(Err(Error::timeout("Timeout".to_string())))
+                    .await;
+            }
+        } else {
+            Self::execute_top_k_query(cluster, policy, tracker, statement, recordset).await;
+        }
+    }
+
+    /// Dedicated executor for Top-K (`ORDER BY <bin> LIMIT k`) statements.
+    ///
+    /// Structurally this mirrors [`Self::execute_query`]'s round-based retry
+    /// loop (partitions are (re)assigned to nodes, one command is spawned
+    /// per node, the loop repeats until [`PartitionTracker::is_complete`]
+    /// says the job is done), but with the streaming behavior replaced by
+    /// per-node buffering + a final client-side merge:
+    ///
+    /// * Each node command is given its own `Arc<Mutex<Vec<Record>>>`
+    ///   (`StreamCommand::top_k_buffer`); on success that buffer (already
+    ///   bounded to `<= k` and sorted server-side) is folded into
+    ///   `all_node_results`, which accumulates across retry rounds.
+    /// * Top-K is single-shot — the server rejects non-zero resume cursors
+    ///   outright — so a node command failure can't be resumed
+    ///   partition-by-partition like a normal query/scan can. Any node
+    ///   error therefore forces a **whole-job retry**: every partition is
+    ///   marked for retry (`PartitionTracker::mark_all_for_retry`) and
+    ///   every buffer gathered so far (this round's and any earlier
+    ///   round's) is discarded, so the eventual merge never mixes results
+    ///   from two differently-scoped attempts.
+    /// * A client-side capability error (`ErrorKind::InvalidArgument` —
+    ///   e.g. `set_query` rejecting the statement because the node doesn't
+    ///   support Top-K yet) is treated as fatal rather than transient:
+    ///   retrying can't fix it, so it's surfaced to the caller immediately
+    ///   instead of being retried until `max_retries`/timeout.
+    /// * Once a round completes with no node errors and
+    ///   `PartitionTracker::is_complete` reports the job done, every
+    ///   accumulated per-node buffer is handed to
+    ///   [`crate::query::top_k_merge::TopKMerger`] and the merged,
+    ///   deduped, truncated result is pushed into `recordset` as a single
+    ///   batch before the stream is closed.
+    async fn execute_top_k_query(
+        cluster: Arc<Cluster>,
+        policy: &QueryPolicy,
+        tracker: Arc<Mutex<PartitionTracker>>,
+        statement: Arc<Statement>,
+        recordset: Arc<Recordset>,
+    ) {
+        let namespace = statement.namespace.clone();
+        let sleep_multiplier = policy.base_policy.sleep_multiplier();
+        let mut sleep_interval = policy.base_policy.sleep_between_retries();
+
+        // Accumulates every node's already-bounded, sorted Top-K buffer
+        // across retry rounds. Cleared whenever a round has any error,
+        // since Top-K can't resume partially (see doc comment above).
+        let mut all_node_results: Vec<Vec<Record>> = Vec::new();
+
+        loop {
+            let mut timed_out = false;
+            let mut round_had_error = false;
+            let mut fatal_error: Option<Error> = None;
+            let node_list: Vec<Arc<Mutex<NodePartitions>>>;
+            {
+                let mut tracker_locked = tracker.lock().await;
+                match tracker_locked
+                    .assign_partitions_to_nodes(cluster.clone(), &namespace)
+                    .await
+                {
+                    Ok(()) => (),
+                    Err(e) => {
+                        recordset.err(e).await;
+                        tracker_locked.partition_error().await;
+                        return;
+                    }
+                }
+
+                node_list = tracker_locked.node_partitions_list().to_vec();
+                recordset.set_instances(node_list.len() + 1); // +1 is for the async executor
+
+                if recordset.is_active() {
+                    let semaphore = Arc::new(Semaphore::new(if policy.max_concurrent_nodes == 0 {
+                        MAX_PERMITS
+                    } else {
+                        policy.max_concurrent_nodes
+                    }));
+
+                    let mut handles = Vec::with_capacity(node_list.len());
+                    for node_partition in &node_list {
+                        let semaphore = semaphore.clone();
+                        let recordset = recordset.clone();
+                        let policy = policy.clone();
+                        let node_partition = node_partition.clone();
+                        let statement = statement.clone();
+                        let cluster = cluster.clone();
+                        let handle = aerospike_rt::spawn(async move {
+                            let permit = semaphore.acquire().await;
+                            let buffer: Arc<Mutex<Vec<Record>>> = Arc::new(Mutex::new(Vec::new()));
+                            let result = QueryCommand::new(
+                                &policy,
+                                statement,
+                                recordset.clone(),
+                                node_partition,
+                                cluster,
+                                Some(buffer.clone()),
+                            )
+                            .await
+                            .execute()
+                            .await;
+
+                            drop(permit);
+                            match result {
+                                Ok(()) => Ok(std::mem::take(&mut *buffer.lock().await)),
+                                Err(e) => Err(e),
+                            }
+                        });
+                        handles.push(handle);
+                    }
+
+                    drop(tracker_locked);
+
+                    // `JoinHandle<T>`'s `Future::Output` differs by runtime:
+                    // tokio wraps it as `Result<T, JoinError>` (so a single
+                    // node's `Result<Vec<Record>>` surfaces inside the `Ok`
+                    // arm below and is inspected one by one), while
+                    // async-std's is `T` directly (so `try_join_all` itself
+                    // treats each node's `Result<Vec<Record>>` as its own
+                    // `TryFuture` output and short-circuits on the first
+                    // per-node error). Both arms apply the same three
+                    // outcomes — fatal capability error, timeout-ish
+                    // transient error, or generic transient error — just at
+                    // different match depths.
+                    #[cfg(feature = "rt-tokio")]
+                    match futures::future::try_join_all(handles).await {
+                        Err(e) => {
+                            warn!("Top-K query node task join error: {e}");
+                            round_had_error = true;
+                        }
+                        Ok(results) => {
+                            for r in results {
+                                match r {
+                                    Ok(buf) => all_node_results.push(buf),
+                                    Err(e) if matches!(e.kind(), ErrorKind::InvalidArgument) => {
+                                        fatal_error = Some(e);
+                                    }
+                                    Err(e)
+                                        if matches!(
+                                            e.kind(),
+                                            ErrorKind::Timeout
+                                                | ErrorKind::Io(_)
+                                                | ErrorKind::Connection
+                                        ) =>
+                                    {
+                                        timed_out = true;
+                                        round_had_error = true;
+                                    }
+                                    Err(_) => round_had_error = true,
+                                }
+                            }
+                        }
+                    }
+                    #[cfg(feature = "rt-async-std")]
+                    match futures::future::try_join_all(handles).await {
+                        Err(e) if matches!(e.kind(), ErrorKind::InvalidArgument) => {
+                            fatal_error = Some(e);
+                        }
+                        Err(e)
+                            if matches!(
+                                e.kind(),
+                                ErrorKind::Timeout | ErrorKind::Io(_) | ErrorKind::Connection
+                            ) =>
+                        {
+                            timed_out = true;
+                            round_had_error = true;
+                        }
+                        Err(e) => {
+                            warn!("Top-K query node task error: {e}");
+                            round_had_error = true;
+                        }
+                        Ok(results) => {
+                            all_node_results.extend(results);
+                        }
+                    }
+                } else {
+                    drop(tracker_locked);
+                }
+            }
+
+            if let Some(e) = fatal_error {
+                recordset.err(e).await;
+                return;
+            }
+
+            if round_had_error {
+                tracker.lock().await.mark_all_for_retry().await;
+                all_node_results.clear();
+                // Guarantee `is_complete` below sees this round as
+                // incomplete (rather than relying solely on `timed_out`,
+                // which isn't set for every error kind).
+                if let Some(np) = node_list.first() {
+                    np.lock().await.parts_unavailable += 1;
+                }
+            }
+
+            let mut tracker_locked = tracker.lock().await;
+            let done = tracker_locked.is_complete(policy, timed_out).await;
+            match (done, recordset.is_active()) {
+                (Ok(true), true) if !round_had_error => {
+                    drop(tracker_locked);
+                    Self::merge_and_push_top_k_results(
+                        &statement,
+                        std::mem::take(&mut all_node_results),
+                        &recordset,
+                    )
+                    .await;
+                    return;
+                }
+                (Ok(true), _) | (Ok(_), false) => return,
+                (Err(e), _) => {
+                    tracker_locked.partition_error().await;
+                    recordset.err(e).await;
+                    return;
+                }
+                _ => (),
+            }
+            drop(tracker_locked);
+
+            if let Some(interval) = sleep_interval {
+                sleep(interval).await;
+                sleep_interval = Some(crate::policy::next_retry_interval(
+                    interval,
+                    sleep_multiplier,
+                ));
+            }
+
+            recordset.reset_task_id();
+        }
+    }
+
+    /// `order_by`/`top_k` (Top-K) are foreground-only (§1, §7): background
+    /// jobs (`query_operate`, `query_execute_udf`) don't produce a result
+    /// stream for the client to merge into, so there's nothing for
+    /// `TopKMerger` to do. Called by both background entry points before
+    /// they build/send their `ServerCommand`; `Client::query`'s foreground
+    /// path never needs this (it's the one path Top-K is valid on).
+    fn reject_top_k_on_background_query(statement: &Statement) -> Result<()> {
+        if statement.order_by.is_some() || statement.top_k.is_some() {
+            return Err(Error::invalid_argument(
+                "orderBy/topK is only valid on foreground (SELECT-style) queries; background \
+                 (UPDATE-style) queries do not produce a result stream"
+                    .to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Merges every node's already-bounded Top-K buffer (§6.2's
+    /// `TopKMerger`) into the final global Top-K and pushes the result into
+    /// `recordset` as a single batch. Split out from
+    /// [`Self::execute_top_k_query`] so the merge-and-push step itself is
+    /// unit-testable with synthetic per-node buffers and a real
+    /// (channel-based) `Recordset`, without needing a live server or the
+    /// surrounding retry loop.
+    async fn merge_and_push_top_k_results(
+        statement: &Statement,
+        all_node_results: Vec<Vec<Record>>,
+        recordset: &Recordset,
+    ) {
+        let Some(order_by) = statement.order_by.clone() else {
+            // Should be unreachable: only called from `execute_top_k_query`,
+            // which only ever runs for statements with `order_by` set.
+            return;
+        };
+        let limit = statement.top_k.map_or(usize::MAX, |k| k as usize);
+        let merger = crate::query::TopKMerger::new(order_by, limit);
+        for record in merger.merge(all_node_results) {
+            if recordset.push(Ok(record)).await.is_err() {
+                break;
+            }
         }
     }
 
@@ -3200,5 +3517,208 @@ impl Client {
             )),
             TxnState::Aborted => Ok(AbortStatus::AlreadyAborted),
         }
+    }
+}
+
+#[cfg(test)]
+mod top_k_execution_tests {
+    //! Unit/mock-level tests for the Top-K per-node-buffering + final-merge
+    //! wiring that don't require a live server: feed synthetic per-node buffers
+    //! through `Client::merge_and_push_top_k_results` and assert the
+    //! `Recordset` observes the correctly merged/deduped/truncated/ordered
+    //! result, then closes.
+    use super::Client;
+    use crate::query::{Order, OrderByFlags, OrderByType, PartitionFilter, PartitionTracker, Recordset};
+    use crate::{Bins, IndexMap, Key, Record, Result, Statement, Value};
+    use aerospike_rt::Mutex;
+    use futures::executor::block_on;
+    use futures::StreamExt;
+    use std::sync::Arc;
+
+    fn top_k_statement(bin: &str, direction: Order, k: u32) -> Statement {
+        let mut stmt = Statement::new("ns", "set", Bins::All);
+        stmt.set_order_by(bin, OrderByType::Integer, direction);
+        stmt.set_top_k(k);
+        stmt
+    }
+
+    fn record(digest_byte: u8, generation: u32, score: i64) -> Record {
+        let mut bins = IndexMap::new();
+        bins.insert("score".to_string(), Value::Int(score));
+        Record::new(
+            Some(Key {
+                namespace: "ns".to_string(),
+                set_name: "set".to_string(),
+                user_key: None,
+                digest: [digest_byte; 20],
+            }),
+            bins,
+            None,
+            generation,
+            0,
+        )
+    }
+
+    fn empty_recordset() -> Arc<Recordset> {
+        let tracker = block_on(PartitionTracker::new(
+            &crate::policy::QueryPolicy::default(),
+            Arc::new(Mutex::new(PartitionFilter::all())),
+            Vec::new(),
+        ))
+        .expect("tracker");
+        Arc::new(Recordset::new(8, 0, 1, Arc::new(Mutex::new(tracker))))
+    }
+
+    /// Closes `rs` (mirroring what `execute_top_k_query`'s caller does once
+    /// the whole job finishes) and drains every buffered record.
+    fn close_and_drain(rs: &Arc<Recordset>) -> Vec<Result<Record>> {
+        rs.close();
+        let mut stream = rs.clone().into_stream();
+        block_on(async {
+            let mut out = Vec::new();
+            while let Some(item) = stream.next().await {
+                out.push(item);
+            }
+            out
+        })
+    }
+
+    #[test]
+    fn merges_and_pushes_bounded_ordered_results_then_leaves_stream_open() {
+        // `merge_and_push_top_k_results` only pushes; closing the
+        // `Recordset` is `execute_top_k_query`'s (and its caller's)
+        // responsibility, exactly like the non-Top-K path.
+        let rs = empty_recordset();
+        let stmt = top_k_statement("score", Order::Desc, 2);
+
+        // Three "nodes'" worth of already-bounded, per-node-sorted buffers.
+        let per_node = vec![
+            vec![record(1, 1, 5), record(2, 1, 1)],
+            vec![record(3, 1, 9)],
+            vec![record(4, 1, 3)],
+        ];
+
+        block_on(Client::merge_and_push_top_k_results(&stmt, per_node, &rs));
+
+        let scores: Vec<i64> = close_and_drain(&rs)
+            .into_iter()
+            .map(|r| match r.unwrap().bins["score"] {
+                Value::Int(i) => i,
+                _ => panic!("expected int"),
+            })
+            .collect();
+
+        // Best-first (DESC), truncated to k = 2.
+        assert_eq!(scores, vec![9, 5]);
+    }
+
+    #[test]
+    fn dedups_by_digest_generation_first_across_node_buffers() {
+        let rs = empty_recordset();
+        let stmt = top_k_statement("score", Order::Desc, 10);
+
+        let stale_but_better = record(1, 1, 9);
+        let fresh_but_worse = record(1, 2, 1);
+
+        block_on(Client::merge_and_push_top_k_results(
+            &stmt,
+            vec![vec![stale_but_better], vec![fresh_but_worse]],
+            &rs,
+        ));
+
+        let results = close_and_drain(&rs);
+        assert_eq!(results.len(), 1, "duplicate digest must be deduped across node buffers");
+        let rec = results[0].as_ref().unwrap();
+        assert_eq!(rec.generation, 2, "generation-first dedup must keep the newer read");
+    }
+
+    #[test]
+    fn order_by_without_top_k_merges_unbounded() {
+        // `top_k` is optional (§8 Phase 0); without it the merge still
+        // sorts but doesn't truncate.
+        let rs = empty_recordset();
+        let mut stmt = Statement::new("ns", "set", Bins::All);
+        stmt.set_order_by("score", OrderByType::Integer, Order::Asc);
+
+        let per_node = vec![vec![record(1, 1, 3), record(2, 1, 1), record(3, 1, 2)]];
+        block_on(Client::merge_and_push_top_k_results(&stmt, per_node, &rs));
+
+        let scores: Vec<i64> = close_and_drain(&rs)
+            .into_iter()
+            .map(|r| match r.unwrap().bins["score"] {
+                Value::Int(i) => i,
+                _ => panic!("expected int"),
+            })
+            .collect();
+        assert_eq!(scores, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn empty_node_results_push_nothing() {
+        let rs = empty_recordset();
+        let stmt = top_k_statement("score", Order::Desc, 5);
+        block_on(Client::merge_and_push_top_k_results(&stmt, Vec::new(), &rs));
+        assert!(close_and_drain(&rs).is_empty());
+    }
+
+    #[test]
+    fn case_insensitive_string_order_by_merges_correctly() {
+        let rs = empty_recordset();
+        let mut stmt = Statement::new("ns", "set", Bins::All);
+        stmt.set_order_by_with_flags(
+            "name",
+            OrderByType::String,
+            Order::Asc,
+            OrderByFlags::CaseInsensitive,
+        );
+
+        let mut upper = record(1, 1, 0);
+        upper.bins.insert("name".to_string(), Value::String("Banana".to_string()));
+        let mut lower = record(2, 1, 0);
+        lower.bins.insert("name".to_string(), Value::String("apple".to_string()));
+
+        block_on(Client::merge_and_push_top_k_results(
+            &stmt,
+            vec![vec![upper], vec![lower]],
+            &rs,
+        ));
+
+        let names: Vec<String> = close_and_drain(&rs)
+            .into_iter()
+            .map(|r| match r.unwrap().bins["name"].clone() {
+                Value::String(s) => s,
+                _ => panic!("expected string"),
+            })
+            .collect();
+        assert_eq!(names, vec!["apple".to_string(), "Banana".to_string()]);
+    }
+
+    #[test]
+    fn background_query_guard_rejects_order_by() {
+        let stmt = top_k_statement("score", Order::Desc, 5);
+        let err = Client::reject_top_k_on_background_query(&stmt).unwrap_err();
+        assert!(err.to_string().contains("foreground"));
+    }
+
+    #[test]
+    fn background_query_guard_allows_plain_statement() {
+        let stmt = Statement::new("ns", "set", Bins::All);
+        assert!(Client::reject_top_k_on_background_query(&stmt).is_ok());
+    }
+
+    #[test]
+    fn merge_uses_order_by_clone_not_the_original_reference() {
+        // Regression for a borrow/lifetime mistake: `merge_and_push_top_k_results`
+        // takes `&Statement`, not an owned one, so the statement must still be
+        // usable by the caller afterward (e.g. across retry rounds).
+        let rs = empty_recordset();
+        let stmt = top_k_statement("score", Order::Desc, 1);
+        block_on(Client::merge_and_push_top_k_results(
+            &stmt,
+            vec![vec![record(1, 1, 1)]],
+            &rs,
+        ));
+        // `stmt` is still valid to read here.
+        assert_eq!(stmt.top_k, Some(1));
     }
 }

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -1056,6 +1056,27 @@ impl fmt::Display for Node {
     }
 }
 
+/// Builds a minimal, connection-less `Node` pinned to `version`, for unit
+/// tests elsewhere in the crate that need to exercise version-gated
+/// wire-encode paths (e.g. `commands::buffer::tests`) without a live server.
+#[cfg(test)]
+pub(crate) fn test_node_with_version(version: crate::Version) -> Node {
+    let policy = ClientPolicy::default();
+    let nv = Arc::new(NodeValidator {
+        name: "test-node".to_string(),
+        aliases: vec![Host::new("127.0.0.1", 3000)],
+        address: "127.0.0.1:3000".to_string(),
+        client_policy: policy.clone(),
+        use_new_info: true,
+        version,
+        detect_load_balancer: false,
+    });
+    let metrics = Arc::new(crate::metrics::NodeMetrics::new(
+        crate::metrics::MetricsPolicy::default(),
+    ));
+    Node::new(policy, nv, metrics, Arc::new(AtomicUsize::new(0)), None)
+}
+
 #[cfg(test)]
 mod node_tests {
     use std::sync::Arc;
@@ -1065,23 +1086,10 @@ mod node_tests {
     use crate::policy::ClientPolicy;
     use crate::Version;
 
-    use super::Node;
+    use super::{test_node_with_version, Node};
 
     fn test_node() -> Node {
-        let policy = ClientPolicy::default();
-        let nv = Arc::new(NodeValidator {
-            name: "test-node".to_string(),
-            aliases: vec![Host::new("127.0.0.1", 3000)],
-            address: "127.0.0.1:3000".to_string(),
-            client_policy: policy.clone(),
-            use_new_info: true,
-            version: Version::default(),
-            detect_load_balancer: false,
-        });
-        let metrics = Arc::new(crate::metrics::NodeMetrics::new(
-            crate::metrics::MetricsPolicy::default(),
-        ));
-        Node::new(policy, nv, metrics, Arc::new(std::sync::atomic::AtomicUsize::new(0)), None)
+        test_node_with_version(Version::default())
     }
 
     /// One idle connection in the pool, using the test [`crate::net::Connection`] (no real socket).

--- a/aerospike-core/src/cluster/version_parser.rs
+++ b/aerospike-core/src/cluster/version_parser.rs
@@ -117,6 +117,20 @@ impl Version {
     pub fn supports_server_compiled_ael(&self) -> bool {
         self >= &Version::new(8, 1, 3, 0)
     }
+
+    /// Server supports `ORDER BY <bin> LIMIT k` ("Top-K") queries
+    /// (`FieldType::OrderBy` / `FieldType::TopK` on the wire).
+    ///
+    /// This feature has no assigned minimum server version yet (still
+    /// unreleased). The threshold below (`u64::MAX` major) is a deliberate
+    /// placeholder no real server can ever report, so this safely evaluates
+    /// to `false` for every real cluster while still letting unit tests
+    /// exercise the gated wire-encode path in
+    /// `commands/buffer.rs::set_query` by constructing a `Version` above it.
+    /// Replace with the real minimum version once one is assigned.
+    pub fn supports_query_top_k(&self) -> bool {
+        self >= &Version::new(u64::MAX, 0, 0, 0)
+    }
 }
 
 #[derive(Debug)]

--- a/aerospike-core/src/commands/buffer.rs
+++ b/aerospike-core/src/commands/buffer.rs
@@ -1512,6 +1512,29 @@ impl Buffer {
             field_count += 4;
         }
 
+        // ---------- estimation: order_by / top_k (Top-K queries) ----------
+        if statement.order_by.is_some() && !node.version().supports_query_top_k() {
+            return Err(Error::invalid_argument(
+                "orderBy/topK requires a server version that supports Top-K queries \
+                 (not yet released)",
+            ));
+        }
+
+        let mut order_by_size = 0;
+        if let Some(ref order_by) = statement.order_by {
+            order_by_size += encoder::pack_array_begin(&mut None, 4);
+            order_by_size += encoder::pack_raw_string(&mut None, &order_by.bin_name);
+            order_by_size += encoder::pack_integer(&mut None, order_by.order_type as i64);
+            order_by_size += encoder::pack_integer(&mut None, order_by.direction as i64);
+            order_by_size += encoder::pack_integer(&mut None, order_by.flags.to_wire_bits() as i64);
+            self.data_offset += order_by_size + FIELD_HEADER_SIZE as usize;
+            field_count += 1;
+        }
+        if statement.top_k.is_some() {
+            self.data_offset += 4 + FIELD_HEADER_SIZE as usize;
+            field_count += 1;
+        }
+
         // ---------- estimation: policy filter expression ----------
         let filter_exp_size = self.estimate_filter_size(direction.filter_expression())?;
         if filter_exp_size > 0 {
@@ -1675,6 +1698,18 @@ impl Buffer {
             } else {
                 self.write_args(None, FieldType::UdfArgList)?;
             }
+        }
+
+        if let Some(ref order_by) = statement.order_by {
+            self.write_field_header(order_by_size, FieldType::OrderBy);
+            encoder::pack_array_begin(&mut Some(self), 4);
+            encoder::pack_raw_string(&mut Some(self), &order_by.bin_name);
+            encoder::pack_integer(&mut Some(self), order_by.order_type as i64);
+            encoder::pack_integer(&mut Some(self), order_by.direction as i64);
+            encoder::pack_integer(&mut Some(self), order_by.flags.to_wire_bits() as i64);
+        }
+        if let Some(k) = statement.top_k {
+            self.write_field_u32(k, FieldType::TopK);
         }
 
         if let Some(filter_exp) = direction.filter_expression() {
@@ -3604,5 +3639,108 @@ mod tests {
         let (read_attr, write_attr) = operate_attrs(&[scalar::get(), str_op::strlen("b")]);
         assert_ne!(read_attr & INFO1_GET_ALL, 0);
         assert_eq!(write_attr & INFO2_RESPOND_ALL_OPS, 0);
+    }
+
+    /// Scans the wire fields written after the message header, returning
+    /// `(FieldType as u8, payload bytes)` pairs in wire order. Only valid
+    /// for buffers with no trailing operations (e.g. `Bins::All`, which
+    /// emits zero ops), since fields and ops share no length-prefixed
+    /// framing that would let this stop at the field/op boundary otherwise.
+    fn read_wire_fields(buf: &Buffer) -> Vec<(u8, Vec<u8>)> {
+        let mut fields = Vec::new();
+        let mut offset = buf.compress_offset + MSG_TOTAL_HEADER_SIZE as usize;
+        while offset < buf.data_buffer.len() {
+            let size = NetworkEndian::read_u32(&buf.data_buffer[offset..offset + 4]) as usize;
+            let ftype = buf.data_buffer[offset + 4];
+            let payload = buf.data_buffer[offset + 5..offset + 4 + size].to_vec();
+            fields.push((ftype, payload));
+            offset += 4 + size;
+        }
+        fields
+    }
+
+    #[test]
+    fn order_by_and_top_k_are_rejected_without_capability_support() {
+        use crate::query::{Order, OrderByType};
+        use crate::{Bins, QueryPolicy, Statement};
+
+        let mut buf = Buffer::new(4096);
+        let node = crate::cluster::node::test_node_with_version(crate::Version::default());
+        let mut stmt = Statement::new("test", "test", Bins::All);
+        stmt.set_order_by("score", OrderByType::Integer, Order::Desc);
+        stmt.set_top_k(5);
+
+        let err = buf
+            .set_query(
+                QueryDirection::Foreground(&QueryPolicy::default()),
+                &stmt,
+                1,
+                &node,
+                None,
+            )
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("Top-K"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn order_by_and_top_k_encode_to_the_documented_wire_format() {
+        use crate::query::order_by::{Order, OrderByFlags, OrderByType};
+        use crate::{Bins, QueryPolicy, Statement};
+
+        let mut buf = Buffer::new(4096);
+        // Sentinel version above `supports_query_top_k()`'s placeholder
+        // threshold — see that function's docs for why this is safe.
+        let node = crate::cluster::node::test_node_with_version(crate::Version::new(
+            u64::MAX,
+            0,
+            0,
+            0,
+        ));
+        let mut stmt = Statement::new("test", "test", Bins::All);
+        stmt.set_order_by_with_flags(
+            "score",
+            OrderByType::Integer,
+            Order::Desc,
+            OrderByFlags::CaseInsensitive,
+        );
+        stmt.set_top_k(5);
+
+        buf.set_query(
+            QueryDirection::Foreground(&QueryPolicy::default()),
+            &stmt,
+            1,
+            &node,
+            None,
+        )
+        .unwrap();
+
+        let fields = read_wire_fields(&buf);
+
+        let order_by_payload = fields
+            .iter()
+            .find(|(ftype, _)| *ftype == FieldType::OrderBy as u8)
+            .map(|(_, payload)| payload.clone())
+            .expect("OrderBy field must be present");
+
+        // msgpack 4-element fixarray, then a plain (untagged) fixstr
+        // "score", then three fixints (type=Integer=0, direction=Desc=1,
+        // flags=CaseInsensitive=1).
+        let mut expected = vec![0x94]; // fixarray, len 4
+        expected.push(0xa5); // fixstr, len 5
+        expected.extend_from_slice(b"score");
+        expected.push(0); // OrderByType::Integer
+        expected.push(1); // Order::Desc
+        expected.push(1); // OrderByFlags::CaseInsensitive wire bit
+        assert_eq!(order_by_payload, expected);
+
+        let top_k_payload = fields
+            .iter()
+            .find(|(ftype, _)| *ftype == FieldType::TopK as u8)
+            .map(|(_, payload)| payload.clone())
+            .expect("TopK field must be present");
+        assert_eq!(top_k_payload, 5u32.to_be_bytes().to_vec());
     }
 }

--- a/aerospike-core/src/commands/field_type.rs
+++ b/aerospike-core/src/commands/field_type.rs
@@ -71,4 +71,16 @@ pub enum FieldType {
     /// expression trace). Present on failure responses only when
     /// error-detail verbosity was requested. Requires server 8.1.3+.
     ErrorMessage = 45,
+    /// Top-K order-by clause: msgpack 4-element array
+    /// `[bin_name, type: uint, direction: uint, flags: uint]`. Written by
+    /// `commands/buffer.rs::set_query`, but gated behind
+    /// `Version::supports_query_top_k()`, which always evaluates to `false`
+    /// against a real server until a real minimum version is assigned (this
+    /// feature is unreleased as of this writing) — see
+    /// [`crate::query::order_by`].
+    OrderBy = 46,
+    /// Top-K limit (`k`): plain big-endian `uint32_t`, `k` in `[1, 1000]`.
+    /// Written alongside [`FieldType::OrderBy`] under the same
+    /// capability gate.
+    TopK = 47,
 }

--- a/aerospike-core/src/commands/query_command.rs
+++ b/aerospike-core/src/commands/query_command.rs
@@ -21,7 +21,7 @@ use crate::errors::Result;
 use crate::net::Connection;
 use crate::policy::QueryPolicy;
 use crate::query::NodePartitions;
-use crate::{Recordset, Statement};
+use crate::{Record, Recordset, Statement};
 
 use aerospike_rt::Mutex;
 
@@ -38,6 +38,7 @@ impl<'a> QueryCommand<'a> {
         recordset: Arc<Recordset>,
         node_partitions: Arc<Mutex<NodePartitions>>,
         cluster: Arc<Cluster>,
+        top_k_buffer: Option<Arc<Mutex<Vec<Record>>>>,
     ) -> Self {
         let node = {
             let node_partitions = node_partitions.lock().await;
@@ -45,7 +46,14 @@ impl<'a> QueryCommand<'a> {
         };
 
         QueryCommand {
-            stream_command: StreamCommand::new(node, recordset, node_partitions, false, cluster),
+            stream_command: StreamCommand::new(
+                node,
+                recordset,
+                node_partitions,
+                false,
+                cluster,
+                top_k_buffer,
+            ),
             policy,
             statement,
         }

--- a/aerospike-core/src/commands/stream_command.rs
+++ b/aerospike-core/src/commands/stream_command.rs
@@ -37,6 +37,14 @@ pub struct StreamCommand {
     cluster: Arc<Cluster>,
     pub(crate) recordset: Arc<Recordset>,
     pub(crate) node_partitions: Arc<Mutex<NodePartitions>>,
+    /// Set only for Top-K (`ORDER BY <bin> LIMIT k`) queries: when present,
+    /// parsed records are appended here instead of being streamed straight
+    /// into `recordset`. Each node's own already-bounded (`<= k`), sorted
+    /// result is buffered independently and handed back to the caller once
+    /// this node's command completes, so it can be merged with every other
+    /// node's buffer after the whole job finishes (see
+    /// `Client::execute_top_k_query` and `query::top_k_merge::TopKMerger`).
+    pub(crate) top_k_buffer: Option<Arc<Mutex<Vec<Record>>>>,
 }
 
 impl Drop for StreamCommand {
@@ -53,6 +61,7 @@ impl StreamCommand {
         node_partitions: Arc<Mutex<NodePartitions>>,
         is_scan: bool,
         cluster: Arc<Cluster>,
+        top_k_buffer: Option<Arc<Mutex<Vec<Record>>>>,
     ) -> Self {
         StreamCommand {
             is_scan,
@@ -60,6 +69,7 @@ impl StreamCommand {
             cluster,
             recordset,
             node_partitions,
+            top_k_buffer,
         }
     }
 
@@ -160,13 +170,26 @@ impl StreamCommand {
                     if !tracker.allow_record(&mut node_partitions) {
                         continue 'outer;
                     }
-                    let key = &rec.key.clone().unwrap();
-                    self.recordset.push(Ok(rec)).await?;
 
-                    if self.is_scan {
-                        tracker.set_digest(&mut node_partitions, key).await?;
+                    if let Some(buffer) = &self.top_k_buffer {
+                        // Top-K: accumulate into this node's own buffer
+                        // instead of streaming straight to the consumer,
+                        // and deliberately skip `set_digest`/`set_last`.
+                        // Those record a mid-partition resume cursor, but
+                        // Top-K is single-shot and the server rejects
+                        // non-zero resume cursors outright — a retried
+                        // partition must always be requested fresh.
+                        node_partitions.record_count += 1;
+                        buffer.lock().await.push(rec);
                     } else {
-                        tracker.set_last(&mut node_partitions, key, bval).await?;
+                        let key = &rec.key.clone().unwrap();
+                        self.recordset.push(Ok(rec)).await?;
+
+                        if self.is_scan {
+                            tracker.set_digest(&mut node_partitions, key).await?;
+                        } else {
+                            tracker.set_last(&mut node_partitions, key, bval).await?;
+                        }
                     }
                     drop(tracker);
                     drop(node_partitions);

--- a/aerospike-core/src/lib.rs
+++ b/aerospike-core/src/lib.rs
@@ -170,8 +170,8 @@ pub use policy::{
 };
 pub use privilege::{Privilege, PrivilegeCode};
 pub use query::{
-    CollectionIndexType, EqFilterValue, IndexType, PartitionFilter, RangeFilterValue, Recordset,
-    Statement, UDFLang,
+    CollectionIndexType, EqFilterValue, IndexType, Order, OrderBy, OrderByFlags, OrderByType,
+    PartitionFilter, RangeFilterValue, Recordset, Statement, UDFLang,
 };
 #[cfg(feature = "lua")]
 pub use query::{ResultSet, ResultStream};

--- a/aerospike-core/src/query/mod.rs
+++ b/aerospike-core/src/query/mod.rs
@@ -19,6 +19,7 @@
 pub use self::filter::{EqFilterValue, Filter, RangeFilterValue};
 pub use self::index_types::{CollectionIndexType, IndexType};
 pub(crate) use self::node_partitions::NodePartitions;
+pub use self::order_by::{Order, OrderBy, OrderByFlags, OrderByType};
 pub use self::partition_filter::PartitionFilter;
 pub use self::partition_status::PartitionStatus;
 pub(crate) use self::partition_tracker::PartitionTracker;
@@ -27,12 +28,15 @@ pub use self::recordset::Recordset;
 #[cfg(feature = "lua")]
 pub use self::result_set::{ResultSet, ResultStream};
 pub use self::statement::Statement;
+pub(crate) use self::top_k_merge::TopKMerger;
 pub use self::udf::UDFLang;
 
 /// Query filter definitions and filter value traits.
 pub mod filter;
 mod index_types;
 mod node_partitions;
+/// Types for `ORDER BY <bin> LIMIT k` ("Top-K") queries.
+pub mod order_by;
 mod partition_filter;
 mod partition_status;
 mod partition_tracker;
@@ -40,4 +44,5 @@ mod recordset;
 #[cfg(feature = "lua")]
 mod result_set;
 mod statement;
+mod top_k_merge;
 mod udf;

--- a/aerospike-core/src/query/order_by.rs
+++ b/aerospike-core/src/query/order_by.rs
@@ -1,0 +1,103 @@
+// Copyright 2015-2026 Aerospike, Inc.
+//
+// Portions may be licensed to Aerospike, Inc. under one or more contributor
+// license agreements.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+//! Types for `ORDER BY <bin> LIMIT k` ("Top-K") queries.
+//!
+//! See `Statement::set_order_by`/`Statement::set_top_k` for the client API.
+//!
+//! # Work in progress
+//!
+//! This client implements Top-K's client-side surface (types, validation,
+//! wire encode, and the per-node merge engine), but the wire encode is
+//! capability-gated behind `Version::supports_query_top_k()`, which always
+//! evaluates to `false` against a real server for now — this feature has no
+//! assigned minimum server version yet. `Statement::set_order_by`/`set_top_k`
+//! can be built and validated today; sending a query with either set fails
+//! fast with a client-side error until that capability gate is updated,
+//! rather than silently sending unrecognized fields to a server that
+//! doesn't understand them.
+
+/// Scalar comparator type for a Top-K order-by key.
+///
+/// Aerospike has no schema, so the type of the order-by bin must be declared
+/// explicitly. Values mirror the server's `AS_ORDER_BY_TYPE_*` wire
+/// constants, so a future wire-encode path is a trivial `as u8` cast.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum OrderByType {
+    /// 64-bit signed integer order key.
+    Integer = 0,
+    /// 64-bit float order key.
+    Double = 1,
+    /// String order key.
+    String = 2,
+    /// Raw bytes order key, compared lexicographically.
+    Bytes = 3,
+}
+
+/// Sort direction for a Top-K query. Values mirror the server's
+/// `AS_ORDER_BY_DIRECTION_*` wire constants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum Order {
+    /// Ascending: smallest order-key value first.
+    Asc = 0,
+    /// Descending: largest order-key value first.
+    Desc = 1,
+}
+
+/// Optional per-type modifiers for `order_by`.
+///
+/// Modeled as a plain enum (rather than a bitflags type) since exactly one
+/// flag bit is currently defined on the wire
+/// (`AS_ORDER_BY_FLAG_CASE_INSENSITIVE`); revisit if the server adds more
+/// flag bits later.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum OrderByFlags {
+    /// No flags.
+    #[default]
+    None,
+    /// Case-insensitive string comparison. Only valid with `OrderByType::String`.
+    CaseInsensitive,
+}
+
+impl OrderByFlags {
+    /// The wire's bitmask representation (`AS_ORDER_BY_FLAG_*`). Deliberately
+    /// not the enum's `as u64` discriminant: the wire field is a bitmask,
+    /// while this type models it as a plain enum for API ergonomics (see the
+    /// type-level docs), so the two representations aren't guaranteed to
+    /// stay numerically identical as more flag bits are added.
+    pub(crate) const fn to_wire_bits(self) -> u64 {
+        match self {
+            OrderByFlags::None => 0,
+            OrderByFlags::CaseInsensitive => 1 << 0,
+        }
+    }
+}
+
+/// The order-by clause of a Top-K query: the order key's bin name, scalar
+/// type, sort direction, and optional flags.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OrderBy {
+    /// Name of the bin (as it appears in the *returned* record — a physical
+    /// bin or one produced by a read-op/read-expression projection) to sort by.
+    pub bin_name: String,
+    /// Scalar type of the order-key bin.
+    pub order_type: OrderByType,
+    /// Sort direction.
+    pub direction: Order,
+    /// Optional modifiers (currently only `CaseInsensitive`, for `String`).
+    pub flags: OrderByFlags,
+}

--- a/aerospike-core/src/query/partition_tracker.rs
+++ b/aerospike-core/src/query/partition_tracker.rs
@@ -472,6 +472,26 @@ impl PartitionTracker {
         }
     }
 
+    /// Marks every partition in the tracked range for retry, regardless of
+    /// per-node/per-partition state. Used by the Top-K query path
+    /// (`Client::execute_top_k_query`), which forces a full whole-job retry
+    /// on any node error instead of the normal partial, per-partition
+    /// resume: Top-K is single-shot and the server rejects non-zero resume
+    /// cursors outright, so every retried partition must be requested
+    /// fresh — never mid-partition — and any already-buffered per-node
+    /// Top-K results from this attempt must be discarded rather than
+    /// merged with results from a differently-scoped retry.
+    pub(crate) async fn mark_all_for_retry(&self) {
+        if let Some(pf) = &self.partition_filter {
+            let pf = pf.lock().await;
+            if let Some(partitions) = pf.partitions.as_ref() {
+                for part in partitions.iter() {
+                    part.lock().retry = true;
+                }
+            }
+        }
+    }
+
     pub(crate) async fn partition_error(&self) {
         // Mark all partitions for retry on fatal errors.
         if let Some(ref pf) = self.partition_filter {

--- a/aerospike-core/src/query/statement.rs
+++ b/aerospike-core/src/query/statement.rs
@@ -15,9 +15,18 @@
 
 use crate::errors::{Error, Result};
 use crate::operations::Operation;
+use crate::query::order_by::{Order, OrderBy, OrderByFlags, OrderByType};
 use crate::query::Filter;
 use crate::Bins;
 use crate::Value;
+
+/// Maximum length, in bytes, of an order-by bin name (`AS_BIN_NAME_MAX_SZ - 1`
+/// on the server).
+const MAX_ORDER_BY_BIN_NAME_LEN: usize = 14;
+
+/// Inclusive bounds for `Statement::set_top_k`'s `k` (`TOP_K_MAX` on the server).
+const TOP_K_MIN: u32 = 1;
+const TOP_K_MAX: u32 = 1000;
 
 #[derive(Clone, Debug)]
 pub struct Aggregation {
@@ -55,6 +64,17 @@ pub struct Statement {
     /// `Read` op here; 8.1.2+ accepts CDT, expression, bit, and HLL
     /// reads as well.
     pub operations: Option<Vec<Operation>>,
+
+    /// Top-K order-by clause. Set via `set_order_by`/`set_order_by_with_flags`.
+    ///
+    /// # Work in progress
+    ///
+    /// This client validates and models Top-K statements, but does not yet
+    /// send them over the wire — see [`crate::query::order_by`].
+    pub order_by: Option<OrderBy>,
+
+    /// Top-K limit (`k`), in `[1, 1000]`. Must be preceded by `set_order_by`.
+    pub top_k: Option<u32>,
 }
 
 impl Statement {
@@ -79,6 +99,8 @@ impl Statement {
             aggregation: None,
             filters: None,
             operations: None,
+            order_by: None,
+            top_k: None,
         }
     }
 
@@ -132,6 +154,42 @@ impl Statement {
         self.aggregation = Some(agg);
     }
 
+    /// Sets the Top-K order-by clause: the order key's bin name (as it
+    /// appears in the *returned* record), its scalar type, and sort
+    /// direction. Equivalent to calling
+    /// `set_order_by_with_flags(bin_name, order_type, direction, OrderByFlags::None)`.
+    ///
+    /// Must be set before `set_top_k`.
+    pub fn set_order_by(&mut self, bin_name: &str, order_type: OrderByType, direction: Order) {
+        self.set_order_by_with_flags(bin_name, order_type, direction, OrderByFlags::None);
+    }
+
+    /// Like [`Self::set_order_by`], with optional modifiers (currently only
+    /// `OrderByFlags::CaseInsensitive`, valid only with `OrderByType::String`).
+    pub fn set_order_by_with_flags(
+        &mut self,
+        bin_name: &str,
+        order_type: OrderByType,
+        direction: Order,
+        flags: OrderByFlags,
+    ) {
+        self.order_by = Some(OrderBy {
+            bin_name: bin_name.to_owned(),
+            order_type,
+            direction,
+            flags,
+        });
+    }
+
+    /// Sets the Top-K limit. `k` must be in `[1, 1000]`. Must be preceded by
+    /// `set_order_by`/`set_order_by_with_flags` (checked by `validate()`, not
+    /// here, so builder calls can happen in either order relative to other
+    /// statement setup as long as `order_by` is set before the statement is
+    /// executed).
+    pub const fn set_top_k(&mut self, k: u32) {
+        self.top_k = Some(k);
+    }
+
     pub(crate) fn validate(&self) -> Result<()> {
         if let Some(ref filters) = self.filters {
             if filters.len() > 1 {
@@ -153,6 +211,219 @@ impl Statement {
             }
         }
 
+        self.validate_top_k()?;
+
         Ok(())
+    }
+
+    /// Validation rules specific to `order_by`/`top_k`, including which
+    /// rules the server also enforces as defense-in-depth.
+    fn validate_top_k(&self) -> Result<()> {
+        if self.order_by.is_none() && self.top_k.is_none() {
+            return Ok(());
+        }
+
+        if self.aggregation.is_some() {
+            return Err(Error::invalid_argument(
+                "orderBy/topK is incompatible with aggregate UDFs; use the UDF's own reduce stage"
+                    .to_string(),
+            ));
+        }
+
+        if let Some(ref order_by) = self.order_by {
+            if order_by.bin_name.is_empty() {
+                return Err(Error::invalid_argument(
+                    "orderBy bin name must not be empty".to_string(),
+                ));
+            }
+
+            if order_by.bin_name.len() > MAX_ORDER_BY_BIN_NAME_LEN {
+                return Err(Error::invalid_argument(format!(
+                    "orderBy bin name '{}' exceeds the {}-character limit",
+                    order_by.bin_name, MAX_ORDER_BY_BIN_NAME_LEN
+                )));
+            }
+
+            if order_by.flags == OrderByFlags::CaseInsensitive
+                && order_by.order_type != OrderByType::String
+            {
+                return Err(Error::invalid_argument(
+                    "orderBy flag CASE_INSENSITIVE is only valid with type STRING".to_string(),
+                ));
+            }
+
+            // Order-by bin must be one of the projected bins, if a projection is set.
+            if let Some(ref operations) = self.operations {
+                let projected = operations.iter().any(|op| {
+                    matches!(&op.bin, crate::operations::OperationBin::Name(name) if name == &order_by.bin_name)
+                });
+                if !projected {
+                    return Err(Error::invalid_argument(format!(
+                        "orderBy bin '{}' is not in projection; add it to setOperations or remove projection",
+                        order_by.bin_name
+                    )));
+                }
+            } else if let Bins::Some(ref bins) = self.bins {
+                if !bins.iter().any(|b| b == &order_by.bin_name) {
+                    return Err(Error::invalid_argument(format!(
+                        "orderBy bin '{}' is not in projection; add it to setBinNames or remove projection",
+                        order_by.bin_name
+                    )));
+                }
+            }
+        } else if self.top_k.is_some() {
+            return Err(Error::invalid_argument(
+                "topK requires orderBy to be set".to_string(),
+            ));
+        }
+
+        if let Some(k) = self.top_k {
+            if !(TOP_K_MIN..=TOP_K_MAX).contains(&k) {
+                return Err(Error::invalid_argument(format!(
+                    "topK must be in [{TOP_K_MIN}, {TOP_K_MAX}]; got {k}"
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::operations;
+
+    fn base_statement() -> Statement {
+        Statement::new("ns", "set", Bins::All)
+    }
+
+    #[test]
+    fn no_order_by_or_top_k_is_valid() {
+        assert!(base_statement().validate().is_ok());
+    }
+
+    #[test]
+    fn order_by_alone_is_valid() {
+        let mut stmt = base_statement();
+        stmt.set_order_by("score", OrderByType::Integer, Order::Desc);
+        assert!(stmt.validate().is_ok());
+    }
+
+    #[test]
+    fn top_k_without_order_by_is_rejected() {
+        let mut stmt = base_statement();
+        stmt.set_top_k(10);
+        let err = stmt.validate().unwrap_err();
+        assert!(err.to_string().contains("topK requires orderBy"));
+    }
+
+    #[test]
+    fn top_k_zero_is_rejected() {
+        let mut stmt = base_statement();
+        stmt.set_order_by("score", OrderByType::Integer, Order::Desc);
+        stmt.set_top_k(0);
+        assert!(stmt.validate().is_err());
+    }
+
+    #[test]
+    fn top_k_over_1000_is_rejected() {
+        let mut stmt = base_statement();
+        stmt.set_order_by("score", OrderByType::Integer, Order::Desc);
+        stmt.set_top_k(1001);
+        assert!(stmt.validate().is_err());
+    }
+
+    #[test]
+    fn top_k_in_range_is_valid() {
+        for k in [1, 500, 1000] {
+            let mut stmt = base_statement();
+            stmt.set_order_by("score", OrderByType::Integer, Order::Desc);
+            stmt.set_top_k(k);
+            assert!(stmt.validate().is_ok(), "k={k} should be valid");
+        }
+    }
+
+    #[test]
+    fn order_by_incompatible_with_aggregation() {
+        let mut stmt = base_statement();
+        stmt.set_order_by("score", OrderByType::Integer, Order::Desc);
+        stmt.set_aggregate_function("pkg", "func", None);
+        let err = stmt.validate().unwrap_err();
+        assert!(err.to_string().contains("aggregate UDF"));
+    }
+
+    #[test]
+    fn case_insensitive_flag_requires_string_type() {
+        let mut stmt = base_statement();
+        stmt.set_order_by_with_flags(
+            "score",
+            OrderByType::Integer,
+            Order::Desc,
+            OrderByFlags::CaseInsensitive,
+        );
+        let err = stmt.validate().unwrap_err();
+        assert!(err.to_string().contains("CASE_INSENSITIVE"));
+    }
+
+    #[test]
+    fn case_insensitive_flag_with_string_type_is_valid() {
+        let mut stmt = base_statement();
+        stmt.set_order_by_with_flags(
+            "name",
+            OrderByType::String,
+            Order::Asc,
+            OrderByFlags::CaseInsensitive,
+        );
+        assert!(stmt.validate().is_ok());
+    }
+
+    #[test]
+    fn order_by_bin_name_too_long_is_rejected() {
+        let mut stmt = base_statement();
+        stmt.set_order_by("this_bin_name_is_too_long", OrderByType::Integer, Order::Desc);
+        let err = stmt.validate().unwrap_err();
+        assert!(err.to_string().contains("14-character limit"));
+    }
+
+    #[test]
+    fn order_by_bin_missing_from_bins_projection_is_rejected() {
+        let mut stmt = Statement::new("ns", "set", Bins::from(["a", "b"]));
+        stmt.set_order_by("c", OrderByType::Integer, Order::Desc);
+        let err = stmt.validate().unwrap_err();
+        assert!(err.to_string().contains("is not in projection"));
+    }
+
+    #[test]
+    fn order_by_bin_present_in_bins_projection_is_valid() {
+        let mut stmt = Statement::new("ns", "set", Bins::from(["a", "b"]));
+        stmt.set_order_by("b", OrderByType::Integer, Order::Desc);
+        assert!(stmt.validate().is_ok());
+    }
+
+    #[test]
+    fn order_by_bin_missing_from_operations_projection_is_rejected() {
+        let mut stmt = base_statement();
+        stmt.set_operations(vec![operations::get_bin("a")]);
+        stmt.set_order_by("dist", OrderByType::Double, Order::Asc);
+        let err = stmt.validate().unwrap_err();
+        assert!(err.to_string().contains("is not in projection"));
+    }
+
+    #[test]
+    fn order_by_bin_present_in_operations_projection_is_valid() {
+        let mut stmt = base_statement();
+        stmt.set_operations(vec![operations::get_bin("dist")]);
+        stmt.set_order_by("dist", OrderByType::Double, Order::Asc);
+        assert!(stmt.validate().is_ok());
+    }
+
+    #[test]
+    fn order_by_with_bins_all_projection_is_valid() {
+        // `Bins::All` means "no explicit projection" — any order-by bin is
+        // allowed since the full record (whatever it contains) comes back.
+        let mut stmt = Statement::new("ns", "set", Bins::All);
+        stmt.set_order_by("anything", OrderByType::Integer, Order::Desc);
+        assert!(stmt.validate().is_ok());
     }
 }

--- a/aerospike-core/src/query/top_k_merge.rs
+++ b/aerospike-core/src/query/top_k_merge.rs
@@ -136,9 +136,9 @@ impl TopKMerger {
 
     /// Merge every node's already-bounded result buffer into the final
     /// global Top-K: concatenate, dedup by digest (generation-first, then
-    /// rank — per the server's `cf_topk` contract; see §3.2 of the
-    /// implementation plan for why this differs from Java's rank-only rule),
-    /// sort best-first, and truncate to `limit`.
+    /// rank — per the server's `cf_topk` contract; this differs from the
+    /// Java client's rank-only dedup rule), sort best-first, and truncate
+    /// to `limit`.
     pub(crate) fn merge(&self, per_node_results: Vec<Vec<Record>>) -> Vec<Record> {
         let mut by_digest: HashMap<[u8; 20], Record> = HashMap::new();
 
@@ -373,9 +373,9 @@ mod tests {
         }
     }
 
-    // Concurrency-adjacent regression test (see §3.0/§9 of the implementation
-    // plan for why Java's suite doesn't cover this): simulate multiple
-    // "node tasks" independently observing the *same* digest at different
+    // Concurrency-adjacent regression test (the Java client's own test
+    // suite doesn't cover this): simulate multiple "node tasks"
+    // independently observing the *same* digest at different
     // generations/values, arriving in every possible order, and assert the
     // outcome is always the correct, order-independent generation-first pick
     // -- not just "doesn't panic under load".

--- a/aerospike-core/src/query/top_k_merge.rs
+++ b/aerospike-core/src/query/top_k_merge.rs
@@ -1,0 +1,426 @@
+// Copyright 2015-2026 Aerospike, Inc.
+//
+// Portions may be licensed to Aerospike, Inc. under one or more contributor
+// license agreements.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+//! Internal Top-K merge engine.
+//!
+//! Each node hands this merger its own already-bounded (`<= k`) result
+//! buffer, accumulated by `Client::execute_top_k_query`
+//! (`aerospike-core/src/client.rs`) via `StreamCommand::top_k_buffer`;
+//! `TopKMerger::merge` combines those buffers into the final global Top-K:
+//! comparator-sort, dedup by digest (generation-first, then rank), truncate
+//! to `limit`.
+//!
+//! No shared mutable state is mutated concurrently here — each node's buffer
+//! is produced independently, and `merge` runs once, sequentially, after
+//! every node's buffer is available (once the whole job completes with no
+//! errors — see `Client::execute_top_k_query`'s doc comment for the
+//! whole-job-retry rationale).
+
+use std::cmp::Ordering;
+use std::collections::HashMap;
+
+use crate::query::order_by::{Order, OrderBy, OrderByFlags, OrderByType};
+use crate::Record;
+use crate::Value;
+
+/// The extracted, comparable form of a record's order-by bin value. `Nil`
+/// represents a missing bin or a bin whose value doesn't match `OrderByType`
+/// (design doc contract: NIL sorts after every non-NIL value, in both
+/// directions).
+#[derive(Debug, Clone, PartialEq)]
+enum RankValue {
+    Integer(i64),
+    Double(f64),
+    String(String),
+    Bytes(Vec<u8>),
+    Nil,
+}
+
+impl RankValue {
+    fn extract(record: &Record, order_by: &OrderBy) -> Self {
+        let Some(value) = record.bins.get(&order_by.bin_name) else {
+            return RankValue::Nil;
+        };
+
+        match (order_by.order_type, value) {
+            (OrderByType::Integer, Value::Int(i)) => RankValue::Integer(*i),
+            (OrderByType::Double, Value::Float(f)) => RankValue::Double(f64::from(f)),
+            (OrderByType::String, Value::String(s)) => {
+                if order_by.flags == OrderByFlags::CaseInsensitive {
+                    RankValue::String(s.to_lowercase())
+                } else {
+                    RankValue::String(s.clone())
+                }
+            }
+            (OrderByType::Bytes, Value::Blob(b)) => RankValue::Bytes(b.clone()),
+            // Type mismatch (e.g. declared Integer but the bin holds a String) is
+            // treated the same as a missing bin: NIL.
+            _ => RankValue::Nil,
+        }
+    }
+
+    /// Ordering ignoring `Nil`/`Nil` and `Nil`/non-`Nil` cases, which the
+    /// caller (`rank_cmp`) handles first so this only needs to compare two
+    /// same-variant, non-`Nil` values.
+    fn cmp_non_nil(&self, other: &Self) -> Ordering {
+        match (self, other) {
+            (RankValue::Integer(a), RankValue::Integer(b)) => a.cmp(b),
+            (RankValue::Double(a), RankValue::Double(b)) => a.total_cmp(b),
+            (RankValue::String(a), RankValue::String(b)) => a.cmp(b),
+            (RankValue::Bytes(a), RankValue::Bytes(b)) => a.cmp(b),
+            // Unreachable in practice: `extract` always produces a `RankValue`
+            // variant matching `order_by.order_type`, so two `RankValue`s
+            // derived from the same `OrderBy` are always the same variant.
+            _ => Ordering::Equal,
+        }
+    }
+}
+
+/// Compares two candidates' rank, per the design doc / server `cf_topk`
+/// contract: NIL sorts after every non-NIL value in *both* directions; ties
+/// (including NIL/NIL) are equal here and broken by digest ascending by the
+/// caller. Returns an ordering where `Less` means "ranks better" (i.e. this
+/// is the ordering a min-heap-of-the-worst or a `sort_by` would use to put
+/// the best candidates first).
+fn rank_cmp(a: &RankValue, b: &RankValue, direction: Order) -> Ordering {
+    match (a, b) {
+        (RankValue::Nil, RankValue::Nil) => Ordering::Equal,
+        (RankValue::Nil, _) => Ordering::Greater,
+        (_, RankValue::Nil) => Ordering::Less,
+        (a, b) => {
+            let cmp = a.cmp_non_nil(b);
+            match direction {
+                Order::Asc => cmp,
+                Order::Desc => cmp.reverse(),
+            }
+        }
+    }
+}
+
+/// Digest tie-break: ascending, per the design doc / server contract.
+fn digest_cmp(a: &Record, b: &Record) -> Ordering {
+    let da = a.key.as_ref().map(|k| k.digest);
+    let db = b.key.as_ref().map(|k| k.digest);
+    da.cmp(&db)
+}
+
+/// Merges per-node Top-K result buffers into the final global Top-K.
+pub(crate) struct TopKMerger {
+    order_by: OrderBy,
+    limit: usize,
+}
+
+impl TopKMerger {
+    pub(crate) const fn new(order_by: OrderBy, limit: usize) -> Self {
+        TopKMerger { order_by, limit }
+    }
+
+    /// Full best-first comparator: rank, then digest ascending on ties.
+    fn compare(&self, a: &Record, b: &Record) -> Ordering {
+        let ra = RankValue::extract(a, &self.order_by);
+        let rb = RankValue::extract(b, &self.order_by);
+        rank_cmp(&ra, &rb, self.order_by.direction).then_with(|| digest_cmp(a, b))
+    }
+
+    /// Merge every node's already-bounded result buffer into the final
+    /// global Top-K: concatenate, dedup by digest (generation-first, then
+    /// rank — per the server's `cf_topk` contract; see §3.2 of the
+    /// implementation plan for why this differs from Java's rank-only rule),
+    /// sort best-first, and truncate to `limit`.
+    pub(crate) fn merge(&self, per_node_results: Vec<Vec<Record>>) -> Vec<Record> {
+        let mut by_digest: HashMap<[u8; 20], Record> = HashMap::new();
+
+        for record in per_node_results.into_iter().flatten() {
+            let Some(digest) = record.key.as_ref().map(|k| k.digest) else {
+                // No digest to dedup on (shouldn't happen on a real query
+                // stream, where every record carries its key) — keep it,
+                // keyed by a value that can never collide with a real digest
+                // dedup entry, so it still participates in the final sort.
+                by_digest.insert(fallback_key(&record), record);
+                continue;
+            };
+
+            match by_digest.get(&digest) {
+                None => {
+                    by_digest.insert(digest, record);
+                }
+                Some(existing) => {
+                    if self.should_replace(existing, &record) {
+                        by_digest.insert(digest, record);
+                    }
+                }
+            }
+        }
+
+        let mut merged: Vec<Record> = by_digest.into_values().collect();
+        merged.sort_by(|a, b| self.compare(a, b));
+        merged.truncate(self.limit);
+        merged
+    }
+
+    /// Generation-first, then rank: the server's authoritative dedup rule
+    /// (`cf_topk.h`: "Duplicate digests keep the highest generation, then
+    /// the better-ranked entry ... if generations tie").
+    fn should_replace(&self, existing: &Record, candidate: &Record) -> bool {
+        match candidate.generation.cmp(&existing.generation) {
+            Ordering::Greater => true,
+            Ordering::Less => false,
+            Ordering::Equal => self.compare(candidate, existing) == Ordering::Less,
+        }
+    }
+}
+
+/// Synthesizes a unique map key for a record with no digest, so it doesn't
+/// collide with (or get silently dropped by) real digest-keyed entries. Only
+/// reachable if a caller feeds this merger records that didn't come from a
+/// normal query stream.
+fn fallback_key(record: &Record) -> [u8; 20] {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    record.generation.hash(&mut hasher);
+    for (k, v) in &record.bins {
+        k.hash(&mut hasher);
+        format!("{v}").hash(&mut hasher);
+    }
+    let h = hasher.finish().to_le_bytes();
+    let mut digest = [0xffu8; 20];
+    digest[..8].copy_from_slice(&h);
+    digest
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{IndexMap, Key};
+
+    fn key_with_digest(byte: u8) -> Key {
+        Key {
+            namespace: "ns".to_string(),
+            set_name: "set".to_string(),
+            user_key: None,
+            digest: [byte; 20],
+        }
+    }
+
+    fn record(digest_byte: u8, generation: u32, bin: Option<(&str, Value)>) -> Record {
+        let mut bins = IndexMap::new();
+        if let Some((name, value)) = bin {
+            bins.insert(name.to_string(), value);
+        }
+        Record::new(
+            Some(key_with_digest(digest_byte)),
+            bins,
+            None,
+            generation,
+            0,
+        )
+    }
+
+    fn order_by(direction: Order) -> OrderBy {
+        OrderBy {
+            bin_name: "score".to_string(),
+            order_type: OrderByType::Integer,
+            direction,
+            flags: OrderByFlags::None,
+        }
+    }
+
+    #[test]
+    fn nil_ranks_last_in_both_directions() {
+        for direction in [Order::Asc, Order::Desc] {
+            let merger = TopKMerger::new(order_by(direction), 10);
+            let with_value = record(1, 1, Some(("score", Value::Int(5))));
+            let missing_bin = record(2, 1, None);
+            let wrong_type = record(3, 1, Some(("score", Value::String("oops".into()))));
+
+            let merged = merger.merge(vec![vec![with_value.clone(), missing_bin, wrong_type]]);
+            assert_eq!(merged.len(), 3);
+            assert_eq!(merged[0].key.as_ref().unwrap().digest, with_value.key.unwrap().digest, "non-NIL must sort before NIL for direction {direction:?}");
+        }
+    }
+
+    #[test]
+    fn descending_orders_largest_first() {
+        let merger = TopKMerger::new(order_by(Order::Desc), 10);
+        let low = record(1, 1, Some(("score", Value::Int(1))));
+        let high = record(2, 1, Some(("score", Value::Int(9))));
+        let mid = record(3, 1, Some(("score", Value::Int(5))));
+
+        let merged = merger.merge(vec![vec![low, high.clone(), mid]]);
+        assert_eq!(merged[0].key.as_ref().unwrap().digest, high.key.unwrap().digest);
+        assert_eq!(merged[0].bins["score"], Value::Int(9));
+        assert_eq!(merged[2].bins["score"], Value::Int(1));
+    }
+
+    #[test]
+    fn ascending_orders_smallest_first() {
+        let merger = TopKMerger::new(order_by(Order::Asc), 10);
+        let low = record(1, 1, Some(("score", Value::Int(1))));
+        let high = record(2, 1, Some(("score", Value::Int(9))));
+
+        let merged = merger.merge(vec![vec![high, low.clone()]]);
+        assert_eq!(merged[0].key.as_ref().unwrap().digest, low.key.unwrap().digest);
+    }
+
+    #[test]
+    fn ties_break_by_digest_ascending() {
+        let merger = TopKMerger::new(order_by(Order::Desc), 10);
+        let a = record(9, 1, Some(("score", Value::Int(5))));
+        let b = record(1, 1, Some(("score", Value::Int(5))));
+
+        let merged = merger.merge(vec![vec![a, b.clone()]]);
+        assert_eq!(merged[0].key.as_ref().unwrap().digest, b.key.unwrap().digest);
+    }
+
+    #[test]
+    fn dedup_prefers_higher_generation_even_if_worse_ranked() {
+        let merger = TopKMerger::new(order_by(Order::Desc), 10);
+        // Same digest, two "reads" of the same record: an older, better-ranked
+        // read (gen 1, score 9) and a newer, worse-ranked read (gen 2, score 1).
+        // The server's generation-first rule must keep the newer one.
+        let stale_but_better = record(1, 1, Some(("score", Value::Int(9))));
+        let fresh_but_worse = record(1, 2, Some(("score", Value::Int(1))));
+
+        let merged = merger.merge(vec![vec![stale_but_better], vec![fresh_but_worse]]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].generation, 2);
+        assert_eq!(merged[0].bins["score"], Value::Int(1));
+    }
+
+    #[test]
+    fn dedup_falls_back_to_rank_when_generation_ties() {
+        let merger = TopKMerger::new(order_by(Order::Desc), 10);
+        let worse = record(1, 1, Some(("score", Value::Int(1))));
+        let better = record(1, 1, Some(("score", Value::Int(9))));
+
+        let merged = merger.merge(vec![vec![worse], vec![better]]);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].bins["score"], Value::Int(9));
+    }
+
+    #[test]
+    fn case_insensitive_string_comparison() {
+        let order_by = OrderBy {
+            bin_name: "name".to_string(),
+            order_type: OrderByType::String,
+            direction: Order::Asc,
+            flags: OrderByFlags::CaseInsensitive,
+        };
+        let merger = TopKMerger::new(order_by, 10);
+        let upper = record(1, 1, Some(("name", Value::String("Banana".into()))));
+        let lower = record(2, 1, Some(("name", Value::String("apple".into()))));
+
+        let merged = merger.merge(vec![vec![upper, lower.clone()]]);
+        assert_eq!(merged[0].key.as_ref().unwrap().digest, lower.key.unwrap().digest);
+    }
+
+    #[test]
+    fn bytes_compare_lexicographically() {
+        let order_by = OrderBy {
+            bin_name: "b".to_string(),
+            order_type: OrderByType::Bytes,
+            direction: Order::Asc,
+            flags: OrderByFlags::None,
+        };
+        let merger = TopKMerger::new(order_by, 10);
+        let a = record(1, 1, Some(("b", Value::Blob(vec![2, 0]))));
+        let b = record(2, 1, Some(("b", Value::Blob(vec![1, 0, 0]))));
+
+        let merged = merger.merge(vec![vec![a, b.clone()]]);
+        assert_eq!(merged[0].key.as_ref().unwrap().digest, b.key.unwrap().digest);
+    }
+
+    #[test]
+    fn truncates_to_limit_across_multiple_node_buffers() {
+        let merger = TopKMerger::new(order_by(Order::Desc), 2);
+        let records: Vec<Record> = (0..5)
+            .map(|i| record(i, 1, Some(("score", Value::Int(i as i64)))))
+            .collect();
+        // Split across two "node buffers" to mirror real per-node input.
+        let (first, second) = records.split_at(3);
+        let merged = merger.merge(vec![first.to_vec(), second.to_vec()]);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].bins["score"], Value::Int(4));
+        assert_eq!(merged[1].bins["score"], Value::Int(3));
+    }
+
+    #[test]
+    fn heap_eviction_boundary_k_minus_1_k_k_plus_1() {
+        for (n, k) in [(4usize, 5usize), (5, 5), (6, 5)] {
+            let merger = TopKMerger::new(order_by(Order::Desc), k);
+            let records: Vec<Record> = (0..n)
+                .map(|i| record(i as u8, 1, Some(("score", Value::Int(i as i64)))))
+                .collect();
+            let merged = merger.merge(vec![records]);
+            assert_eq!(merged.len(), n.min(k));
+            // Best-first: highest score first.
+            for pair in merged.windows(2) {
+                assert!(pair[0].bins["score"] >= pair[1].bins["score"]);
+            }
+        }
+    }
+
+    // Concurrency-adjacent regression test (see §3.0/§9 of the implementation
+    // plan for why Java's suite doesn't cover this): simulate multiple
+    // "node tasks" independently observing the *same* digest at different
+    // generations/values, arriving in every possible order, and assert the
+    // outcome is always the correct, order-independent generation-first pick
+    // -- not just "doesn't panic under load".
+    #[test]
+    fn dedup_is_order_independent_for_racing_duplicate_digests() {
+        let merger = TopKMerger::new(order_by(Order::Desc), 10);
+        let candidates = [
+            record(7, 1, Some(("score", Value::Int(100)))), // gen 1, best rank
+            record(7, 3, Some(("score", Value::Int(1)))),   // gen 3, worst rank -> must win
+            record(7, 2, Some(("score", Value::Int(50)))),  // gen 2, mid rank
+        ];
+
+        // Every permutation of "arrival order" (as if fed by racing node
+        // tasks / partition re-scans) must converge on the same answer.
+        use itertools_like_permutations::permutations;
+        for perm in permutations(&candidates) {
+            let buffers: Vec<Vec<Record>> = perm.into_iter().map(|r| vec![r]).collect();
+            let merged = merger.merge(buffers);
+            assert_eq!(merged.len(), 1);
+            assert_eq!(merged[0].generation, 3, "must always keep the highest generation regardless of arrival order");
+            assert_eq!(merged[0].bins["score"], Value::Int(1));
+        }
+    }
+
+    // Minimal permutation helper so this test doesn't need an extra dev-dependency.
+    mod itertools_like_permutations {
+        use crate::Record;
+
+        pub(super) fn permutations(items: &[Record]) -> Vec<Vec<Record>> {
+            fn helper(remaining: Vec<Record>, acc: &mut Vec<Record>, out: &mut Vec<Vec<Record>>) {
+                if remaining.is_empty() {
+                    out.push(acc.clone());
+                    return;
+                }
+                for i in 0..remaining.len() {
+                    let mut rest = remaining.clone();
+                    let item = rest.remove(i);
+                    acc.push(item);
+                    helper(rest, acc, out);
+                    acc.pop();
+                }
+            }
+            let mut out = Vec::new();
+            helper(items.to_vec(), &mut Vec::new(), &mut out);
+            out
+        }
+    }
+}

--- a/examples/query_top_k.rs
+++ b/examples/query_top_k.rs
@@ -1,0 +1,210 @@
+//! `ORDER BY <bin> LIMIT k` ("Top-K") queries — client-side API and validation.
+//!
+//! # Work in progress — read before using
+//!
+//! This example demonstrates the parts of Top-K that are implemented today:
+//! `Statement::set_order_by`/`set_top_k`, client-side validation, and the
+//! wire encode. **The feature cannot actually run against a server yet**,
+//! though: the wire encode is capability-gated behind
+//! `Version::supports_query_top_k()`, which always evaluates to `false`
+//! against a real server for now (this feature has no assigned minimum
+//! server version — it's unreleased). So a well-formed statement still
+//! passes `Client::query`'s upfront validation (the `Recordset` is created
+//! successfully), but draining the resulting stream surfaces a per-node
+//! error instead of records, once each node's command actually tries to
+//! encode the request. What *is* real and tested today:
+//!
+//! * The builder methods themselves (`set_order_by`, `set_order_by_with_flags`, `set_top_k`).
+//! * `Statement::validate()` (invoked by `Client::query` before any network
+//!   I/O) rejecting invalid combinations client-side.
+//! * The wire-encode logic itself (`FieldType::OrderBy`/`FieldType::TopK`),
+//!   unit-tested byte-for-byte in `commands/buffer.rs`, but not reachable
+//!   against a real cluster until the capability gate above is updated.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example query_top_k
+//! ```
+
+#[allow(unused_imports)]
+use aerospike::{as_bin, as_key};
+
+use aerospike::query::{Order, OrderByFlags, OrderByType, PartitionFilter};
+use aerospike::{Bins, Client, ClientPolicy, QueryPolicy, Statement, WritePolicy};
+use futures::stream::StreamExt;
+use std::env;
+
+const DEFAULT_NAMESPACE: &str = "test";
+const DEFAULT_SET: &str = "query_top_k";
+const SCORE_BIN: &str = "score";
+const NAME_BIN: &str = "name";
+
+#[tokio::main]
+async fn main() {
+    run().await;
+}
+
+/// Example body. Standalone via `cargo run --example`, and also driven by
+/// the integration test suite (`tests/src/examples.rs`) so the example stays
+/// compiling and working as the API evolves.
+pub async fn run() {
+    let client = connect_to_aerospike().await;
+    println!("Connected to Aerospike!");
+
+    populate_test_data(&client).await;
+
+    valid_statement_passes_validation(&client).await;
+    top_k_without_order_by_is_rejected(&client).await;
+    top_k_out_of_range_is_rejected(&client).await;
+    order_by_bin_not_in_projection_is_rejected(&client).await;
+    case_insensitive_flag_requires_string_type_is_rejected(&client).await;
+
+    cleanup(&client).await;
+    client.close().await.unwrap();
+}
+
+async fn connect_to_aerospike() -> Client {
+    let hosts = env::var("AEROSPIKE_HOSTS").unwrap_or_else(|_| String::from("127.0.0.1:3100"));
+
+    let mut policy = ClientPolicy::default();
+    policy.use_services_alternate = std::env::var("AEROSPIKE_USE_SERVICES_ALTERNATE")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+
+    Client::new(&policy, &hosts)
+        .await
+        .expect("Failed to connect to cluster")
+}
+
+async fn populate_test_data(client: &Client) {
+    let wpolicy = WritePolicy::default();
+    let scores: &[(&str, i64, &str)] = &[
+        ("alice", 92, "Alice"),
+        ("bob", 75, "Bob"),
+        ("carol", 88, "Carol"),
+        ("dave", 61, "Dave"),
+        ("erin", 99, "Erin"),
+    ];
+
+    for (user_key, score, name) in scores {
+        let key = as_key!(DEFAULT_NAMESPACE, DEFAULT_SET, *user_key);
+        let bins = [as_bin!(SCORE_BIN, *score), as_bin!(NAME_BIN, *name)];
+        client
+            .put(&wpolicy, &key, &bins)
+            .await
+            .expect("Failed to write record");
+    }
+}
+
+/// A well-formed `order_by`/`top_k` statement passes `Statement::validate()`
+/// (called internally by `Client::query`), so the call itself succeeds and
+/// returns a `Recordset` — but draining it surfaces a capability error from
+/// each node's command instead of records, since no real server satisfies
+/// `Version::supports_query_top_k()` yet (see the module docs above).
+async fn valid_statement_passes_validation(client: &Client) {
+    println!("\n--- 1. Well-formed order_by + top_k passes validation, but can't run yet ---");
+
+    let mut stmt = Statement::new(DEFAULT_NAMESPACE, DEFAULT_SET, Bins::All);
+    stmt.set_order_by(SCORE_BIN, OrderByType::Integer, Order::Desc);
+    stmt.set_top_k(3);
+
+    let rs = client
+        .query(&QueryPolicy::default(), PartitionFilter::all(), stmt)
+        .await
+        .expect("a well-formed statement must pass Client::query's upfront validation");
+    println!("Statement accepted by Client::query (Recordset created).");
+
+    let mut stream = rs.into_stream();
+    match stream.next().await {
+        Some(Err(err)) => println!(
+            "Draining the stream surfaces the expected per-node capability error: {err}"
+        ),
+        Some(Ok(rec)) => panic!(
+            "Expected a capability error (no server supports Top-K yet), got a record: {rec:?}"
+        ),
+        None => panic!("Expected at least one error result from the query stream"),
+    }
+}
+
+/// `set_top_k` without a preceding `set_order_by` is rejected client-side,
+/// before any request reaches the server.
+async fn top_k_without_order_by_is_rejected(client: &Client) {
+    println!("\n--- 2. top_k without order_by is rejected ---");
+
+    let mut stmt = Statement::new(DEFAULT_NAMESPACE, DEFAULT_SET, Bins::All);
+    stmt.set_top_k(5);
+
+    match client
+        .query(&QueryPolicy::default(), PartitionFilter::all(), stmt)
+        .await
+    {
+        Ok(_) => panic!("Expected validation error for top_k without order_by"),
+        Err(err) => println!("Rejected as expected: {err}"),
+    }
+}
+
+/// `k` must be in `[1, 1000]`.
+async fn top_k_out_of_range_is_rejected(client: &Client) {
+    println!("\n--- 3. top_k outside [1, 1000] is rejected ---");
+
+    let mut stmt = Statement::new(DEFAULT_NAMESPACE, DEFAULT_SET, Bins::All);
+    stmt.set_order_by(SCORE_BIN, OrderByType::Integer, Order::Desc);
+    stmt.set_top_k(0);
+
+    match client
+        .query(&QueryPolicy::default(), PartitionFilter::all(), stmt)
+        .await
+    {
+        Ok(_) => panic!("Expected validation error for top_k == 0"),
+        Err(err) => println!("Rejected as expected: {err}"),
+    }
+}
+
+/// When a bin projection is set (via `Bins::Some`, or `set_operations`), the
+/// order-by bin must be one of the projected bins.
+async fn order_by_bin_not_in_projection_is_rejected(client: &Client) {
+    println!("\n--- 4. order_by bin missing from the bin projection is rejected ---");
+
+    let mut stmt = Statement::new(DEFAULT_NAMESPACE, DEFAULT_SET, Bins::from([NAME_BIN]));
+    stmt.set_order_by(SCORE_BIN, OrderByType::Integer, Order::Desc);
+    stmt.set_top_k(3);
+
+    match client
+        .query(&QueryPolicy::default(), PartitionFilter::all(), stmt)
+        .await
+    {
+        Ok(_) => panic!("Expected validation error for order_by bin outside the projection"),
+        Err(err) => println!("Rejected as expected: {err}"),
+    }
+}
+
+/// `OrderByFlags::CaseInsensitive` only makes sense for `OrderByType::String`.
+async fn case_insensitive_flag_requires_string_type_is_rejected(client: &Client) {
+    println!("\n--- 5. CASE_INSENSITIVE flag on a non-STRING type is rejected ---");
+
+    let mut stmt = Statement::new(DEFAULT_NAMESPACE, DEFAULT_SET, Bins::All);
+    stmt.set_order_by_with_flags(
+        SCORE_BIN,
+        OrderByType::Integer,
+        Order::Desc,
+        OrderByFlags::CaseInsensitive,
+    );
+    stmt.set_top_k(3);
+
+    match client
+        .query(&QueryPolicy::default(), PartitionFilter::all(), stmt)
+        .await
+    {
+        Ok(_) => panic!("Expected validation error for CASE_INSENSITIVE with type Integer"),
+        Err(err) => println!("Rejected as expected: {err}"),
+    }
+}
+
+async fn cleanup(client: &Client) {
+    let wpolicy = WritePolicy::default();
+    for user_key in ["alice", "bob", "carol", "dave", "erin"] {
+        let key = as_key!(DEFAULT_NAMESPACE, DEFAULT_SET, user_key);
+        let _ = client.delete(&wpolicy, &key).await;
+    }
+}

--- a/tests/src/examples.rs
+++ b/tests/src/examples.rs
@@ -39,6 +39,10 @@ mod batch_operations_example;
 #[allow(dead_code)]
 mod query_example;
 
+#[path = "../../examples/query_top_k.rs"]
+#[allow(dead_code)]
+mod query_top_k_example;
+
 #[path = "../../examples/timeout_configuration.rs"]
 #[allow(dead_code)]
 mod timeout_configuration_example;
@@ -92,6 +96,11 @@ async fn example_batch_operations() {
 #[aerospike_macro::test]
 async fn example_query() {
     query_example::run().await;
+}
+
+#[aerospike_macro::test]
+async fn example_query_top_k() {
+    query_top_k_example::run().await;
 }
 
 #[aerospike_macro::test]


### PR DESCRIPTION
## Add Top-K query support (`ORDER BY <bin> LIMIT k`)

Implements the client-side API and wire-integrated execution path for Top-K queries (Architecture B: server does per-node bounded reduction, client merges the small per-node results). See `docs/design/top-k-queries-implementation-plan.md` for the full design.

**What's included:**
- New `Statement::set_order_by`/`set_order_by_with_flags`/`set_top_k` API, with client-side validation (bin name length, projection membership, `CASE_INSENSITIVE`/type compatibility, `top_k` range, aggregation incompatibility).
- Wire protocol: `FieldType::OrderBy`/`TopK` encoding in `set_query`, capability-gated on `Version::supports_query_top_k()`.
- `TopKMerger`: client-side merge engine (NIL-aware comparator, generation-first dedup, sort + truncate).
- Execution wiring: a dedicated `Client::execute_top_k_query` path buffers each node's bounded result independently and merges once the whole job completes; any node error forces a whole-job retry (Top-K can't resume mid-partition).
- Background queries (`query_operate`, `query_execute_udf`) reject `order_by`/`top_k`.
- `examples/query_top_k.rs` + unit tests (validation, merge engine, wire encoding, execution wiring).

**Not done / follow-up:**
- **No real server version gating yet** — `supports_query_top_k()` is pinned to a placeholder that's always `false` against real servers, since the server feature has no assigned release version yet. The feature is effectively inert against real clusters until that's wired up.
- **No live end-to-end integration tests** — everything is unit/mock-tested; `tests/src/query_top_k.rs` (ordering/limit correctness, retry, multi-node dedup against a real server) is not written yet, blocked on a reachable server build.
- **Mixed-capability-cluster behavior** (rolling upgrade, some nodes support Top-K and some don't) isn't decided or implemented.
- **`max_records`/`top_k` inconsistency check**, `QueryDuration::Short` rejection, and resumed-`PartitionFilter` rejection are not yet validated client-side (server enforces these, but the client doesn't pre-check).
- Vector-similarity Top-K worked example is out of scope here — still blocked on the vector distance expression's wire contract being finalized separately.