### PR TITLE
CLIENT 5414 set TCP_NODELAY

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ required-features = ["sync", "rt-tokio"]
 
 # Diagnostic: counts the socket writes rustls emits per request, and traces the
 # handshake syscall order. Evidence for the TCP_NODELAY decision in
-# `Connection::disable_nagle`; see `tools/nagle_probe.py` for the latency half.
+# `Connection::set_nodelay`; see `tools/nagle_probe.py` for the latency half.
 [[example]]
 name = "tls_write_shape"
 required-features = ["rt-tokio", "tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,13 @@ webpki-roots = "1"
 name = "crud_sync"
 required-features = ["sync", "rt-tokio"]
 
+# Diagnostic: counts the socket writes rustls emits per request, and traces the
+# handshake syscall order. Evidence for the TCP_NODELAY decision in
+# `Connection::disable_nagle`; see `tools/nagle_probe.py` for the latency half.
+[[example]]
+name = "tls_write_shape"
+required-features = ["rt-tokio", "tls"]
+
 [[example]]
 name = "query_aggregate"
 required-features = ["lua"]

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -206,7 +206,7 @@ impl Connection {
         Ok(Netsocket::Tcp(stream))
     }
 
-    /// Turns off Nagle for a freshly opened socket.
+    /// Sets `TCP_NODELAY` on a freshly opened socket (disables Nagle).
     ///
     /// Nagle withholds a small segment while earlier small data is still
     /// unacked, which deadlocks against the peer's delayed ACK: the server
@@ -214,13 +214,13 @@ impl Connection {
     /// the request arrives in full. Linux breaks the tie only when its
     /// delayed-ACK timer expires — `TCP_DELACK_MIN`, 40ms.
     ///
-    /// Every other Aerospike client disables it: Java `setTcpNoDelay(true)`,
+    /// Every other Aerospike client sets it: Java `setTcpNoDelay(true)`,
     /// C `setsockopt(TCP_NODELAY)` in `as_socket_create_fd`, C# `NoDelay`, Go
-    /// via its stdlib. The C client re-enables Nagle *only* for fire-and-forget
-    /// pipeline sockets (`as_pipe.c`), so off is the protocol's intended
+    /// via its stdlib. The C client clears it *only* for fire-and-forget
+    /// pipeline sockets (`as_pipe.c`), so on is the protocol's intended
     /// setting for request/response traffic rather than a tuning knob.
     ///
-    /// Measured cost of leaving it on, on Linux with a 1448-byte MSS:
+    /// Measured cost of leaving it unset, on Linux with a 1448-byte MSS:
     ///
     /// | path | Nagle on | `TCP_NODELAY` |
     /// |------|----------|---------------|
@@ -243,7 +243,7 @@ impl Connection {
     ///
     /// Best-effort. A platform that refuses the option still yields a usable
     /// connection, so the error is dropped rather than failing the connect.
-    fn disable_nagle(stream: &TcpStream) {
+    fn set_nodelay(stream: &TcpStream) {
         let _ = stream.set_nodelay(true);
     }
 
@@ -280,7 +280,7 @@ impl Connection {
 
         let stream = stream.unwrap()?;
 
-        Self::disable_nagle(&stream);
+        Self::set_nodelay(&stream);
 
         let stream = Self::get_netsocket(stream, host, policy).await?;
 
@@ -1663,27 +1663,27 @@ mod liveness_probe_tests {
         addr
     }
 
-    /// Nagle must be off on every socket the client opens, matching every other
-    /// Aerospike client. Asserted through the real getsockopt rather than by
-    /// trusting the setter, so a platform that silently ignores the option
-    /// fails here instead of in production.
+    /// `TCP_NODELAY` must be set on every socket the client opens, matching
+    /// every other Aerospike client. Asserted through the real getsockopt
+    /// rather than by trusting the setter, so a platform that silently ignores
+    /// the option fails here instead of in production.
     ///
-    /// This covers [`Connection::disable_nagle`], not its call site: under
+    /// This covers [`Connection::set_nodelay`], not its call site: under
     /// `cfg(test)` `Connection::new` returns a `Netsocket::TestDummy` and never
     /// opens a socket, so the real connect path is unreachable from a unit
     /// test.
     #[aerospike_macro::test]
-    async fn sockets_are_opened_with_nagle_disabled() {
+    async fn sockets_are_opened_with_tcp_nodelay() {
         let addr = spawn_quiet_peer().await;
         let stream = TcpStream::connect(&*addr).await.unwrap();
 
         assert!(
             !socket2::SockRef::from(&stream).tcp_nodelay().unwrap(),
-            "a fresh socket is expected to start with Nagle on; if the platform \
-             default changed, this test no longer proves anything"
+            "a fresh socket is expected to start with TCP_NODELAY unset; if the \
+             platform default changed, this test no longer proves anything"
         );
 
-        Connection::disable_nagle(&stream);
+        Connection::set_nodelay(&stream);
 
         assert!(
             socket2::SockRef::from(&stream).tcp_nodelay().unwrap(),

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -206,6 +206,47 @@ impl Connection {
         Ok(Netsocket::Tcp(stream))
     }
 
+    /// Turns off Nagle for a freshly opened socket.
+    ///
+    /// Nagle withholds a small segment while earlier small data is still
+    /// unacked, which deadlocks against the peer's delayed ACK: the server
+    /// holds its ACK waiting to piggyback a response it cannot produce until
+    /// the request arrives in full. Linux breaks the tie only when its
+    /// delayed-ACK timer expires — `TCP_DELACK_MIN`, 40ms.
+    ///
+    /// Every other Aerospike client disables it: Java `setTcpNoDelay(true)`,
+    /// C `setsockopt(TCP_NODELAY)` in `as_socket_create_fd`, C# `NoDelay`, Go
+    /// via its stdlib. The C client re-enables Nagle *only* for fire-and-forget
+    /// pipeline sockets (`as_pipe.c`), so off is the protocol's intended
+    /// setting for request/response traffic rather than a tuning knob.
+    ///
+    /// Measured cost of leaving it on, on Linux with a 1448-byte MSS:
+    ///
+    /// | path | Nagle on | `TCP_NODELAY` |
+    /// |------|----------|---------------|
+    /// | TLS connection setup | **41.4ms p50, 130/130 stalled** | 0.25ms |
+    /// | plain request, 64B–33KB | 0.05ms, 0 stalled | 0.05ms |
+    ///
+    /// TLS setup stalls because rustls writes `change_cipher_spec` (6 bytes)
+    /// and `Finished` (74 bytes) as two consecutive socket writes with no read
+    /// between them — traced as `W1460 R1803 W6 W74` by
+    /// `examples/tls_write_shape.rs`. The 6-byte segment goes out, then Nagle
+    /// pins the 74-byte one behind it, and the peer has nothing to answer yet,
+    /// so both sides wait out the delayed-ACK timer. Every new TLS connection
+    /// pays it: client init, pool growth, and reconnect storms after a
+    /// failover, which is the worst moment to add 41ms per socket.
+    ///
+    /// Plain-TCP commands are already safe and stay that way — a request goes
+    /// out as one contiguous `write_all` (see [`flush`](Self::flush)), and
+    /// Linux's Minshall variant of Nagle lets a trailing partial segment
+    /// follow full-size ones. Replay both halves with `tools/nagle_probe.py`.
+    ///
+    /// Best-effort. A platform that refuses the option still yields a usable
+    /// connection, so the error is dropped rather than failing the connect.
+    fn disable_nagle(stream: &TcpStream) {
+        let _ = stream.set_nodelay(true);
+    }
+
     #[cfg(not(test))]
     pub async fn new(
         host: &Host,
@@ -238,6 +279,9 @@ impl Connection {
         }
 
         let stream = stream.unwrap()?;
+
+        Self::disable_nagle(&stream);
+
         let stream = Self::get_netsocket(stream, host, policy).await?;
 
         let idle_timeout = if policy.idle_timeout > 0 {
@@ -1617,6 +1661,35 @@ mod liveness_probe_tests {
             }
         });
         addr
+    }
+
+    /// Nagle must be off on every socket the client opens, matching every other
+    /// Aerospike client. Asserted through the real getsockopt rather than by
+    /// trusting the setter, so a platform that silently ignores the option
+    /// fails here instead of in production.
+    ///
+    /// This covers [`Connection::disable_nagle`], not its call site: under
+    /// `cfg(test)` `Connection::new` returns a `Netsocket::TestDummy` and never
+    /// opens a socket, so the real connect path is unreachable from a unit
+    /// test.
+    #[aerospike_macro::test]
+    async fn sockets_are_opened_with_nagle_disabled() {
+        let addr = spawn_quiet_peer().await;
+        let stream = TcpStream::connect(&*addr).await.unwrap();
+
+        assert!(
+            !socket2::SockRef::from(&stream).tcp_nodelay().unwrap(),
+            "a fresh socket is expected to start with Nagle on; if the platform \
+             default changed, this test no longer proves anything"
+        );
+
+        Connection::disable_nagle(&stream);
+
+        assert!(
+            socket2::SockRef::from(&stream).tcp_nodelay().unwrap(),
+            "TCP_NODELAY must be set: Nagle deadlocks against the peer's \
+             delayed ACK for 40ms on any request written as more than one write"
+        );
     }
 
     /// Build a `Connection` around a real socket, bypassing the handshake.

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -210,10 +210,7 @@ impl Connection {
     ///
     /// Nagle withholds a small segment while earlier data is still unacked,
     /// which stalls against the peer's delayed ACK until Linux's
-    /// `TCP_DELACK_MIN` (40ms) expires. Every other Aerospike client sets this
-    /// option: Java `setTcpNoDelay(true)`, C `setsockopt(TCP_NODELAY)` in
-    /// `as_socket_create_fd`, C# `NoDelay`, Go via its stdlib. The C client
-    /// clears it *only* for fire-and-forget pipeline sockets (`as_pipe.c`).
+    /// `TCP_DELACK_MIN` (40ms) expires.
     ///
     /// Best-effort. A platform that refuses the option still yields a usable
     /// connection, so the error is dropped rather than failing the connect.
@@ -1637,10 +1634,10 @@ mod liveness_probe_tests {
         addr
     }
 
-    /// `TCP_NODELAY` must be set on every socket the client opens, matching
-    /// every other Aerospike client. Asserted through the real getsockopt
-    /// rather than by trusting the setter, so a platform that silently ignores
-    /// the option fails here instead of in production.
+    /// `TCP_NODELAY` must be set on every socket the client opens. Asserted
+    /// through the real getsockopt rather than by trusting the setter, so a
+    /// platform that silently ignores the option fails here instead of in
+    /// production.
     ///
     /// This covers [`Connection::set_nodelay`], not its call site: under
     /// `cfg(test)` `Connection::new` returns a `Netsocket::TestDummy` and never

--- a/aerospike-core/src/net/connection.rs
+++ b/aerospike-core/src/net/connection.rs
@@ -208,38 +208,12 @@ impl Connection {
 
     /// Sets `TCP_NODELAY` on a freshly opened socket (disables Nagle).
     ///
-    /// Nagle withholds a small segment while earlier small data is still
-    /// unacked, which deadlocks against the peer's delayed ACK: the server
-    /// holds its ACK waiting to piggyback a response it cannot produce until
-    /// the request arrives in full. Linux breaks the tie only when its
-    /// delayed-ACK timer expires — `TCP_DELACK_MIN`, 40ms.
-    ///
-    /// Every other Aerospike client sets it: Java `setTcpNoDelay(true)`,
-    /// C `setsockopt(TCP_NODELAY)` in `as_socket_create_fd`, C# `NoDelay`, Go
-    /// via its stdlib. The C client clears it *only* for fire-and-forget
-    /// pipeline sockets (`as_pipe.c`), so on is the protocol's intended
-    /// setting for request/response traffic rather than a tuning knob.
-    ///
-    /// Measured cost of leaving it unset, on Linux with a 1448-byte MSS:
-    ///
-    /// | path | Nagle on | `TCP_NODELAY` |
-    /// |------|----------|---------------|
-    /// | TLS connection setup | **41.4ms p50, 130/130 stalled** | 0.25ms |
-    /// | plain request, 64B–33KB | 0.05ms, 0 stalled | 0.05ms |
-    ///
-    /// TLS setup stalls because rustls writes `change_cipher_spec` (6 bytes)
-    /// and `Finished` (74 bytes) as two consecutive socket writes with no read
-    /// between them — traced as `W1460 R1803 W6 W74` by
-    /// `examples/tls_write_shape.rs`. The 6-byte segment goes out, then Nagle
-    /// pins the 74-byte one behind it, and the peer has nothing to answer yet,
-    /// so both sides wait out the delayed-ACK timer. Every new TLS connection
-    /// pays it: client init, pool growth, and reconnect storms after a
-    /// failover, which is the worst moment to add 41ms per socket.
-    ///
-    /// Plain-TCP commands are already safe and stay that way — a request goes
-    /// out as one contiguous `write_all` (see [`flush`](Self::flush)), and
-    /// Linux's Minshall variant of Nagle lets a trailing partial segment
-    /// follow full-size ones. Replay both halves with `tools/nagle_probe.py`.
+    /// Nagle withholds a small segment while earlier data is still unacked,
+    /// which stalls against the peer's delayed ACK until Linux's
+    /// `TCP_DELACK_MIN` (40ms) expires. Every other Aerospike client sets this
+    /// option: Java `setTcpNoDelay(true)`, C `setsockopt(TCP_NODELAY)` in
+    /// `as_socket_create_fd`, C# `NoDelay`, Go via its stdlib. The C client
+    /// clears it *only* for fire-and-forget pipeline sockets (`as_pipe.c`).
     ///
     /// Best-effort. A platform that refuses the option still yields a usable
     /// connection, so the error is dropped rather than failing the connect.

--- a/examples/tls_write_shape.rs
+++ b/examples/tls_write_shape.rs
@@ -1,0 +1,181 @@
+//! Counts socket-level writes per request on the TLS path.
+//!
+//! `Connection::flush` does `write_all(buf).await?; flush().await` on a
+//! `tokio_rustls` stream. Nagle acts on kernel segments, so what matters is
+//! how many separate `write` syscalls rustls issues underneath that one
+//! logical request. One write is safe (measured: no stall). Two or more is
+//! the split-write shape that stalls for TCP_DELACK_MIN = 40ms.
+//!
+//! This wraps the TcpStream in a counting adapter and reports the write
+//! sizes rustls actually emits, for payloads either side of the 16 KiB TLS
+//! record limit.
+//!
+//! Run:  cargo run --example tls_write_shape --features rt-tokio,tls
+
+use std::io;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName};
+use rustls::{RootCertStore, ServerConfig};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadBuf};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+const TEST_CERT_PEM: &[u8] = b"\
+-----BEGIN CERTIFICATE-----
+MIIBkjCCATigAwIBAgIUBd8CSag9UwVN+CmSCt1fHb95AXowCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDgyMTAxMDcyOFoYDzIxMjYwNzI4
+MDEwNzI4WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAARaDG4MJdt4ujwjndx1baO6lEZF2JIggiXBCqFUdjj6IPPzkDZtMO1f
+U3lfoCm6z5EGqRhWg8An6dxdhFCdc2AZo2YwZDAdBgNVHQ4EFgQUkmu2kSnGV8kL
+9Fd/i3OqX64gxlowHwYDVR0jBBgwFoAUkmu2kSnGV8kL9Fd/i3OqX64gxlowFAYD
+VR0RBA0wC4IJbG9jYWxob3N0MAwGA1UdEwEB/wQCMAAwCgYIKoZIzj0EAwIDSAAw
+RQIgD7tXhh5Ldb6hp8VcfcmI8MZQf5TrJSJO2SEXAVOzcmECIQCfDq3M7/QhO7f/
++5kpUI6o5q5Lp53WCGOvmKjvMmEfKg==
+-----END CERTIFICATE-----
+";
+
+const TEST_KEY_PEM: &[u8] = b"\
+-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgZcTGiz3ft6sc5Q+L
+rHUGuKRhKz67vcrzXrqQFgLuGO+hRANCAARaDG4MJdt4ujwjndx1baO6lEZF2JIg
+giXBCqFUdjj6IPPzkDZtMO1fU3lfoCm6z5EGqRhWg8An6dxdhFCdc2AZ
+-----END PRIVATE KEY-----
+";
+
+fn self_signed() -> (ServerConfig, RootCertStore) {
+    let cert = CertificateDer::from_pem_slice(TEST_CERT_PEM).expect("test certificate");
+    let key = PrivateKeyDer::from_pem_slice(TEST_KEY_PEM).expect("test key");
+    let server = ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert.clone()], key)
+        .unwrap();
+    let mut roots = RootCertStore::empty();
+    roots.add(cert).unwrap();
+    (server, roots)
+}
+
+/// Records the length of every `poll_write` that reaches the socket, plus an
+/// interleaved trace of reads. Whether two small writes are *consecutive*
+/// (no read between them) is what decides if Nagle can deadlock: a read
+/// implies the peer's reply, which carries the ACK that releases the sender.
+struct Counting {
+    inner: TcpStream,
+    writes: Arc<Mutex<Vec<usize>>>,
+    trace: Arc<Mutex<Vec<String>>>,
+}
+
+impl tokio::io::AsyncWrite for Counting {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let res = Pin::new(&mut self.inner).poll_write(cx, buf);
+        if let Poll::Ready(Ok(n)) = res {
+            self.writes.lock().unwrap().push(n);
+            self.trace.lock().unwrap().push(format!("W{n}"));
+        }
+        res
+    }
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+impl tokio::io::AsyncRead for Counting {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let before = buf.filled().len();
+        let res = Pin::new(&mut self.inner).poll_read(cx, buf);
+        if let Poll::Ready(Ok(())) = res {
+            let n = buf.filled().len() - before;
+            if n > 0 {
+                self.trace.lock().unwrap().push(format!("R{n}"));
+            }
+        }
+        res
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let (server_config, roots) = self_signed();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+    let sizes: Vec<usize> = vec![512, 4096, 8192, 16_000, 16_384, 16_500, 32_768, 65_536, 262_144];
+    let server_sizes = sizes.clone();
+
+    tokio::spawn(async move {
+        let (sock, _) = listener.accept().await.unwrap();
+        let mut tls = acceptor.accept(sock).await.unwrap();
+        for size in server_sizes {
+            let mut buf = vec![0u8; size];
+            // Read the request in full before replying: the server cannot
+            // piggyback an ACK on a response it cannot yet produce.
+            tls.read_exact(&mut buf).await.unwrap();
+            tls.write_all(&[0u8; 8]).await.unwrap();
+            tls.flush().await.unwrap();
+        }
+    });
+
+    let writes = Arc::new(Mutex::new(Vec::new()));
+    let trace = Arc::new(Mutex::new(Vec::new()));
+    let sock = TcpStream::connect(addr).await.unwrap();
+    sock.set_nodelay(true).unwrap();
+    let counting = Counting {
+        inner: sock,
+        writes: writes.clone(),
+        trace: trace.clone(),
+    };
+
+    let config = rustls::ClientConfig::builder()
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+    let mut tls = TlsConnector::from(Arc::new(config))
+        .connect(ServerName::try_from("localhost").unwrap(), counting)
+        .await
+        .unwrap();
+
+    let handshake = writes.lock().unwrap().clone();
+    println!(
+        "TLS handshake: {} socket writes {:?}",
+        handshake.len(),
+        handshake
+    );
+    println!(
+        "handshake syscall trace (W=write, R=read): {}",
+        trace.lock().unwrap().join(" ")
+    );
+    println!("\nOne `write_all(buf) + flush()` per row -- the Connection::flush shape.\n");
+    println!(
+        "{:>9} | {:>7} | {}",
+        "payload", "writes", "socket write sizes"
+    );
+    println!("{}", "-".repeat(76));
+
+    let mut reply = [0u8; 8];
+    for size in sizes {
+        writes.lock().unwrap().clear();
+        let buf = vec![0xABu8; size];
+
+        tls.write_all(&buf).await.unwrap();
+        tls.flush().await.unwrap();
+        tls.read_exact(&mut reply).await.unwrap();
+
+        let w = writes.lock().unwrap().clone();
+        let verdict = if w.len() > 1 { "  <== SPLIT" } else { "" };
+        println!("{:>9} | {:>7} | {:?}{}", size, w.len(), w, verdict);
+    }
+}

--- a/examples/tls_write_shape.rs
+++ b/examples/tls_write_shape.rs
@@ -1,14 +1,22 @@
 //! Counts socket-level writes per request on the TLS path.
 //!
-//! `Connection::flush` does `write_all(buf).await?; flush().await` on a
-//! `tokio_rustls` stream. Nagle acts on kernel segments, so what matters is
-//! how many separate `write` syscalls rustls issues underneath that one
-//! logical request. One write is safe (measured: no stall). Two or more is
-//! the split-write shape that stalls for TCP_DELACK_MIN = 40ms.
+//! Evidence for `Connection::set_nodelay`. Nagle acts on kernel segments, so
+//! what matters is how many separate `write` syscalls rustls issues under one
+//! logical request. One write is safe; two or more consecutive writes with no
+//! read between them is the Nagle + delayed-ACK stall (`TCP_DELACK_MIN` =
+//! 40ms on Linux).
 //!
-//! This wraps the TcpStream in a counting adapter and reports the write
-//! sizes rustls actually emits, for payloads either side of the 16 KiB TLS
-//! record limit.
+//! The handshake is the smoking gun: rustls emits
+//! `change_cipher_spec` (6 bytes) and `Finished` (74 bytes) as consecutive
+//! socket writes — traced here as `W1460 R1803 W6 W74`. With Nagle on, the
+//! 6-byte segment goes out, the 74-byte one is pinned behind it, and the peer
+//! has nothing to answer yet, so both sides wait out the delayed-ACK timer.
+//! Every new TLS connection pays it (client init, pool growth, reconnect
+//! storms). Replay the latency half with `tools/nagle_probe.py`.
+//!
+//! This wraps the TcpStream in a counting adapter and reports the write sizes
+//! rustls actually emits, for payloads either side of the 16 KiB TLS record
+//! limit.
 //!
 //! Run:  cargo run --example tls_write_shape --features rt-tokio,tls
 

--- a/tools/nagle_probe.py
+++ b/tools/nagle_probe.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Probe for the Nagle + delayed-ACK stall in a request/response protocol.
+
+Reproduces the exact write shape the Aerospike Rust client uses: one
+sendall() of the whole request, then a blocking read of the response.
+Sweeps request sizes across the MSS boundary and reports the latency tail
+with TCP_NODELAY off (Nagle on, the client's current behaviour) and on.
+
+Usage:
+    nagle_probe.py [--host H] [--port P] [--serve] [--iters N]
+
+With no --host it runs its own echo server in a thread on 127.0.0.1.
+With --serve it only runs the server (for cross-container runs).
+"""
+
+import argparse
+import socket
+import statistics
+import struct
+import sys
+import threading
+import time
+
+RESP = b"\x00" * 8
+
+
+def recvall(sock, n):
+    buf = bytearray()
+    while len(buf) < n:
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("peer closed")
+        buf += chunk
+    return buf
+
+
+def handshake_server(sock, stop):
+    """Replays the peer side of a rustls TLS handshake at the socket level.
+
+    The syscall shape was measured from the real client stack with
+    `examples/tls_write_shape.rs`, which traced: W1460 R1803 W6 W74.
+    TLS crypto is irrelevant to Nagle -- only the write/read syscall
+    sequence determines TCP behaviour -- so replaying that sequence over a
+    plain socket reproduces the kernel-level conditions exactly.
+    """
+    sock.settimeout(0.5)
+    while not stop.is_set():
+        try:
+            conn, _ = sock.accept()
+        except socket.timeout:
+            continue
+        except OSError:
+            return
+        threading.Thread(target=serve_handshake, args=(conn,), daemon=True).start()
+
+
+def serve_handshake(conn):
+    conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    try:
+        recvall(conn, 1460)          # ClientHello
+        conn.sendall(b"\x00" * 1803)  # server flight
+        recvall(conn, 6 + 74)         # change_cipher_spec + Finished
+        conn.sendall(b"\x00")         # session ticket / first reply
+    except (ConnectionError, OSError):
+        pass
+    finally:
+        conn.close()
+
+
+def measure_handshake(host, port, iters, nodelay):
+    """Time a full connection setup, fresh socket each time."""
+    lat = []
+    for _ in range(iters):
+        s = socket.create_connection((host, port))
+        s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1 if nodelay else 0)
+        try:
+            t0 = time.perf_counter()
+            s.sendall(b"\x00" * 1460)
+            recvall(s, 1803)
+            # The two consecutive small writes. Nagle holds the second
+            # because the first is small and still unacked; the peer holds
+            # its ACK because it has no response to piggyback on yet.
+            s.sendall(b"\x00" * 6)
+            s.sendall(b"\x00" * 74)
+            recvall(s, 1)
+            lat.append((time.perf_counter() - t0) * 1000.0)
+        finally:
+            s.close()
+    return lat
+
+
+def server(sock, stop):
+    """Read a length-prefixed request in full, then reply. The 'read the
+    whole request before replying' part is what creates the deadlock: the
+    server cannot piggyback an ACK on a response it cannot yet produce."""
+    sock.settimeout(0.5)
+    while not stop.is_set():
+        try:
+            conn, _ = sock.accept()
+        except socket.timeout:
+            continue
+        except OSError:
+            return
+        threading.Thread(target=serve_conn, args=(conn, stop), daemon=True).start()
+
+
+def serve_conn(conn, stop):
+    # Server side gets NODELAY so its own 8-byte replies are never the
+    # thing being delayed. We are measuring the request direction.
+    conn.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    try:
+        while not stop.is_set():
+            hdr = recvall(conn, 4)
+            (n,) = struct.unpack("!I", hdr)
+            if n == 0:
+                return
+            recvall(conn, n - 4)
+            conn.sendall(RESP)
+    except (ConnectionError, OSError):
+        return
+    finally:
+        conn.close()
+
+
+def measure(host, port, size, iters, nodelay, split=False):
+    """One request/response round trip, timed.
+
+    split=False mirrors the Rust client: a single write_all() of the whole
+    request. split=True is the positive control -- header and body as two
+    separate writes, the classic Nagle/delayed-ACK deadlock shape. If the
+    control shows no stall either, the probe itself is not sensitive and
+    the negative result means nothing.
+    """
+    s = socket.create_connection((host, port))
+    s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1 if nodelay else 0)
+    try:
+        mss = s.getsockopt(socket.IPPROTO_TCP, socket.TCP_MAXSEG)
+    except OSError:
+        mss = -1
+
+    req = struct.pack("!I", size) + b"\xab" * (size - 4)
+
+    def send_one():
+        if split:
+            # Small write first, then the rest. Nagle holds the second
+            # write because a small segment is already unacked.
+            s.sendall(req[:4])
+            s.sendall(req[4:])
+        else:
+            s.sendall(req)
+
+    # Warm up: get past slow-start and any quickack window at connect.
+    for _ in range(20):
+        send_one()
+        recvall(s, len(RESP))
+
+    lat = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        send_one()
+        recvall(s, len(RESP))
+        lat.append((time.perf_counter() - t0) * 1000.0)
+
+    s.sendall(struct.pack("!I", 0))
+    s.close()
+    return lat, mss
+
+
+def summarize(lat):
+    lat_sorted = sorted(lat)
+    n = len(lat_sorted)
+    return {
+        "p50": lat_sorted[n // 2],
+        "p99": lat_sorted[min(n - 1, int(n * 0.99))],
+        "max": lat_sorted[-1],
+        "mean": statistics.fmean(lat_sorted),
+        # Anything at/above 30ms is the delayed-ACK timer, not real work.
+        "stalls": sum(1 for x in lat_sorted if x >= 30.0),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host")
+    ap.add_argument("--port", type=int, default=48123)
+    ap.add_argument("--serve", action="store_true")
+    ap.add_argument("--iters", type=int, default=300)
+    args = ap.parse_args()
+
+    stop = threading.Event()
+    host = args.host or "127.0.0.1"
+
+    if args.serve or not args.host:
+        srv = socket.socket()
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("0.0.0.0", args.port))
+        srv.listen(16)
+        threading.Thread(target=server, args=(srv, stop), daemon=True).start()
+
+        hsrv = socket.socket()
+        hsrv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        hsrv.bind(("0.0.0.0", args.port + 1))
+        hsrv.listen(16)
+        threading.Thread(target=handshake_server, args=(hsrv, stop), daemon=True).start()
+
+        if args.serve:
+            print(f"serving on 0.0.0.0:{args.port}", flush=True)
+            try:
+                while True:
+                    time.sleep(1)
+            except KeyboardInterrupt:
+                stop.set()
+            return
+
+    # Sizes chosen to straddle both the 1500-byte-Ethernet MSS (~1448) and
+    # the macOS loopback MSS (~16324). The stall is expected just above one
+    # MSS, where the receiver holds a lone segment's ACK.
+    sizes = [
+        64, 512, 1400, 1448, 1460, 1500, 2000, 2896, 2900, 4096, 8192,
+        14000, 16000, 16324, 16384, 16500, 17000, 20000, 32648, 33000,
+    ]
+
+    print(f"host={host}:{args.port}  iters={args.iters}  python={sys.platform}")
+
+    for split in (False, True):
+        shape = ("SPLIT WRITE (header+body, positive control)" if split
+                 else "SINGLE write_all (what the Rust client does)")
+        print(f"\n### {shape}")
+        print(f"{'size':>7} {'MSS':>6} | {'Nagle ON (current)':>34} | {'NODELAY (fix)':>34}")
+        print(f"{'':>7} {'':>6} | {'p50':>7} {'p99':>7} {'max':>8} {'stalls':>7} |"
+              f" {'p50':>7} {'p99':>7} {'max':>8} {'stalls':>7}")
+        print("-" * 96)
+
+        for size in sizes:
+            try:
+                off, mss = measure(host, args.port, size, args.iters,
+                                   nodelay=False, split=split)
+                on, _ = measure(host, args.port, size, args.iters,
+                                nodelay=True, split=split)
+            except (ConnectionError, OSError) as e:
+                print(f"{size:>7} {'-':>6} | error: {e}")
+                continue
+            a, b = summarize(off), summarize(on)
+            flag = "  <== STALL" if a["stalls"] > 0 and b["stalls"] == 0 else ""
+            print(
+                f"{size:>7} {mss:>6} |"
+                f" {a['p50']:>7.2f} {a['p99']:>7.2f} {a['max']:>8.2f} {a['stalls']:>7} |"
+                f" {b['p50']:>7.2f} {b['p99']:>7.2f} {b['max']:>8.2f} {b['stalls']:>7}"
+                f"{flag}"
+            )
+
+    # TLS connection setup. Write shape traced from the real rustls stack.
+    print("\n### TLS HANDSHAKE replay (W1460 R1803 W6 W74) -- per new connection")
+    print(f"{'':>7} {'':>6} | {'p50':>7} {'p99':>7} {'max':>8} {'stalls':>7} |"
+          f" {'p50':>7} {'p99':>7} {'max':>8} {'stalls':>7}")
+    print("-" * 96)
+    hs_iters = max(30, args.iters // 5)
+    try:
+        off = measure_handshake(host, args.port + 1, hs_iters, nodelay=False)
+        on = measure_handshake(host, args.port + 1, hs_iters, nodelay=True)
+        a, b = summarize(off), summarize(on)
+        flag = "  <== STALL" if a["stalls"] > 0 and b["stalls"] == 0 else ""
+        print(
+            f"{'setup':>7} {'':>6} |"
+            f" {a['p50']:>7.2f} {a['p99']:>7.2f} {a['max']:>8.2f} {a['stalls']:>7} |"
+            f" {b['p50']:>7.2f} {b['p99']:>7.2f} {b['max']:>8.2f} {b['stalls']:>7}"
+            f"{flag}"
+        )
+        print(f"\n  n={hs_iters} connections per arm; "
+              f"mean {a['mean']:.2f}ms -> {b['mean']:.2f}ms "
+              f"({a['mean'] / max(b['mean'], 1e-9):.0f}x)")
+    except (ConnectionError, OSError) as e:
+        print(f"  handshake probe error: {e}")
+
+    stop.set()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
SET TCP_NODELAY similar to other clients. Can improve latency for potentially small sized packets like TLS handshake.
An LLM generated TLS measurement shows improvement; but I haven't run the full benchmark suite.