### PR TITLE
[CLIENT-5402]: use enterprise db in github actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -7,6 +7,10 @@ on:
       - v3
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write  # required by setup-aerospike-server's JFrog OIDC login
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -44,7 +48,12 @@ jobs:
           shared-key: ${{ matrix.runtime }}
 
       - name: Set up Aerospike Database
-        uses: reugn/github-action-aerospike@2065a9209cfd5ef88a3e07f3e7929e321d1e0067 # v1.1.0
+        uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@0d843cff870d70ac527048ab0d006c7c301fbb2f # v4.1.0
+        with:
+          enable-strong-consistency: "true"
+          features-content: ${{ secrets.AEROSPIKE_SERVER_FEATURES_CONF }}
+          oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
 
       - name: Build workspace
         run: |
@@ -99,7 +108,12 @@ jobs:
           shared-key: aerospike-core-coverage
 
       - name: Set up Aerospike Database
-        uses: reugn/github-action-aerospike@2065a9209cfd5ef88a3e07f3e7929e321d1e0067 # v1.1.0
+        uses: aerospike/shared-workflows/.github/actions/setup-aerospike-server@0d843cff870d70ac527048ab0d006c7c301fbb2f # v4.1.0
+        with:
+          enable-strong-consistency: "true"
+          features-content: ${{ secrets.AEROSPIKE_SERVER_FEATURES_CONF }}
+          oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
+          oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2.87.2

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -52,8 +52,8 @@ jobs:
         with:
           enable-strong-consistency: "true"
           features-content: ${{ secrets.AEROSPIKE_SERVER_FEATURES_CONF }}
-          oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
-          oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          oidc-provider: ${{ vars.OIDC_PROVIDER_NAME }}
+          oidc-audience: ${{ vars.OIDC_AUDIENCE }}
 
       - name: Build workspace
         run: |
@@ -112,8 +112,8 @@ jobs:
         with:
           enable-strong-consistency: "true"
           features-content: ${{ secrets.AEROSPIKE_SERVER_FEATURES_CONF }}
-          oidc-provider: ${{ vars.JFROG_OIDC_PROVIDER }}
-          oidc-audience: ${{ vars.JFROG_OIDC_AUDIENCE }}
+          oidc-provider: ${{ vars.OIDC_PROVIDER_NAME }}
+          oidc-audience: ${{ vars.OIDC_AUDIENCE }}
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@1ed6d7be6168f6c9046541087ff549b6bc581fdf # v2.87.2

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -415,12 +415,16 @@ macro_rules! namespace_sc {
 #[derive(Clone, Copy, Debug)]
 pub struct ServerCapabilities {
     pub explicit_record_ttl_allowed: bool,
+    /// Whether the SC namespace allows non-durable ("expunge") deletes on existing
+    /// records. Only meaningful when the namespace is SC; `false` on AP namespaces.
+    pub sc_allow_expunge: bool,
 }
 
 impl ServerCapabilities {
     pub async fn detect(client: &aerospike::Client) -> Self {
         Self {
             explicit_record_ttl_allowed: explicit_record_ttl_probe(client).await,
+            sc_allow_expunge: sc_allow_expunge_probe(client).await,
         }
     }
 }
@@ -486,6 +490,24 @@ async fn explicit_record_ttl_probe(client: &aerospike::Client) -> bool {
             false
         }
         Err(e) => panic!("explicit TTL probe put: {}", e),
+    }
+}
+
+/// Reads `strong-consistency-allow-expunge` straight off the server's own
+/// `info namespace/{ns}` output -- it's a config value, not something worth a
+/// synthetic behavioral probe like `explicit_record_ttl_probe`.
+async fn sc_allow_expunge_probe(client: &aerospike::Client) -> bool {
+    let node = match client.cluster.get_random_node() {
+        Ok(n) => n,
+        Err(_) => return false,
+    };
+    let info_key = format!("namespace/{}", namespace());
+    match node.info(&AdminPolicy::default(), &[&info_key]).await {
+        Ok(map) => map
+            .get(&info_key)
+            .map(|info| info.contains("strong-consistency-allow-expunge=true"))
+            .unwrap_or(false),
+        Err(_) => false,
     }
 }
 

--- a/tests/src/batch.rs
+++ b/tests/src/batch.rs
@@ -576,12 +576,21 @@ async fn batch_single_key_fast_path_delete() {
 // outcomes for fixed policies. On the fast path, `FailForbidden` / `GenerationError` bubble as
 // a per-key server error (see `BatchExecutor::execute_single_op`).
 
+// Non-durable deletes on existing records are forbidden under SC by default (no
+// tombstone would be left, which SC needs to distinguish "deliberately deleted"
+// from "never replicated" during migrations). `strong-consistency-allow-expunge`
+// is an explicit opt-in escape hatch that lifts that restriction -- some CI
+// server configs enable it, some don't, so branch on the live namespace setting
+// (via `ServerCapabilities`) instead of assuming one or the other.
 #[aerospike_macro::test]
 async fn batch_sc_delete_non_durable_forbidden_when_record_exists() {
     let client = common::client().await;
     if !namespace_sc!(&client) {
         return;
     }
+    let allow_expunge = common::ServerCapabilities::detect(&client)
+        .await
+        .sc_allow_expunge;
 
     let ns = common::namespace();
     let set = &common::rand_str(10);
@@ -603,23 +612,38 @@ async fn batch_sc_delete_non_durable_forbidden_when_record_exists() {
     let res = client
         .batch(&bp, &[BatchOperation::delete(&bpd, key.clone())])
         .await;
-    match res {
-        Err(e) if e.server_result_code() == Some(ResultCode::FailForbidden) => {}
-        other => panic!(
-            "expected FailForbidden for non-durable delete on SC when record exists, got {:?}",
-            other
-        ),
+
+    if allow_expunge {
+        // Expunge is explicitly allowed on this namespace: the non-durable
+        // delete should succeed outright, leaving no record behind.
+        res.expect("expunge is allowed on this namespace; delete should succeed");
+        let result = client.get(&ReadPolicy::default(), &key, Bins::All).await;
+        match result {
+            Err(e) if e.server_result_code() == Some(ResultCode::KeyNotFoundError) => {}
+            other => panic!(
+                "expected record to be gone after an allowed expunge delete, got {:?}",
+                other
+            ),
+        }
+    } else {
+        match res {
+            Err(e) if e.server_result_code() == Some(ResultCode::FailForbidden) => {}
+            other => panic!(
+                "expected FailForbidden for non-durable delete on SC when record exists, got {:?}",
+                other
+            ),
+        }
+
+        let rec = client
+            .get(&ReadPolicy::default(), &key, Bins::All)
+            .await
+            .expect("record should still exist after forbidden delete");
+        assert_eq!(rec.bins.get("a"), Some(&Value::from(1_i64)));
+
+        common::delete_durably(&client, &wpolicy, &key)
+            .await
+            .unwrap();
     }
-
-    let rec = client
-        .get(&ReadPolicy::default(), &key, Bins::All)
-        .await
-        .expect("record should still exist after forbidden delete");
-    assert_eq!(rec.bins.get("a"), Some(&Value::from(1_i64)));
-
-    common::delete_durably(&client, &wpolicy, &key)
-        .await
-        .unwrap();
 }
 
 #[aerospike_macro::test]
@@ -648,16 +672,19 @@ async fn batch_sc_delete_generation_mismatch_errors() {
     bpd.generation_policy = GenerationPolicy::ExpectGenEqual;
     bpd.generation = 9_999;
 
-    let res = client
+    // client.batch() only fails the outer Result for whole-batch errors; a
+    // per-key rejection like GenerationError shows up in that key's own
+    // BatchRecord.result_code, not as an Err from the call itself.
+    let recs = client
         .batch(&bp, &[BatchOperation::delete(&bpd, key.clone())])
-        .await;
-    match res {
-        Err(e) if e.server_result_code() == Some(ResultCode::GenerationError) => {}
-        other => panic!(
-            "expected GenerationError for ExpectGenEqual with wrong generation on SC, got {:?}",
-            other
-        ),
-    }
+        .await
+        .unwrap();
+    assert_eq!(
+        recs[0].result_code,
+        Some(ResultCode::GenerationError),
+        "expected GenerationError for ExpectGenEqual with wrong generation on SC, got {:?}",
+        recs[0].result_code
+    );
 
     let rec = client
         .get(&ReadPolicy::default(), &key, Bins::All)

--- a/tests/src/examples.rs
+++ b/tests/src/examples.rs
@@ -27,6 +27,8 @@
 //! The examples read `AEROSPIKE_HOSTS` themselves — the same variable the
 //! test suite uses — and target the default `test` namespace.
 
+use crate::common;
+
 #[path = "../../examples/crud.rs"]
 #[allow(dead_code)]
 mod crud_example;
@@ -101,6 +103,19 @@ async fn example_timeout_configuration() {
 
 #[aerospike_macro::test]
 async fn example_record_operations() {
+    // The example writes an explicit record TTL, which SC namespaces commonly
+    // reject (see ServerCapabilities' doc comment) -- keep the example itself
+    // unguarded (it's customer-facing demo code) and skip here instead.
+    let client = common::client().await;
+    if !common::ServerCapabilities::detect(&client)
+        .await
+        .explicit_record_ttl_allowed
+    {
+        eprintln!(
+            "example_record_operations: skipped — explicit client TTL not allowed on this namespace"
+        );
+        return;
+    }
     record_operations_example::run().await;
 }
 


### PR DESCRIPTION
Fixes: https://aerospike.atlassian.net/browse/CLIENT-5402

Switch CI's Aerospike server from Community Edition to Enterprise Edition with strong consistency enabled, using the org's shared aerospike/shared-workflows setup-aerospike-server action instead of reugn/github-action-aerospike, in both the test job and the aerospike-core-coverage job.

Why: tests/src/txn.rs already has 18 MRT/SC integration tests that were silently skipping in CI (skip_if_no_mrt macro), since Community Edition can't support strong consistency. This PR gets them actually running instead of never executing at all.

Turning this on surfaced three tests that broke once they ran for real, all fixed here:
- batch_sc_delete_non_durable_forbidden_when_record_exists now branches on the live strong-consistency-allow-expunge setting (via a new ServerCapabilities.sc_allow_expunge field) instead of assuming one server config.
- example_record_operations now skips cleanly when explicit record TTL isn't allowed on the namespace, matching the existing ServerCapabilities pattern used elsewhere.
- batch_sc_delete_generation_mismatch_errors was checking the wrong thing: client.batch() only fails its outer Result for whole-batch errors, per-key outcomes live in each BatchRecord.result_code. The server was already correctly rejecting the write; the test assertion was wrong, not the client.

Result: aerospike-core line coverage is now 80.79%, up from the 75.58% Community-only baseline.

Requires new AEROSPIKE_SERVER_FEATURES_CONF secret (added for this PR).

Verified here: https://github.com/aerospike/aerospike-client-rust/actions/runs/33845519696