### PR TITLE
[CLIENT-5251] Fix flaky in-doubt UDF timeout test

### DIFF
--- a/tests/src/batch_in_doubt.rs
+++ b/tests/src/batch_in_doubt.rs
@@ -31,13 +31,15 @@ use aerospike::{
     Bins, Client, ErrorKind, Key, ResultCode, Task, UDFLang, Value, WritePolicy,
 };
 
-// A UDF that occupies the server for `secs` before writing. `os.clock()` is CPU
-// time and `os.time()` has one-second granularity, so this spins on wall clock
-// via `os.time()` and needs `secs >= 1` to be reliable.
+// A UDF that occupies the server for at least `secs` before writing. `os.clock()`
+// is CPU time, so this spins on wall clock via `os.time()`, which ticks in whole
+// seconds. Stopping once the clock *reaches* `stop` would end at the next second
+// boundary and wait anywhere from 0 to `secs` seconds, so the spin runs until the
+// clock moves past it.
 const WAIT_UDF: &str = r#"
 function wait_and_update(rec, secs)
   local stop = os.time() + secs
-  while os.time() < stop do end
+  while os.time() <= stop do end
   if aerospike:exists(rec) then
     rec['bin'] = 1
     aerospike:update(rec)


### PR DESCRIPTION
## Summary

`src::batch_in_doubt::single_key_udf_client_timeout_marks_in_doubt` fails roughly a quarter of CI runs, on branches that touch nothing related. Recent examples: run [32638473139](https://github.com/aerospike/aerospike-client-rust/actions/runs/32638473139) on `CLIENT-5202-early-eof-idle-timeout`, run [32885454186](https://github.com/aerospike/aerospike-client-rust/actions/runs/32885454186) on #240, and run [32896652425](https://github.com/aerospike/aerospike-client-rust/actions/runs/32896652425) on #241 — all the same panic at `batch_in_doubt.rs:98` with `the UDF outruns the socket timeout: Some(Int(1))`.

The `Some(Int(1))` is the UDF's own return value, so the command succeeded rather than timing out. The wait UDF is the cause:

```lua
local stop = os.time() + secs
while os.time() < stop do end
```

`os.time()` ticks in whole seconds, so with `secs = 1` the spin ends at the next second boundary and lasts `1 - frac(start)` seconds — uniformly distributed over (0 s, 1 s]. Whenever the UDF starts in the last quarter of a second it finishes inside the 250 ms socket timeout, the command completes normally, and `expect_err` panics.

Spinning until the clock moves *past* `stop` makes the wait a full second or more every time, always clear of the socket timeout.

## Test plan

Measured against a local server, running only `single_key_udf_client_timeout_marks_in_doubt`:

- before: 4 failures in 20 runs (20%, in line with the ~25% the timing math predicts)
- after: 0 failures in 15 runs

All three tests in `batch_in_doubt.rs` pass together in 4.4 s, so the longer per-row wait does not meaningfully add to suite runtime.

Made with [Cursor](https://cursor.com)