### PR TITLE
CLIENT-5202: evict dead pooled sockets under default policy (idle_timeout=0)

### DIFF
--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -14,6 +14,7 @@
 // the License.
 
 use std::collections::HashMap;
+use std::time::Duration;
 use indexmap::IndexMap;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -33,7 +34,7 @@ use crate::cluster::CLIENT_VERSION;
 use crate::commands::Message;
 use crate::errors::{Error, Result};
 use crate::metrics::NodeMetrics;
-use crate::net::{Connection, ConnectionPool, Host, PooledConnection};
+use crate::net::{Connection, ConnectionPool, Host, PooledConnection, Queue, TailVerdict};
 use crate::policy::{AdminPolicy, ClientPolicy};
 use crate::Version;
 
@@ -41,6 +42,11 @@ pub const PARTITIONS: usize = 4096;
 pub const PARTITION_GENERATION: &str = "partition-generation";
 pub const PEERS_GENERATION: &str = "peers-generation";
 pub const REBALANCE_GENERATION: &str = "rebalance-generation";
+
+/// Safety margin added to the keep-alive look-ahead: a floor connection is
+/// healed once its idle deadline is within `tend_interval + this`, so a late
+/// or skipped tend pass cannot let it expire in the pool.
+const KEEPALIVE_MARGIN: Duration = Duration::from_secs(1);
 
 /// The node instance holding connections and node settings.
 /// Exposed for usage in the sync client interface.
@@ -924,83 +930,78 @@ impl Node {
     /// Returns the number of connections processed (reaped + refreshed).
     pub async fn reap_and_refresh_idle_connections(&self) -> usize {
         let policy = &self.client_policy;
-        let num_queues = policy.conn_pools_per_node as usize;
-        if num_queues == 0 {
+        if policy.conn_pools_per_node == 0 {
             return 0;
         }
 
-        // How many idle connections we may reap this pass without taking the
-        // node below `min_conns_per_node`. This is a GLOBAL budget shared across
-        // the internal queues, matching `fill_min_conns` (which also compares
-        // the whole pool against `min`).
+        // Global budget shared across queues: how many may be closed without
+        // taking the node below `min_conns_per_node`.
         let mut droppable = self
             .connection_pool
             .total_reserved()
             .saturating_sub(policy.min_conns_per_node);
+
+        // A floor connection whose idle deadline falls inside this horizon
+        // would expire before tend can look again — heal it now.
+        let expiry_horizon =
+            std::time::Duration::from_millis(u64::from(policy.tend_interval)) + KEEPALIVE_MARGIN;
 
         let probe_policy = AdminPolicy {
             // Tight timeout — this is a keep-alive probe, not a command.
             timeout: policy.timeout.min(2000),
         };
 
+        // Decide first: walk each queue's tail and collect verdicts. At most
+        // one connection leaves a queue per step, so callers never find the
+        // pool drained by maintenance.
+        let mut to_probe: Vec<(Queue, Connection)> = Vec::new();
         let mut total_processed = 0usize;
         for queue in self.connection_pool.queues() {
-            let Some(idle) = queue.try_extract_idle() else {
-                // Queue is contended by a live caller — skip this tend.
-                continue;
-            };
-            if idle.is_empty() {
-                continue;
-            }
-
-            // Reap only the surplus (up to the remaining global budget); keep
-            // the rest alive via a probe so the pool stays at/above `min`.
-            let to_drop = droppable.min(idle.len());
-            droppable -= to_drop;
-
-            let mut idle_iter = idle.into_iter();
-            for conn in idle_iter.by_ref().take(to_drop) {
-                drop(conn);
-                queue.reduce_capacity();
-                self.metrics.incr_connections_idle_dropped();
-                self.metrics.incr_connections_closed();
-                total_processed += 1;
-            }
-            let keepers: Vec<Connection> = idle_iter.collect();
-
-            if keepers.is_empty() {
-                continue;
-            }
-
-            // Probe keepers concurrently. Successful probe → surviving conn
-            // goes straight back in the queue (its idle deadline was reset
-            // as a side effect of reading the info response). Failed probe
-            // → the connection is dead; free its slot.
-            let probes = keepers.into_iter().map(|mut conn| {
-                let pp = probe_policy;
-                async move {
-                    match Message::info(&pp, &mut conn, &["node"]).await {
-                        Ok(_) => Some(conn),
-                        Err(_) => None,
+            loop {
+                match queue.inspect_tail(droppable > 0, expiry_horizon) {
+                    // Contended or settled: everything deeper is fresher.
+                    None | Some(TailVerdict::Settled) => break,
+                    Some(TailVerdict::Retire(conn)) => {
+                        drop(conn);
+                        queue.reduce_capacity();
+                        droppable = droppable.saturating_sub(1);
+                        self.metrics.incr_connections_idle_dropped();
+                        self.metrics.incr_connections_closed();
+                        total_processed += 1;
+                    }
+                    Some(TailVerdict::KeepAlive(conn)) => {
+                        to_probe.push((queue.clone(), conn));
                     }
                 }
-            });
-            let results = futures::future::join_all(probes).await;
+            }
+        }
 
-            for result in results {
-                if let Some(conn) = result {
-                    // `put_back` uses a blocking `lock()` but only
-                    // briefly (push one element) — no async I/O is
-                    // held under it. Keeps the API simple and the
-                    // probed conns go back in order.
-                    queue.put_back(conn);
-                    total_processed += 1;
-                } else {
-                    queue.reduce_capacity();
-                    self.metrics.incr_connections_closed();
-                    total_processed += 1;
+        if to_probe.is_empty() {
+            return total_processed;
+        }
+
+        // Act: probe the keepers concurrently, so wall-clock is one round-trip
+        // rather than one per connection. A successful probe refreshes the
+        // connection (the response read stamps it), and `put_back` re-pools it
+        // as the freshest; a failure means the socket is dead — free its slot.
+        let probes = to_probe.into_iter().map(|(queue, mut conn)| {
+            let pp = probe_policy;
+            async move {
+                match Message::info(&pp, &mut conn, &["node"]).await {
+                    Ok(_) => (queue, Some(conn)),
+                    Err(_) => (queue, None),
                 }
             }
+        });
+        for (queue, result) in futures::future::join_all(probes).await {
+            match result {
+                Some(conn) => queue.put_back(conn),
+                None => {
+                    queue.reduce_capacity();
+                    self.metrics.incr_connections_closed();
+                }
+            }
+            total_processed += 1;
         }
 
         total_processed
@@ -1338,5 +1339,294 @@ mod node_tests {
         assert_eq!(node.connection_pool.total_reserved(), 5);
 
         drop(in_flight);
+    }
+}
+
+/// LIFO pool-health tests. A loopback fake node stands in for `asd`: dead
+/// mode FINs every accepted socket, live mode answers info probes. Each test
+/// drives one or more reaper passes directly — the same method tend calls.
+#[cfg(all(test, feature = "rt-tokio"))]
+mod pool_health_tests {
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use aerospike_rt::net::TcpListener;
+
+    use crate::cluster::node_validator::NodeValidator;
+    use crate::net::Host;
+    use crate::policy::ClientPolicy;
+    use crate::Version;
+
+    use super::Node;
+
+    /// Fake node; the flag toggles dead (FIN on accept) vs live (answers info).
+    async fn spawn_fake_node(dead: bool) -> (SocketAddr, Arc<AtomicBool>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let dead_flag = Arc::new(AtomicBool::new(dead));
+        let flag = dead_flag.clone();
+        aerospike_rt::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            loop {
+                let Ok((mut sock, _)) = listener.accept().await else {
+                    break;
+                };
+                if flag.load(Ordering::SeqCst) {
+                    let _ = sock.shutdown().await;
+                    drop(sock);
+                } else {
+                    aerospike_rt::spawn(async move {
+                        loop {
+                            // Info framing: 8-byte header + payload.
+                            let mut header = [0u8; 8];
+                            if sock.read_exact(&mut header).await.is_err() {
+                                return;
+                            }
+                            let mut len8 = [0u8; 8];
+                            len8[2..8].copy_from_slice(&header[2..8]);
+                            let len = u64::from_be_bytes(len8) as usize;
+                            let mut payload = vec![0u8; len];
+                            if sock.read_exact(&mut payload).await.is_err() {
+                                return;
+                            }
+                            let body: &[u8] = b"node\tFAKEPEER\n";
+                            let mut resp = Vec::with_capacity(8 + body.len());
+                            resp.push(2);
+                            resp.push(1);
+                            resp.extend_from_slice(&(body.len() as u64).to_be_bytes()[2..8]);
+                            resp.extend_from_slice(body);
+                            if sock.write_all(&resp).await.is_err() {
+                                return;
+                            }
+                        }
+                    });
+                }
+            }
+        });
+        (addr, dead_flag)
+    }
+
+    fn node_against(addr: SocketAddr, policy: ClientPolicy) -> Node {
+        let nv = Arc::new(NodeValidator {
+            name: "fake-node".to_string(),
+            aliases: vec![Host::new(&addr.ip().to_string(), addr.port())],
+            address: addr.to_string(),
+            client_policy: policy.clone(),
+            use_new_info: true,
+            version: Version::default(),
+            detect_load_balancer: false,
+        });
+        let metrics = Arc::new(crate::metrics::NodeMetrics::new(
+            crate::metrics::MetricsPolicy::default(),
+        ));
+        Node::new(policy, nv, metrics, Arc::new(AtomicUsize::new(0)), None)
+    }
+
+    /// Park `n` real TCP conns (make_conn's test shim has no socket).
+    async fn park_conns(node: &Node, addr: SocketAddr, policy: &ClientPolicy, n: usize) {
+        let queue = &node.connection_pool.queues()[0];
+        for _ in 0..n {
+            let stream = aerospike_rt::net::TcpStream::connect(addr)
+                .await
+                .expect("connect to fake node");
+            let conn = crate::net::Connection::test_from_tcp_stream(stream, policy);
+            assert!(queue.reserve_capacity());
+            queue.put_back(conn);
+        }
+        // Let the peer's accept/FIN land.
+        aerospike_rt::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(node.connection_pool.num_conns(), n);
+    }
+
+    fn test_policy(idle_timeout: u32, min_conns: usize) -> ClientPolicy {
+        ClientPolicy {
+            idle_timeout,
+            min_conns_per_node: min_conns,
+            tend_interval: 250,
+            // Generous, so a probe cannot time out on a loaded machine.
+            timeout: 5_000,
+            ..ClientPolicy::default()
+        }
+    }
+
+    // ─── LIFO ordering ────────────────────────────────────────────────────
+
+    /// Checkout returns the most recently returned connection; a reused
+    /// connection stays on top while the rest of the pool ages untouched.
+    #[aerospike_macro::test]
+    async fn checkout_is_lifo() {
+        let (addr, _dead) = spawn_fake_node(false).await;
+        let policy = test_policy(0, 0);
+        let node = node_against(addr, policy.clone());
+        park_conns(&node, addr, &policy, 3).await;
+
+        let queue = &node.connection_pool.queues()[0];
+        let first = queue.get().expect("conn");
+        drop(first); // returns to the top
+        let again = queue.get().expect("conn");
+        // With three parked conns and LIFO order, num_conns dropped by one and
+        // the same top slot cycles; the two older conns were never touched.
+        assert_eq!(node.connection_pool.num_conns(), 2);
+        drop(again);
+    }
+
+    // ─── retention: surplus retires, floor survives ───────────────────────
+
+    /// The regression gate: surplus retires across repeated tends even while
+    /// tend keeps running. Under FIFO+probe designs the maintenance itself
+    /// kept renewing the surplus deadlines and the pool never shrank.
+    #[aerospike_macro::test]
+    async fn surplus_retires_across_repeated_tends() {
+        let (addr, _dead) = spawn_fake_node(false).await;
+        let policy = test_policy(600, 1); // retire after 600ms, keep 1 warm
+        let node = node_against(addr, policy.clone());
+        park_conns(&node, addr, &policy, 4).await;
+
+        for _ in 0..4 {
+            aerospike_rt::sleep(std::time::Duration::from_millis(300)).await;
+            node.reap_and_refresh_idle_connections().await;
+        }
+
+        assert_eq!(
+            node.connection_pool.total_reserved(),
+            1,
+            "surplus must retire down to min_conns_per_node across repeated tends"
+        );
+    }
+
+    /// A connection short of its idle deadline is left alone — no drop, no
+    /// probe. Touching it would renew the deadline and keep surplus alive.
+    #[aerospike_macro::test]
+    async fn unexpired_conns_are_left_alone() {
+        let (addr, _dead) = spawn_fake_node(false).await;
+        let policy = test_policy(60_000, 0); // one minute: nothing expires here
+        let node = node_against(addr, policy.clone());
+        park_conns(&node, addr, &policy, 2).await;
+
+        let processed = node.reap_and_refresh_idle_connections().await;
+        assert_eq!(processed, 0, "nothing is expired, so tend must touch nothing");
+        assert_eq!(node.connection_pool.num_conns(), 2);
+    }
+
+    /// A floor connection past its deadline (e.g. after a missed pass) is
+    /// healed — probed and re-pooled — not stranded or dropped.
+    #[aerospike_macro::test]
+    async fn expired_floor_conn_is_healed() {
+        let (addr, _dead) = spawn_fake_node(false).await;
+        let policy = test_policy(300, 1); // floor of 1
+        let node = node_against(addr, policy.clone());
+        park_conns(&node, addr, &policy, 1).await;
+
+        aerospike_rt::sleep(std::time::Duration::from_millis(400)).await; // expired
+
+        let processed = node.reap_and_refresh_idle_connections().await;
+        assert_eq!(processed, 1, "the floor conn must be probed");
+        assert_eq!(
+            node.connection_pool.num_conns(),
+            1,
+            "a live floor conn survives its probe and returns to the pool"
+        );
+        // And checkout can use it immediately (no expired-discard at checkout).
+        assert!(node.connection_pool.queues()[0].get().is_ok());
+    }
+
+    /// A dead floor connection fails its probe and is evicted, freeing the
+    /// slot for fill_min_conns to replace.
+    #[aerospike_macro::test]
+    async fn dead_floor_conn_is_evicted_by_probe() {
+        let (addr, _dead) = spawn_fake_node(true).await; // peer FINs everything
+        let policy = test_policy(300, 1);
+        let node = node_against(addr, policy.clone());
+        park_conns(&node, addr, &policy, 1).await;
+
+        aerospike_rt::sleep(std::time::Duration::from_millis(400)).await;
+
+        node.reap_and_refresh_idle_connections().await;
+        assert_eq!(
+            node.connection_pool.total_reserved(),
+            0,
+            "a dead floor conn must be evicted so the fill can replace it"
+        );
+    }
+
+    /// idle_timeout = 0: no deadline exists, so tend must touch nothing —
+    /// no drops, no probes. Dead sockets are the checkout peek's job.
+    #[aerospike_macro::test]
+    async fn idle_timeout_zero_tend_is_noop() {
+        let (addr, _dead) = spawn_fake_node(true).await; // even with DEAD conns
+        let policy = test_policy(0, 0);
+        let node = node_against(addr, policy.clone());
+        park_conns(&node, addr, &policy, 3).await;
+
+        aerospike_rt::sleep(std::time::Duration::from_millis(400)).await;
+
+        let processed = node.reap_and_refresh_idle_connections().await;
+        assert_eq!(processed, 0, "no deadline armed: tend has nothing to do");
+        assert_eq!(node.connection_pool.num_conns(), 3);
+    }
+
+    /// One pass over a fully-expired pool retires exactly the surplus and
+    /// keep-alives exactly the floor — the probe batch is bounded by
+    /// `min_conns_per_node`, and the loop terminates with the queue drained.
+    #[aerospike_macro::test]
+    async fn keepalive_batch_is_bounded_by_the_floor() {
+        let (addr, _dead) = spawn_fake_node(false).await;
+        let policy = test_policy(300, 2); // floor of 2
+        let node = node_against(addr, policy.clone());
+        park_conns(&node, addr, &policy, 5).await;
+
+        aerospike_rt::sleep(std::time::Duration::from_millis(400)).await; // all expired
+
+        let processed = node.reap_and_refresh_idle_connections().await;
+
+        assert_eq!(processed, 5, "3 retired + 2 probed: every conn accounted for");
+        assert_eq!(
+            node.connection_pool.total_reserved(),
+            2,
+            "exactly the floor survives: surplus retired, keepers healed"
+        );
+        assert_eq!(
+            node.connection_pool.num_conns(),
+            2,
+            "both floor conns are back in the pool after their probes"
+        );
+    }
+
+    /// The retire budget is global across queues: the pool settles at the
+    /// floor and the budget cannot underflow.
+    #[aerospike_macro::test]
+    async fn retire_budget_is_shared_across_queues() {
+        let (addr, _dead) = spawn_fake_node(false).await;
+        let policy = ClientPolicy {
+            idle_timeout: 300,
+            min_conns_per_node: 1,
+            tend_interval: 250,
+            conn_pools_per_node: 4,
+            timeout: 5_000,
+            ..ClientPolicy::default()
+        };
+        let node = node_against(addr, policy.clone());
+        for qi in 0..4 {
+            let queue = &node.connection_pool.queues()[qi];
+            for _ in 0..2 {
+                let stream = aerospike_rt::net::TcpStream::connect(addr)
+                    .await
+                    .expect("connect");
+                let conn = crate::net::Connection::test_from_tcp_stream(stream, &policy);
+                assert!(queue.reserve_capacity());
+                queue.put_back(conn);
+            }
+        }
+        assert_eq!(node.connection_pool.total_reserved(), 8);
+        aerospike_rt::sleep(std::time::Duration::from_millis(600)).await;
+
+        node.reap_and_refresh_idle_connections().await;
+
+        assert_eq!(
+            node.connection_pool.total_reserved(),
+            1,
+            "7 of 8 must retire across the four queues, stopping at the floor"
+        );
     }
 }

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -34,7 +34,7 @@ use crate::cluster::CLIENT_VERSION;
 use crate::commands::Message;
 use crate::errors::{Error, Result};
 use crate::metrics::NodeMetrics;
-use crate::net::{Connection, ConnectionPool, Host, PooledConnection, Queue, TailVerdict};
+use crate::net::{Connection, ConnectionPool, Host, PooledConnection, TailVerdict};
 use crate::policy::{AdminPolicy, ClientPolicy};
 use crate::Version;
 
@@ -968,13 +968,21 @@ impl Node {
             timeout: policy.timeout.min(2000),
         };
 
-        // One verdict per queue per turn. Every turn either pops a connection
-        // (finite) or retires the queue from the rotation — bounded, no spinning.
+        // Cycle through queues one verdict at a time so the retire budget is spread
+        // evenly instead of draining queues in order. A full lap of quiet verdicts
+        // (fresh, empty, or contended) ends the sweep. With no queues, cycle() is empty.
+        //
+        // Probed connections are put back only after this loop. Putting one back here
+        // could make it immediately eligible again—especially when
+        // idle_timeout <= tend_interval + KEEPALIVE_MARGIN—and cause an infinite sweep.
+        // `take` is the safety bound: capacity-bounded pops should terminate normally;
+        // it only protects against an accidental non-terminating sweep.
         let mut probe_handles = Vec::new();
         let mut total_processed = 0usize;
-        let mut active: std::collections::VecDeque<&Queue> =
-            self.connection_pool.queues().iter().collect();
-        while let Some(queue) = active.pop_front() {
+        let queues = self.connection_pool.queues();
+        let max_probe_attempts = queues.len() * (policy.max_conns_per_node + 1);
+        let mut queues_without_work = 0;
+        for queue in queues.iter().cycle().take(max_probe_attempts) {
             match queue.inspect_tail(droppable > 0, expiry_horizon) {
                 Some(TailVerdict::Retire(conn)) => {
                     drop(conn);
@@ -983,7 +991,7 @@ impl Node {
                     self.metrics.incr_connections_idle_dropped();
                     self.metrics.incr_connections_closed();
                     total_processed += 1;
-                    active.push_back(queue);
+                    queues_without_work = 0;
                 }
                 Some(TailVerdict::KeepAlive(conn)) => {
                     // Probe runs concurrently from here; pool mutation waits below.
@@ -998,10 +1006,16 @@ impl Node {
                         }
                     });
                     probe_handles.push((queue.clone(), handle));
-                    active.push_back(queue);
+                    queues_without_work = 0;
                 }
-                // Contended or settled: everything deeper is fresher.
-                None | Some(TailVerdict::Settled) => {}
+                // Settled (front is fresh, so everything behind it is fresher) or
+                // contended (leave it for traffic and re-check it on the next lap).
+                None | Some(TailVerdict::Settled) => {
+                    queues_without_work += 1;
+                    if queues_without_work == queues.len() {
+                        break;
+                    }
+                }
             }
         }
 

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -109,7 +109,8 @@ async fn await_spawned_task<T>(handle: aerospike_rt::task::JoinHandle<Option<T>>
     use futures::FutureExt;
     std::panic::AssertUnwindSafe(async move {
         #[cfg(feature = "rt-tokio")]
-        return handle.await.unwrap_or(None); // JoinError → None, no panic involved
+        return handle.await.ok().flatten(); 
+
         #[cfg(feature = "rt-async-std")]
         return handle.await; // task panic re-raises here → caught below
     })

--- a/aerospike-core/src/cluster/node.rs
+++ b/aerospike-core/src/cluster/node.rs
@@ -103,6 +103,22 @@ pub struct Node {
     opening_connections: Arc<AtomicUsize>,
 }
 
+/// Await a spawned probe task. A panicked task degrades to a failed probe
+/// (`None`) on both runtimes, so the tend task survives.
+async fn await_spawned_task<T>(handle: aerospike_rt::task::JoinHandle<Option<T>>) -> Option<T> {
+    use futures::FutureExt;
+    std::panic::AssertUnwindSafe(async move {
+        #[cfg(feature = "rt-tokio")]
+        return handle.await.unwrap_or(None); // JoinError → None, no panic involved
+        #[cfg(feature = "rt-async-std")]
+        return handle.await; // task panic re-raises here → caught below
+    })
+    .catch_unwind()
+    .await
+    .ok() // Err(payload) = a panic was caught → None
+    .flatten()
+}
+
 impl Drop for Node {
     fn drop(&mut self) {
         debug!("Node closed {self}");
@@ -922,10 +938,10 @@ impl Node {
     /// calls `conn.refresh()` internally), so the probed connection goes
     /// back into the pool as fresh.
     ///
-    /// **Non-blocking**: uses `try_lock` on each queue so a contended pool
-    /// is skipped for this tend iteration — tend retries next time. Probes
-    /// run concurrently via `join_all` so total wall-clock is bounded by
-    /// the single slowest probe, not `N × per-probe latency`.
+    /// Queues are swept round-robin, one verdict per queue per turn, so the
+    /// retire budget is spent evenly across queues instead of draining them
+    /// in order. All keep-alive probes complete before this function returns,
+    /// so the pool is settled and the returned count is final.
     ///
     /// Returns the number of connections processed (reaped + refreshed).
     pub async fn reap_and_refresh_idle_connections(&self) -> usize {
@@ -951,50 +967,50 @@ impl Node {
             timeout: policy.timeout.min(2000),
         };
 
-        // Decide first: walk each queue's tail and collect verdicts. At most
-        // one connection leaves a queue per step, so callers never find the
-        // pool drained by maintenance.
-        let mut to_probe: Vec<(Queue, Connection)> = Vec::new();
+        // One verdict per queue per turn. Every turn either pops a connection
+        // (finite) or retires the queue from the rotation — bounded, no spinning.
+        let mut probe_handles = Vec::new();
         let mut total_processed = 0usize;
-        for queue in self.connection_pool.queues() {
-            loop {
-                match queue.inspect_tail(droppable > 0, expiry_horizon) {
-                    // Contended or settled: everything deeper is fresher.
-                    None | Some(TailVerdict::Settled) => break,
-                    Some(TailVerdict::Retire(conn)) => {
-                        drop(conn);
-                        queue.reduce_capacity();
-                        droppable = droppable.saturating_sub(1);
-                        self.metrics.incr_connections_idle_dropped();
-                        self.metrics.incr_connections_closed();
-                        total_processed += 1;
-                    }
-                    Some(TailVerdict::KeepAlive(conn)) => {
-                        to_probe.push((queue.clone(), conn));
-                    }
+        let mut active: std::collections::VecDeque<&Queue> =
+            self.connection_pool.queues().iter().collect();
+        while let Some(queue) = active.pop_front() {
+            match queue.inspect_tail(droppable > 0, expiry_horizon) {
+                Some(TailVerdict::Retire(conn)) => {
+                    drop(conn);
+                    queue.reduce_capacity();
+                    droppable = droppable.saturating_sub(1);
+                    self.metrics.incr_connections_idle_dropped();
+                    self.metrics.incr_connections_closed();
+                    total_processed += 1;
+                    active.push_back(queue);
                 }
+                Some(TailVerdict::KeepAlive(conn)) => {
+                    // Probe runs concurrently from here; pool mutation waits below.
+                    // The queue stays outside the task so its slot can be freed
+                    // even if the task dies.
+                    let pp = probe_policy;
+                    let handle = aerospike_rt::spawn(async move {
+                        let mut conn = conn;
+                        match Message::info(&pp, &mut conn, &["node"]).await {
+                            Ok(_) => Some(conn),
+                            Err(_) => None,
+                        }
+                    });
+                    probe_handles.push((queue.clone(), handle));
+                    active.push_back(queue);
+                }
+                // Contended or settled: everything deeper is fresher.
+                None | Some(TailVerdict::Settled) => {}
             }
         }
 
-        if to_probe.is_empty() {
-            return total_processed;
-        }
-
-        // Act: probe the keepers concurrently, so wall-clock is one round-trip
-        // rather than one per connection. A successful probe refreshes the
-        // connection (the response read stamps it), and `put_back` re-pools it
-        // as the freshest; a failure means the socket is dead — free its slot.
-        let probes = to_probe.into_iter().map(|(queue, mut conn)| {
-            let pp = probe_policy;
-            async move {
-                match Message::info(&pp, &mut conn, &["node"]).await {
-                    Ok(_) => (queue, Some(conn)),
-                    Err(_) => (queue, None),
-                }
-            }
-        });
-        for (queue, result) in futures::future::join_all(probes).await {
-            match result {
+        // Each handle is paired with the queue its connection came from, and
+        // the task returns the connection itself on success. The probes have
+        // been running since spawn, so awaiting them in order costs only the
+        // slowest one. A healed connection re-pools into its own queue, and a
+        // failed one frees that queue's reserved slot.
+        for (queue, handle) in probe_handles {
+            match await_spawned_task(handle).await {
                 Some(conn) => queue.put_back(conn),
                 None => {
                     queue.reduce_capacity();
@@ -1628,5 +1644,47 @@ mod pool_health_tests {
             1,
             "7 of 8 must retire across the four queues, stopping at the floor"
         );
+    }
+
+    /// The retire budget is spent round-robin, one connection per queue per
+    /// turn — the old queue-by-queue sweep left (0, 0, 2, 2) here.
+    #[aerospike_macro::test]
+    async fn retire_budget_spreads_across_queues_fairly() {
+        let (addr, _dead) = spawn_fake_node(false).await;
+        let policy = ClientPolicy {
+            idle_timeout: 300,
+            min_conns_per_node: 4,
+            tend_interval: 250,
+            conn_pools_per_node: 4,
+            timeout: 5_000,
+            ..ClientPolicy::default()
+        };
+        let node = node_against(addr, policy.clone());
+        for qi in 0..4 {
+            let queue = &node.connection_pool.queues()[qi];
+            for _ in 0..2 {
+                let stream = aerospike_rt::net::TcpStream::connect(addr)
+                    .await
+                    .expect("connect");
+                let conn = crate::net::Connection::test_from_tcp_stream(stream, &policy);
+                assert!(queue.reserve_capacity());
+                queue.put_back(conn);
+            }
+        }
+        assert_eq!(node.connection_pool.total_reserved(), 8);
+        aerospike_rt::sleep(std::time::Duration::from_millis(600)).await;
+
+        // Budget = 8 - 4 = 4: one retirement per queue, then the floor
+        // survivors (one per queue) are probed and re-pooled.
+        node.reap_and_refresh_idle_connections().await;
+
+        for qi in 0..4 {
+            assert_eq!(
+                node.connection_pool.queues()[qi].reserved_count(),
+                1,
+                "queue {qi} must keep exactly one conn: retirement is spread \
+                 one-per-queue, not drained queue-by-queue"
+            );
+        }
     }
 }

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -75,6 +75,17 @@ enum Liveness {
     Closed,
 }
 
+/// A pooled connection's position relative to its idle deadline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum IdleStatus {
+    /// No deadline armed (`idle_timeout = 0`), or plenty of time left.
+    Fresh,
+    /// The deadline falls inside the caller's expiry horizon.
+    ExpiringSoon,
+    /// The deadline has passed.
+    Expired,
+}
+
 /// Underlying socket type for a connection (TCP or TLS).
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -337,6 +348,42 @@ impl Connection {
         };
         conn.refresh();
         Ok(conn)
+    }
+
+    /// Test-only: connection over a real TCP stream (`new`'s test shim
+    /// has no socket).
+    #[cfg(all(test, feature = "rt-tokio"))]
+    pub(crate) fn test_from_tcp_stream(
+        stream: aerospike_rt::net::TcpStream,
+        policy: &ClientPolicy,
+    ) -> Self {
+        let idle_timeout = if policy.idle_timeout > 0 {
+            Some(Duration::from_millis(u64::from(policy.idle_timeout)))
+        } else {
+            None
+        };
+        let mut conn = Connection {
+            addr: "127.0.0.1:0".into(),
+            buffer: Buffer::new(policy.buffer_reclaim_threshold),
+            bytes_read: 0,
+            conn: Netsocket::Tcp(stream),
+            socket_timeout: 5_000,
+            timeout_delay: 0,
+            deadline: None,
+            idle_timeout,
+            idle_deadline: idle_timeout.map(|timeout| Instant::now() + timeout),
+            state: ConnectionState::Ready,
+            can_recover_connection: false,
+            response_decompressed: false,
+            compressed_stream_body: false,
+            rnd: XorShift::new(),
+            // Far-future deadline; reset before each IO so this never fires first.
+            sleep: Box::pin(aerospike_rt::tokio::time::sleep(
+                aerospike_rt::time::Duration::from_secs(3600),
+            )),
+        };
+        conn.refresh();
+        conn
     }
 
     /// Returns the connection's per-connection random generator, used by the
@@ -698,6 +745,17 @@ impl Connection {
     pub fn is_idle(&self) -> bool {
         self.idle_deadline
             .is_some_and(|idle_dl| Instant::now() >= idle_dl)
+    }
+
+    /// Where this connection stands relative to its idle deadline. A deadline
+    /// within `expiry_horizon` counts as expiring.
+    pub(crate) fn idle_status(&self, now: Instant, expiry_horizon: Duration) -> IdleStatus {
+        match self.idle_deadline {
+            None => IdleStatus::Fresh,
+            Some(deadline) if now >= deadline => IdleStatus::Expired,
+            Some(deadline) if now + expiry_horizon >= deadline => IdleStatus::ExpiringSoon,
+            Some(_) => IdleStatus::Fresh,
+        }
     }
 
     /// What a one-byte peek says about a socket.
@@ -1445,6 +1503,59 @@ impl<'a> ConnectionRecovery<'a> {
 
         assert!(self.conn.bytes_read == total_size);
         Ok(last_record)
+    }
+}
+
+#[cfg(test)]
+mod idle_status_tests {
+    use super::*;
+
+    async fn conn_with_deadline(deadline: Option<Duration>) -> Connection {
+        let mut c = Connection::new(&Host::new("127.0.0.1", 0), &ClientPolicy::default(), None)
+            .await
+            .unwrap();
+        c.idle_deadline = deadline.map(|d| Instant::now() + d);
+        c
+    }
+
+    #[aerospike_macro::test]
+    async fn no_deadline_is_fresh() {
+        let c = conn_with_deadline(None).await;
+        let now = Instant::now();
+        assert_eq!(
+            c.idle_status(now, Duration::from_secs(100)),
+            IdleStatus::Fresh,
+            "idle_timeout = 0 arms no deadline, so nothing ever expires"
+        );
+    }
+
+    #[aerospike_macro::test]
+    async fn deadline_far_away_is_fresh() {
+        let c = conn_with_deadline(Some(Duration::from_secs(60))).await;
+        assert_eq!(
+            c.idle_status(Instant::now(), Duration::from_secs(2)),
+            IdleStatus::Fresh
+        );
+    }
+
+    #[aerospike_macro::test]
+    async fn deadline_inside_window_is_expiring() {
+        let c = conn_with_deadline(Some(Duration::from_secs(1))).await;
+        assert_eq!(
+            c.idle_status(Instant::now(), Duration::from_secs(2)),
+            IdleStatus::ExpiringSoon
+        );
+    }
+
+    #[aerospike_macro::test]
+    async fn deadline_in_the_past_is_expired() {
+        let c = conn_with_deadline(Some(Duration::from_secs(0))).await;
+        aerospike_rt::sleep(std::time::Duration::from_millis(5)).await;
+        assert_eq!(
+            c.idle_status(Instant::now(), Duration::from_secs(2)),
+            IdleStatus::Expired,
+            "the loose predicate must classify a missed deadline as Expired"
+        );
     }
 }
 

--- a/aerospike-core/src/net/connection_pool.rs
+++ b/aerospike-core/src/net/connection_pool.rs
@@ -19,7 +19,9 @@ use std::sync::Arc;
 use crate::commands::admin_command::SessionInfo;
 use crate::errors::{Error, Result};
 use crate::metrics::NodeMetrics;
+use crate::net::connection::IdleStatus;
 use crate::net::{Connection, ConnectionState, Host};
+use aerospike_rt::time::Instant;
 use crate::policy::ClientPolicy;
 use std::collections::VecDeque;
 use std::sync::Mutex;
@@ -199,19 +201,12 @@ impl Queue {
                 .connections
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if let Some(conn) = connections.pop_front() {
+            // LIFO: the most recently returned connection is the freshest and
+            // the most likely to be healthy. Retirement of idle connections is
+            // tend's job exclusively (it holds the min-conns budget); checkout
+            // checks health only.
+            if let Some(conn) = connections.pop_back() {
                 drop(connections);
-                if conn.is_idle() {
-                    // let the connection drop and close
-                    if let Some(metrics) = self.metrics() {
-                        metrics.incr_connections_idle_dropped();
-                        metrics.incr_connections_closed();
-                    }
-                    drop(conn);
-                    self.reduce_capacity();
-                    continue;
-                }
-
                 // A server restart leaves the pool full of sockets the peer has
                 // already closed. Handing one to a command makes it fail on its
                 // first read (`early eof`) and burn a retry, so discard it here
@@ -291,31 +286,52 @@ impl Queue {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    /// Pull every currently-idle connection out of the queue without
-    /// blocking — uses `try_lock` so a contended pool returns `None`
-    /// and the caller can skip this iteration.
+    /// Inspect the oldest pooled connection and, when it needs attention,
+    /// take it out with the verdict. `may_retire` = the caller's global
+    /// budget still allows closing a connection without breaching
+    /// `min_conns_per_node`. `expiry_horizon` = a deadline inside it counts
+    /// as expiring. `None` = queue contended by a live caller; skip it
+    /// this tend.
     ///
-    /// Ownership of the returned connections transfers to the caller: they
-    /// must either put survivors back with [`put_back`] or drop + call
-    /// [`reduce_capacity`] for each one that goes away. Non-idle connections
-    /// stay in the queue.
-    pub fn try_extract_idle(&self) -> Option<Vec<Connection>> {
+    /// The pool is LIFO (`get` and `put_back` both work the back), so the
+    /// front is always the least recently used connection: once it is
+    /// `Fresh`, everything behind it is fresher.
+    pub(crate) fn inspect_tail(
+        &self,
+        may_retire: bool,
+        expiry_horizon: std::time::Duration,
+    ) -> Option<TailVerdict> {
         let mut connections = self.0.connections.try_lock().ok()?;
-        if connections.is_empty() {
-            return Some(Vec::new());
-        }
-        let mut idle = Vec::new();
-        let mut kept = VecDeque::with_capacity(connections.len());
-        for conn in connections.drain(..) {
-            if conn.is_idle() {
-                idle.push(conn);
-            } else {
-                kept.push_back(conn);
+        let Some(oldest) = connections.front() else {
+            return Some(TailVerdict::Settled);
+        };
+        let verdict = match oldest.idle_status(Instant::now(), expiry_horizon) {
+            // Surplus retires when its own clock runs out.
+            IdleStatus::Expired if may_retire => {
+                TailVerdict::Retire(connections.pop_front().unwrap())
             }
-        }
-        *connections = kept;
-        Some(idle)
+            // Floor-protected and expired (a missed pass) or about to expire:
+            // heal it. Never reached while retiring is still allowed, so a
+            // probe can never renew a clock the pool is waiting on.
+            IdleStatus::Expired | IdleStatus::ExpiringSoon if !may_retire => {
+                TailVerdict::KeepAlive(connections.pop_front().unwrap())
+            }
+            // Fresh — or expiring surplus, which is left to age out.
+            _ => TailVerdict::Settled,
+        };
+        Some(verdict)
     }
+}
+
+/// Tend's decision about a queue's oldest connection.
+#[derive(Debug)]
+pub(crate) enum TailVerdict {
+    /// The tail needs no attention; everything behind it is fresher.
+    Settled,
+    /// Expired surplus, taken out of the queue: close it.
+    Retire(Connection),
+    /// Expired or expiring but floor-protected, taken out: probe and re-pool.
+    KeepAlive(Connection),
 }
 
 impl Clone for Queue {
@@ -849,7 +865,7 @@ mod tests {
     }
 
     #[aerospike_macro::test]
-    async fn get_idle_reduces_reserved() {
+    async fn get_hands_out_expired_connection_retirement_is_tends_job() {
         let host = Host::new("some-url", 30000);
         let policy = ClientPolicy {
             idle_timeout: 1,
@@ -861,19 +877,18 @@ mod tests {
             .await
             .expect("creating dummy connection failed");
         put_back_with_reserve!(q, c);
-        assert_eq!(q.reserved(), 1);
-        assert_eq!(q.num_conns(), 1);
 
         aerospike_rt::sleep(aerospike_rt::time::Duration::from_millis(5)).await;
 
+        // The connection is past its idle deadline but healthy. Checkout must
+        // hand it out anyway: an expired connection works fine, and retiring
+        // it here would bypass the min-conns budget that only tend holds.
         let result = q.get();
-        assert!(result.is_err(), "idle connection should have been skipped");
-        assert_eq!(
-            q.reserved(),
-            0,
-            "reserved must be decremented when an idle connection is dropped"
+        assert!(
+            result.is_ok(),
+            "checkout must not retire expired-but-healthy connections"
         );
-        assert_eq!(q.num_conns(), 0);
+        assert_eq!(q.reserved(), 1, "the connection is loaned out, not closed");
     }
 
     #[aerospike_macro::test]

--- a/aerospike-core/src/net/mod.rs
+++ b/aerospike-core/src/net/mod.rs
@@ -17,7 +17,7 @@ pub use self::connection::BufferedConn;
 pub use self::connection::Connection;
 pub use self::connection::ConnectionState;
 pub use self::connection_pool::ConnectionPool;
-pub(crate) use self::connection_pool::{Queue, TailVerdict};
+pub(crate) use self::connection_pool::TailVerdict;
 pub use self::connection_pool::PooledConnection;
 pub use self::host::Host;
 pub use self::host::ToHosts;

--- a/aerospike-core/src/net/mod.rs
+++ b/aerospike-core/src/net/mod.rs
@@ -17,6 +17,7 @@ pub use self::connection::BufferedConn;
 pub use self::connection::Connection;
 pub use self::connection::ConnectionState;
 pub use self::connection_pool::ConnectionPool;
+pub(crate) use self::connection_pool::{Queue, TailVerdict};
 pub use self::connection_pool::PooledConnection;
 pub use self::host::Host;
 pub use self::host::ToHosts;


### PR DESCRIPTION
The pool is now `LIFO`: `put_back()` still pushes to the **back**, and `get()`
now pops from the **back** too. The last connection returned is the first
one lent out, so a few hot connections serve the traffic while the
unused ones age at the front and retire on schedule.

**Note**:  We could have implemented **LIFO** using either end of the `VecDeque`, as long as `get() `and `put_back()` use the same end. I chose to keep the hottest connection at the back and the oldest at the front to minimize code changes. This is equivalent in both behavior and performance, since `VecDeque` supports `O(1)` operations at both ends. The important part is that `get()` always picks the most recently returned `(hottest)` connection first.

## Benchmark against `V3` as baseline and observation are captured below:
- **Hot path unchanged** — sustained 45 s ×2: 9,380/9,348 tps (v3) vs 9,418/9,392 tps; p99 ~1.1 ms both. Within noise.
- **No cold-tail penalty** — burst after 90 s idle: 0 reconnects both sides; p99 1.27 ms (v3) vs 1.12 ms.
 - **Cyclic rebuild cost inherited, not introduced** — peak/valley with idle=2s, min=4: +12 conns/cycle on both sides; p99 equal.
- **Default policy stays stable** — peak/valley with idle=0: pool built once (+15), then +0 forever, both sides.
No churn at rest — 180 s idle, min=8: both settle 16→8, 0 opened.
