### PR TITLE
[CLIENT-5291]: update API documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ readme = "README.md"
 travis-ci = { repository = "aerospike/aerospike-client-rust" }
 appveyor = { repository = "aerospike/aerospike-client-rust" }
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [dependencies]
 aerospike-core = {path = "aerospike-core", optional = true, version = "3.0.0-alpha.2"}
 aerospike-sync = {path = "aerospike-sync", optional = true, version = "3.0.0-alpha.2"}

--- a/README.md
+++ b/README.md
@@ -795,6 +795,29 @@ while let Some(value) = stream.next().await {
 See [`examples/query_aggregate.rs`](./examples/query_aggregate.rs) for a
 complete working example, including the Lua UDF source.
 
+## Known traps
+
+Behaviors that look like missing features or call for extra application code, but aren't. Each
+one is a confirmed gap between what the code does and what the docs used to say, recorded with
+the wrong behavior an agent actually produced before the docs were fixed.
+
+- **`Client::batch` already drops a single-key sub-batch to the single-record path.** After
+  routing, if a cluster node ends up responsible for exactly one key from a batch call, the
+  client already executes that node's share via the plain single-record command path instead of
+  the multi-key batch protocol — automatically, regardless of the batch's total size. An agent
+  has been observed reimplementing this optimization in application code. See
+  [`Client::batch`](./aerospike-core/src/client.rs).
+- **Reading or writing multiple keys? Use `Client::batch`, not a loop.** An agent has been
+  observed implementing a batch read as a for-loop of sequential single-record `get` calls
+  instead of one `batch` call. See the `batch` cross-reference on `get`, `put`, `delete`, and
+  `operate` in [`client.rs`](./aerospike-core/src/client.rs).
+- **`modify_by_path` / `exp_modify_by_path` can remove matching elements, not just replace
+  them.** Pass `exp_remove_result()` as the modify expression — or use the ready-made
+  `remove` / `exp_remove` convenience wrapper. An agent has been observed concluding this
+  removal functionality does not exist. See
+  [`operations/path.rs`](./aerospike-core/src/operations/path.rs) and
+  [`expressions/mod.rs`](./aerospike-core/src/expressions/mod.rs).
+
 ## Feedback wanted
 
 We need your help with:

--- a/aerospike-core/src/client.rs
+++ b/aerospike-core/src/client.rs
@@ -230,6 +230,7 @@ impl Client {
     /// discovery failures. A provider that fails its initial load does not fail
     /// construction — it is logged and retried on the next watch tick.
     #[cfg(feature = "dynamic-config")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "dynamic-config")))]
     pub async fn new_with_config(
         policy: &ClientPolicy,
         hosts: &(dyn ToHosts + Send + Sync),
@@ -457,7 +458,9 @@ impl Client {
     ///
     /// # See also
     ///
-    /// * [`put`](Self::put), [`operate`](Self::operate), [`exists`](Self::exists)
+    /// * [`put`](Self::put), [`operate`](Self::operate), [`exists`](Self::exists),
+    ///   [`batch`](Self::batch) (fetching many keys at once — prefer this over a loop of
+    ///   individual [`get`](Self::get) calls)
     ///
     /// # Examples
     ///
@@ -539,6 +542,16 @@ impl Client {
     /// # Errors
     ///
     /// * Returns an error if the batch request fails (e.g. timeout, cluster error). Individual key-not-found is indicated by `record: None` in the corresponding [`BatchRecord`].
+    ///
+    /// # Performance
+    ///
+    /// After routing, if a given cluster node ends up responsible for exactly one key from this
+    /// batch — whether the whole call has one key or many — the client already executes that
+    /// node's share via the plain single-record command path instead of the multi-key batch wire
+    /// protocol. This happens per node, automatically, regardless of how many total keys the
+    /// batch has. There is no need to special-case a single-key batch (or check for one after
+    /// partitioning) and fall back to [`get`](Self::get)/[`put`](Self::put)/etc. yourself; the
+    /// client already does it.
     ///
     /// # See also
     ///
@@ -705,7 +718,9 @@ impl Client {
     ///
     /// # See also
     ///
-    /// * [`get`](Self::get), [`operate`](Self::operate), [`add`](Self::add), [`delete`](Self::delete)
+    /// * [`get`](Self::get), [`operate`](Self::operate), [`add`](Self::add), [`delete`](Self::delete),
+    ///   [`batch`](Self::batch) (writing many keys at once — prefer this over a loop of
+    ///   individual [`put`](Self::put) calls)
     ///
     /// # Examples
     ///
@@ -942,7 +957,9 @@ impl Client {
     ///
     /// # See also
     ///
-    /// * [`put`](Self::put), [`get`](Self::get), [`touch`](Self::touch)
+    /// * [`put`](Self::put), [`get`](Self::get), [`touch`](Self::touch),
+    ///   [`batch`](Self::batch) (deleting many keys at once — prefer this over a loop of
+    ///   individual [`delete`](Self::delete) calls)
     ///
     /// # Examples
     ///
@@ -1093,7 +1110,9 @@ impl Client {
     ///
     /// # See also
     ///
-    /// * [`get`](Self::get), [`put`](Self::put), [`operations`](crate::operations)
+    /// * [`get`](Self::get), [`put`](Self::put), [`operations`](crate::operations),
+    ///   [`batch`](Self::batch) (running per-key operations across many keys at once — prefer
+    ///   this over a loop of individual [`operate`](Self::operate) calls)
     ///
     /// # Examples
     ///
@@ -1704,6 +1723,7 @@ impl Client {
     /// # }
     /// ```
     #[cfg(feature = "lua")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "lua")))]
     pub async fn query_aggregate(
         &self,
         policy: &QueryPolicy,

--- a/aerospike-core/src/expressions/mod.rs
+++ b/aerospike-core/src/expressions/mod.rs
@@ -2438,6 +2438,25 @@ pub fn exp_select_by_path(
 ///
 /// Like [`exp_select_by_path`] this accepts anything convertible to
 /// `&[CdtContext]`.
+///
+/// `modify_exp` is not limited to producing a replacement value — passing
+/// [`exp_remove_result`] as `modify_exp` **removes** every leaf the path
+/// resolves to, instead of replacing it. The [`exp_remove`] convenience
+/// wrapper packages exactly this:
+///
+/// ```rust
+/// use aerospike::expressions::{exp_modify_by_path, exp_remove, exp_remove_result, ExpType};
+/// use aerospike::operations::cdt_context::Path;
+/// use aerospike::operations::path::ModifyFlag;
+///
+/// let path = Path::new().map_key("book").all_children().map_key("price");
+/// let bin_exp = aerospike::expressions::map_bin("myBin".into());
+///
+/// // Remove every matching "price" entry...
+/// let exp = exp_modify_by_path(ExpType::MAP, ModifyFlag::DEFAULT, bin_exp.clone(), exp_remove_result(), &path);
+/// // ...equivalently, via the ready-made wrapper:
+/// let exp = exp_remove(ExpType::MAP, bin_exp, &path);
+/// ```
 pub fn exp_modify_by_path(
     return_type: ExpType,
     flag: crate::operations::path::ModifyFlag,

--- a/aerospike-core/src/lib.rs
+++ b/aerospike-core/src/lib.rs
@@ -41,6 +41,11 @@
     clippy::use_self,
     clippy::missing_errors_doc
 )]
+// `doc_cfg` is nightly-only; gated so it only activates for the docsrs build
+// (docs.rs sets `--cfg docsrs`, see the root Cargo.toml's
+// `[package.metadata.docs.rs]`), letting feature-gated items render a
+// "Available on crate feature `x` only" badge instead of just disappearing.
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! A pure-rust client for the Aerospike `NoSQL` database.
 //!
@@ -178,6 +183,7 @@ pub use query::{
     FLAG_HARD_HINT, FLAG_KNOWN, FLAG_REQUIRE_INDEX,
 };
 #[cfg(feature = "lua")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lua")))]
 pub use query::{ResultSet, ResultStream};
 // `CITRUSLEAF_EPOCH` comes along because it is the unit `Record::new`'s
 // `expiration` argument is counted from, and a caller building a record cannot
@@ -207,10 +213,12 @@ mod client;
 mod cluster;
 pub(crate) mod commands;
 #[cfg(feature = "dynamic-config")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dynamic-config")))]
 pub mod config;
 mod common;
 pub mod expressions;
 #[cfg(feature = "lua")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lua")))]
 pub mod lua;
 pub mod mapping;
 pub mod metrics;

--- a/aerospike-core/src/operations/path.rs
+++ b/aerospike-core/src/operations/path.rs
@@ -79,6 +79,24 @@ pub fn select_by_path(bin: &str, flag: SelectFlag, ctx: impl AsRef<[CdtContext]>
 ///
 /// Like [`select_by_path`] this accepts anything convertible to
 /// `&[CdtContext]`.
+///
+/// `exp` is not limited to producing a replacement value — passing
+/// [`exp_remove_result`](crate::expressions::exp_remove_result) as `exp`
+/// **removes** every leaf the path resolves to, instead of replacing it. The
+/// [`remove`] convenience wrapper packages exactly this:
+///
+/// ```rust
+/// use aerospike::expressions::exp_remove_result;
+/// use aerospike::operations::cdt_context::Path;
+/// use aerospike::operations::path::{modify_by_path, remove, ModifyFlag};
+///
+/// let path = Path::new().map_key("book").all_children().map_key("price");
+///
+/// // Remove every matching "price" entry...
+/// let op = modify_by_path("myBin", ModifyFlag::DEFAULT, exp_remove_result(), &path);
+/// // ...equivalently, via the ready-made wrapper:
+/// let op = remove("myBin", &path);
+/// ```
 pub fn modify_by_path(
     bin: &str,
     flag: ModifyFlag,

--- a/aerospike-core/src/policy/client_policy.rs
+++ b/aerospike-core/src/policy/client_policy.rs
@@ -110,6 +110,7 @@ pub struct ClientPolicy {
     ///     .with_no_client_auth();
     /// ```
     #[cfg(feature = "tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tls")))]
     #[cfg_attr(feature = "dynamic-config", config(skip))]
     pub tls_config: Option<ClientConfig>,
 

--- a/aerospike-core/src/query/mod.rs
+++ b/aerospike-core/src/query/mod.rs
@@ -29,6 +29,7 @@ pub(crate) use self::partition_tracker::PartitionTracker;
 pub use self::recordset::RecordStream;
 pub use self::recordset::Recordset;
 #[cfg(feature = "lua")]
+#[cfg_attr(docsrs, doc(cfg(feature = "lua")))]
 pub use self::result_set::{ResultSet, ResultStream};
 pub use self::statement::Statement;
 pub use self::udf::UDFLang;

--- a/aerospike-core/src/query/recordset.rs
+++ b/aerospike-core/src/query/recordset.rs
@@ -140,6 +140,7 @@ impl Recordset {
     }
 
     #[cfg(feature = "sync")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
     /// Returns a result from the queue if it exists. Otherwise, returns None.
     pub fn next_record(&self) -> Option<Result<Record>> {
         self.rx.try_recv().ok()
@@ -153,6 +154,7 @@ impl Recordset {
 }
 
 #[cfg(feature = "sync")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
 impl Iterator for &Recordset {
     type Item = Result<Record>;
 

--- a/aerospike-core/src/query/result_set.rs
+++ b/aerospike-core/src/query/result_set.rs
@@ -72,6 +72,7 @@ impl ResultSet {
     }
 
     #[cfg(feature = "sync")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
     /// Returns a result from the queue if one is available. Otherwise,
     /// returns None.
     pub fn next_value(&self) -> Option<Result<Value>> {
@@ -86,6 +87,7 @@ impl ResultSet {
 }
 
 #[cfg(feature = "sync")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
 impl Iterator for &ResultSet {
     type Item = Result<Value>;
 


### PR DESCRIPTION
Fixes: https://aerospike.atlassian.net/browse/CLIENT-5291

Closes 4 rustdoc gaps confirmed present on v3 (CLIENT-5291):

- Client::batch: document that a single-key sub-batch already drops to the single-record path
- get/put/delete/operate: cross-reference batch
- modify_by_path / exp_modify_by_path: document removal support, with a compiler-verified example
- Feature-gated APIs (lua, dynamic-config, tls, sync) now render a "requires feature X" badge via doc_cfg

Also mirrors the first three into a new "Known traps" section in the README.

All changes are rustdoc/attributes only -- no behavior change. Verified: stable build (with/without lua), nightly --cfg docsrs build (badges render correctly), and cargo test --doc (176 passed, including the 2 new examples).
