### PR TITLE
CLIENT-4990: retry - don't sleep past the command deadline

### DIFF
--- a/aerospike-core/src/commands/single_command.rs
+++ b/aerospike-core/src/commands/single_command.rs
@@ -131,6 +131,12 @@ impl<'a> SingleCommand<'a> {
                 }
 
                 if let Some(sleep_between_retries) = policy.sleep_between_retries() {
+                    if let Some(deadline) = deadline {
+                        if Instant::now() + sleep_between_retries > deadline {
+                            // We will timeout anyway after sleep. break immediately.
+                            break;
+                        }
+                    }
                     sleep(sleep_between_retries).await;
                 }
             }

--- a/tests/src/backoff.rs
+++ b/tests/src/backoff.rs
@@ -218,6 +218,52 @@ async fn pipeline_returns_max_error_rate_when_breaker_open() {
     client.close().await.unwrap();
 }
 
+/// A retry whose sleep would end past the command deadline must not sleep at
+/// all. The command has already lost, so the sleep only delays the answer and
+/// costs the caller the real cause: the deadline path reports a bare timeout,
+/// discarding the error that actually stopped the command.
+#[aerospike_macro::test]
+async fn retry_does_not_sleep_past_the_deadline() {
+    let client = breaker_client(1).await;
+
+    for node in client.cluster.nodes() {
+        for _ in 0..16 {
+            node.incr_error_rate();
+        }
+    }
+
+    // Every attempt fails immediately on the breaker, and the retry sleep is
+    // far longer than the deadline it would overrun.
+    let mut wp = WritePolicy::default();
+    wp.base_policy.max_retries = 5;
+    wp.base_policy.total_timeout = 200;
+    wp.base_policy.socket_timeout = 200;
+    wp.base_policy.sleep_between_retries = 5_000;
+
+    let key = as_key!(common::namespace(), "breaker_test", 2_i64);
+    let bin = as_bin!("a", 1);
+
+    let start = std::time::Instant::now();
+    let err = client
+        .put(&wp, &key, &[bin])
+        .await
+        .expect_err("put should fail with the breaker open");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < std::time::Duration::from_millis(2_000),
+        "returned after {:?}; the retry sleep was not skipped",
+        elapsed
+    );
+    assert!(
+        format!("{err}").contains("Max error rate exceeded"),
+        "expected MaxErrorRate, got: {}",
+        err
+    );
+
+    client.close().await.unwrap();
+}
+
 /// Trip the breaker on every node so each batch attempt fails immediately
 /// without opening a socket, then read the attempt count straight out of the
 /// retry loop's own "Timeout after N tries" message.


### PR DESCRIPTION
Back-ports part of CLIENT-4990 to v2_improvements: when sleep_between_retries would run past the command's total-timeout deadline, the retry loop now fails immediately instead of sleeping into a guaranteed timeout; the command is already guaranteed to fail its deadline, and the sleep only delayed the answer and replaced the real cause with a bare timeout.

Regression test in tests/src/backoff.rs. Benchmarked perf-neutral on a 3-node cluster.

Together with #245, this makes every blocking step inside the retry loop respect the command deadline on its own, which will allow a follow-up PR to remove the redundant outer per-command timeout wrapper in SingleCommand::execute (the remaining piece of CLIENT-4990 - that wrapper arms a timer-wheel entry per command, which contends on the runtime's global time driver under high concurrency).