### PR TITLE
[CLIENT-5202] Connection Liveness Check

### DIFF
--- a/aerospike-core/Cargo.toml
+++ b/aerospike-core/Cargo.toml
@@ -41,6 +41,10 @@ regex = "1"
 tokio-rustls = { version = "0.26.4", optional = true }
 rustls = { version = "0.23.42", optional = true }
 async-channel = "2.5.0"
+# Borrowed, non-owning socket handle for the connection pool liveness probe:
+# one implementation covering tokio, async-std and the TLS inner stream, with no
+# unsafe and no fd ownership. Already in the tree via tokio.
+socket2 = "0.6"
 hazarc = "0.2.0"
 indexmap = "2"
 # `async` so stream reads/writes are await points on the client executor

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -64,6 +64,17 @@ pub enum ConnectionState {
     ReadingStreamBody(usize),
 }
 
+/// Result of a pool-checkout liveness peek.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Liveness {
+    /// Socket open with nothing pending.
+    Alive,
+    /// Socket open, but bytes are waiting that nobody asked for.
+    PendingBytes,
+    /// Peer closed the connection, or the socket is broken.
+    Closed,
+}
+
 /// Underlying socket type for a connection (TCP or TLS).
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
@@ -687,6 +698,72 @@ impl Connection {
     pub fn is_idle(&self) -> bool {
         self.idle_deadline
             .is_some_and(|idle_dl| Instant::now() >= idle_dl)
+    }
+
+    /// What a one-byte peek says about a socket.
+    fn peek_liveness(sock: &socket2::SockRef<'_>) -> Liveness {
+        // MSG_PEEK, so nothing is consumed: a byte seen here is still there for
+        // the command that follows. Both runtimes keep the fd non-blocking, so
+        // this never waits.
+        let mut probe = [std::mem::MaybeUninit::<u8>::uninit(); 1];
+        match sock.peek(&mut probe) {
+            // Nothing to read on an open socket: the healthy idle case.
+            Err(ref e)
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::Interrupted
+                ) =>
+            {
+                Liveness::Alive
+            }
+            // A peer that sent FIN reads as end-of-stream; an RST, EBADF or
+            // anything else is equally unusable.
+            Ok(0) | Err(_) => Liveness::Closed,
+            Ok(_) => Liveness::PendingBytes,
+        }
+    }
+
+    /// Non-blocking one-byte peek for pool checkout, so a socket the peer closed
+    /// while it sat in the pool is discarded instead of handed to a command that
+    /// would fail on its first read with `early eof`.
+    ///
+    /// Deliberately independent of `idle_timeout`: a socket can die long before
+    /// its idle deadline — a server restart kills sockets that were in use a
+    /// millisecond earlier — and with the default `idle_timeout = 0` no
+    /// connection is ever *idle*, so the tend-time reaper
+    /// (`Node::reap_and_refresh_idle_connections`) has nothing to walk. This
+    /// checkout probe is what covers that gap.
+    pub(crate) fn is_alive(&self) -> bool {
+        match self.conn {
+            Netsocket::Tcp(ref s) => {
+                // Unsolicited bytes on a plain connection mean the stream is out
+                // of step with the protocol, which is not recoverable here.
+                !matches!(
+                    Self::peek_liveness(&socket2::SockRef::from(s)),
+                    Liveness::Closed | Liveness::PendingBytes
+                )
+            }
+            #[cfg(feature = "tls")]
+            Netsocket::Tls(ref s) => {
+                // Peek the TCP socket underneath the TLS session.
+                //
+                // Pending bytes are treated as ALIVE here, unlike the plain arm:
+                // post-handshake TLS control records (a TLS 1.3
+                // NewSessionTicket, a KeyUpdate) legitimately arrive while a
+                // connection sits idle in the pool, and they are not application
+                // data. Calling those dead would evict a healthy connection,
+                // reconnect, receive a fresh ticket and evict again — churn
+                // caused by the probe itself. Only a closed or broken socket is
+                // fatal.
+                let (tcp, _session) = s.get_ref();
+                !matches!(
+                    Self::peek_liveness(&socket2::SockRef::from(tcp)),
+                    Liveness::Closed
+                )
+            }
+            #[cfg(test)]
+            _ => true,
+        }
     }
 
     fn refresh(&mut self) {
@@ -1372,6 +1449,134 @@ impl<'a> ConnectionRecovery<'a> {
 }
 
 ///  socket-level liveness probe and the `Error::Connection` classification of socket I/O failures.
+/// The pool-checkout liveness probe, on whichever runtime is compiled.
+///
+/// `tests_eof_loopback` below is tokio-only; these cases are runtime-agnostic on
+/// purpose, because the async-std arm of [`Connection::is_alive`] has no other
+/// coverage.
+#[cfg(test)]
+mod liveness_probe_tests {
+    use super::*;
+    use aerospike_rt::net::{TcpListener, TcpStream};
+
+    /// Half-close the accepted socket, so the client side sees FIN.
+    async fn spawn_finning_peer() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        aerospike_rt::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                #[cfg(feature = "rt-tokio")]
+                {
+                    use aerospike_rt::io::AsyncWriteExt;
+                    let _ = sock.shutdown().await;
+                }
+                #[cfg(feature = "rt-async-std")]
+                {
+                    let _ = sock.shutdown(aerospike_rt::async_std::net::Shutdown::Both);
+                }
+                drop(sock);
+            }
+        });
+        addr
+    }
+
+    /// Accept and hold the socket open, saying nothing.
+    async fn spawn_quiet_peer() -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        aerospike_rt::spawn(async move {
+            if let Ok((sock, _)) = listener.accept().await {
+                aerospike_rt::sleep(Duration::from_secs(30)).await;
+                drop(sock);
+            }
+        });
+        addr
+    }
+
+    /// Build a `Connection` around a real socket, bypassing the handshake.
+    fn conn_over(stream: TcpStream) -> Connection {
+        let mut conn = Connection {
+            addr: "127.0.0.1:0".into(),
+            buffer: Buffer::new(0),
+            bytes_read: 0,
+            conn: Netsocket::Tcp(stream),
+            socket_timeout: 5_000,
+            timeout_delay: 0,
+            deadline: None,
+            idle_timeout: None,
+            idle_deadline: None,
+            state: ConnectionState::Ready,
+            can_recover_connection: false,
+            response_decompressed: false,
+            compressed_stream_body: false,
+            rnd: XorShift::new(),
+            #[cfg(feature = "rt-tokio")]
+            sleep: Box::pin(aerospike_rt::tokio::time::sleep(Duration::from_secs(3600))),
+        };
+        conn.refresh();
+        conn
+    }
+
+    #[aerospike_macro::test]
+    async fn probe_says_alive_for_an_open_idle_socket() {
+        let addr = spawn_quiet_peer().await;
+        let stream = TcpStream::connect(&*addr).await.unwrap();
+        aerospike_rt::sleep(Duration::from_millis(20)).await;
+        assert!(
+            conn_over(stream).is_alive(),
+            "an open socket with nothing pending must probe alive"
+        );
+    }
+
+    #[aerospike_macro::test]
+    async fn probe_says_dead_after_peer_fin() {
+        let addr = spawn_finning_peer().await;
+        let stream = TcpStream::connect(&*addr).await.unwrap();
+        // Let the FIN land in our kernel before probing.
+        aerospike_rt::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !conn_over(stream).is_alive(),
+            "a socket the peer closed must probe dead"
+        );
+    }
+
+    /// The peek must not consume: probing twice gives the same answer, and the
+    /// command that follows still sees the pending bytes.
+    #[aerospike_macro::test]
+    async fn probe_does_not_consume_pending_bytes() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap().to_string();
+        aerospike_rt::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                #[cfg(feature = "rt-tokio")]
+                {
+                    use aerospike_rt::io::AsyncWriteExt;
+                    let _ = sock.write_all(b"XY").await;
+                }
+                #[cfg(feature = "rt-async-std")]
+                {
+                    use futures::AsyncWriteExt;
+                    let _ = sock.write_all(b"XY").await;
+                }
+                aerospike_rt::sleep(Duration::from_secs(30)).await;
+            }
+        });
+
+        let stream = TcpStream::connect(&*addr).await.unwrap();
+        aerospike_rt::sleep(Duration::from_millis(50)).await;
+        let mut conn = conn_over(stream);
+
+        // Unsolicited bytes on a plain connection: not usable, twice over.
+        assert!(!conn.is_alive());
+        assert!(!conn.is_alive(), "the verdict must be stable, not consumed");
+
+        // And the bytes are still on the socket for whoever reads next.
+        let mut buf = [0_u8; 2];
+        conn.read_all(&mut buf).await.expect("bytes still readable");
+        assert_eq!(&buf, b"XY", "MSG_PEEK must leave the data in place");
+    }
+}
+
 #[cfg(all(test, feature = "rt-tokio"))]
 mod tests_eof_loopback {
     use super::*;
@@ -1416,6 +1621,21 @@ mod tests_eof_loopback {
                 use tokio::io::AsyncWriteExt;
                 let _ = sock.shutdown().await;
                 drop(sock);
+            }
+        });
+        addr
+    }
+
+    /// Spawn a peer that pushes bytes at the client without being asked —
+    /// exercises the "stray bytes pending" branch of the probe.
+    async fn spawn_chatty_peer() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        aerospike_rt::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                use tokio::io::AsyncWriteExt;
+                let _ = sock.write_all(b"unsolicited").await;
+                aerospike_rt::sleep(std::time::Duration::from_secs(60)).await;
             }
         });
         addr
@@ -1499,6 +1719,68 @@ mod tests_eof_loopback {
     // Lives here (rather than in connection_pool.rs) because the
     // `conn_from_stream` helper needs access to `Connection`'s private
     // fields, which are only visible from within `connection.rs`.
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_alive_returns_true_for_idle_socket() {
+        let addr = spawn_idle_peer().await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        aerospike_rt::sleep(std::time::Duration::from_millis(20)).await;
+        let conn = conn_from_stream(stream);
+        assert!(conn.is_alive(), "idle live socket must probe alive");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_alive_returns_false_after_peer_fin() {
+        let addr = spawn_fin_peer().await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        // Give the peer's shutdown a moment to arrive at our kernel.
+        aerospike_rt::sleep(std::time::Duration::from_millis(50)).await;
+        let conn = conn_from_stream(stream);
+        assert!(!conn.is_alive(), "FIN'd socket must probe dead");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn is_alive_returns_false_when_stray_bytes_pending() {
+        let addr = spawn_chatty_peer().await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        aerospike_rt::sleep(std::time::Duration::from_millis(50)).await;
+        let conn = conn_from_stream(stream);
+        assert!(
+            !conn.is_alive(),
+            "a socket with unsolicited bytes is out of step with the protocol"
+        );
+    }
+
+    /// The regression this whole probe exists for: a pooled socket the peer
+    /// closed must not be handed to the next command.
+    #[tokio::test(flavor = "current_thread")]
+    async fn queue_get_evicts_peer_finned_socket() {
+        use crate::net::connection_pool::Queue;
+        use crate::net::Host;
+        use crate::policy::ClientPolicy;
+
+        let host = Host::new("127.0.0.1", 0);
+        let policy = ClientPolicy::default();
+        let q = Queue::with_capacity(1, host, policy, None, None);
+
+        let addr = spawn_fin_peer().await;
+        let stream = TcpStream::connect(addr).await.unwrap();
+        aerospike_rt::sleep(std::time::Duration::from_millis(50)).await;
+
+        let conn = conn_from_stream(stream);
+        assert!(q.reserve_capacity());
+        q.put_back(conn);
+
+        // The dead socket is dropped rather than returned, so the queue reports
+        // empty and the caller opens a fresh connection instead of failing on
+        // its first read.
+        let result = q.get();
+        assert!(
+            result.is_err(),
+            "Queue::get() must evict a peer-FIN'd socket, not hand it out"
+        );
+        assert_eq!(q.num_conns(), 0, "the dead socket must be gone from the queue");
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn queue_get_returns_live_socket() {

--- a/aerospike-core/src/net/connection_pool.rs
+++ b/aerospike-core/src/net/connection_pool.rs
@@ -211,6 +211,19 @@ impl Queue {
                     self.reduce_capacity();
                     continue;
                 }
+
+                // A server restart leaves the pool full of sockets the peer has
+                // already closed. Handing one to a command makes it fail on its
+                // first read (`early eof`) and burn a retry, so discard it here
+                // and take the next one.
+                if !conn.is_alive() {
+                    if let Some(metrics) = self.metrics() {
+                        metrics.incr_connections_closed();
+                    }
+                    drop(conn);
+                    self.reduce_capacity();
+                    continue;
+                }
                 connection = conn;
                 break;
             }

--- a/aerospike-rt/Cargo.toml
+++ b/aerospike-rt/Cargo.toml
@@ -17,7 +17,10 @@ rust-version.workspace = true
 
 [dependencies]
 tokio = { version = "1.53.0", features = ["fs", "net", "rt", "rt-multi-thread", "time", "io-util", "sync"], optional = true }
-async-std = {version = "1.13.2", optional = true}
+# "io_safety" gates async-std AsFd/AsSocket impls, which the connection layer
+# needs to borrow a socket for its liveness probe without taking ownership of the
+# fd. The feature adds no code of its own.
+async-std = {version = "1.13.2", features = ["io_safety"], optional = true}
 async-lock = { version = "3.4.2", optional = true}
 
 [features]


### PR DESCRIPTION
PR #227 removed Connection::is_alive() and its guard in Queue::get() on the assumption that Node::reap_and_refresh_idle_connections() would evict stale sockets during tend. It does not under default policy: idle_timeout defaults to 0, so idle_deadline is never set, is_idle() always answers false, and try_extract_idle() hands the reaper an empty list. With no checkout-side check either, sockets a restarted server has already closed stay in the pool until a command draws one and fails on its first read with `early eof`, burning a retry.

The probe is back, in the form v2 arrived at: a non-blocking one-byte MSG_PEEK through socket2's SockRef, which borrows the fd without owning it and needs no unsafe. Unlike the original try_read version it consumes nothing, so a byte it sees is still there for the command that follows. It is deliberately independent of idle_timeout, because a socket can die long before its idle deadline — a server restart kills sockets that were in use a millisecond earlier.

Coverage now extends past plain TCP on tokio. The same peek serves the TcpStream under a rustls session and async-std's socket, both of which previously had no liveness check at all. TLS differs in one rule: pending bytes count as alive there, because post-handshake control records (TLS 1.3 NewSessionTicket, KeyUpdate) legitimately arrive while a connection sits idle in the pool, and evicting on them would reconnect, receive a fresh ticket and evict again — churn caused by the probe itself. Only a closed or broken socket is fatal.

Evicting at checkout counts as a closed connection in the node metrics. aerospike-rt enables async-std's "io_safety" feature for its AsFd impls.